### PR TITLE
Precision of eta.

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage5.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage5.java
@@ -182,10 +182,14 @@ public class AisMessage5 extends AisStaticCommon {
         }
         Calendar cal = Calendar.getInstance();
         cal.setTimeZone(TimeZone.getTimeZone("GMT+0000"));
+        
+		cal.set(Calendar.MILLISECOND, 0);
+        cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MINUTE, min);
         cal.set(Calendar.HOUR_OF_DAY, hour);
         cal.set(Calendar.DAY_OF_MONTH, day);
         cal.set(Calendar.MONTH, mon - 1);
+        
         return cal.getTime();
     }
 


### PR DESCRIPTION
Ais eta information do not include SECOND or MILLISECOND and since they where not set in getEtaDate they will be sett to the current second and millisecond.