### PR TITLE
Added support for Inland AIS message (DAC=200, FI=10)

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AisApplicationMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AisApplicationMessage.java
@@ -105,6 +105,9 @@ public abstract class AisApplicationMessage {
         if (binaryMessage.getDac() == RouteSuggestion.DAC && binaryMessage.getFi() == RouteSuggestion.FI) {
             return new RouteSuggestion(binaryMessage.getData());
         }
+	if (binaryMessage.getDac() == 200 && binaryMessage.getFi() == 10) {
+            return new InlandVoyage(binaryMessage.getData());
+        }	
 
         return new UnknownAsm(binaryMessage);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
@@ -1,0 +1,188 @@
+/*
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.dma.ais.message.binary;
+
+import dk.dma.ais.binary.BinArray;
+import dk.dma.ais.binary.SixbitEncoder;
+import dk.dma.ais.binary.SixbitException;
+
+/**
+ *
+ * Subtype (DAC=200, FI=10) of AIS type 8 binary application message.
+ * With title: Inland ship static and voyage related data
+ * 
+ * @author oteken
+ */
+public class InlandVoyage extends AisApplicationMessage{
+
+    private String vesselId;  // 48 bits
+    private int lengthOfShip;  // 13 bits
+    private int beamOfShip; // 10 bits
+    private int combinationType; // 14 bits
+    private int hazardousCargo; // 3 bits
+    private int draught; // 11 bits
+    private int loadedOrUnloaded; // 2 bits
+    private int qualityOfSpeedData; // 1 bit
+    private int qualityOfCourseData; // 1 bit
+    private int qualityOfHeadingData; // 1 bit
+    private int spare; // 8 bit
+
+    public InlandVoyage(BinArray binArray) throws SixbitException {
+        super(200, 10, binArray);
+    }
+    
+    
+    @Override
+    public void parse(BinArray binArray) throws SixbitException {
+        StringBuilder vesselIdBuilder = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            int value = (int) binArray.getVal(6);
+            vesselIdBuilder.append((char) value);
+        }
+        this.vesselId = vesselIdBuilder.toString();
+        this.lengthOfShip = (int) binArray.getVal(13);
+        this.beamOfShip = (int) binArray.getVal(10);
+        this.combinationType = (int) binArray.getVal(14);
+        this.hazardousCargo = (int) binArray.getVal(3);
+        this.draught = (int) binArray.getVal(11);
+        this.loadedOrUnloaded = (int) binArray.getVal(2);
+        this.qualityOfSpeedData = (int) binArray.getVal(1);
+        this.qualityOfCourseData = (int) binArray.getVal(1);
+        this.qualityOfHeadingData = (int) binArray.getVal(1);
+        this.spare = (int) binArray.getVal(8);
+    }
+
+    @Override
+    public SixbitEncoder getEncoded() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("[InlandVoyage: lengthOfShip=");
+        builder.append(lengthOfShip);
+        builder.append(", beamOfShip=");
+        builder.append(beamOfShip);
+        builder.append(", combinationType=");
+        builder.append(combinationType);
+        builder.append(", hazardousCargo=");
+        builder.append(hazardousCargo);
+        builder.append(", draught=");
+        builder.append(draught);
+        builder.append(", loadedOrUnloaded=");
+        builder.append(loadedOrUnloaded);
+        builder.append(", qualityOfSpeedData=");
+        builder.append(qualityOfSpeedData);
+        builder.append(", qualityOfCourseData=");
+        builder.append(qualityOfCourseData);
+        builder.append(", qualityOfHeadingData=");
+        builder.append(qualityOfHeadingData);
+        builder.append(", spare=");
+        builder.append(spare);
+        builder.append(", vesselId=");
+        builder.append(vesselId);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public int getLengthOfShip() {
+        return lengthOfShip;
+    }
+
+    public void setLengthOfShip(int lengthOfShip) {
+        this.lengthOfShip = lengthOfShip;
+    }
+
+    public int getBeamOfShip() {
+        return beamOfShip;
+    }
+
+    public void setBeamOfShip(int beamOfShip) {
+        this.beamOfShip = beamOfShip;
+    }
+
+    public int getCombinationType() {
+        return combinationType;
+    }
+
+    public void setCombinationType(int combinationType) {
+        this.combinationType = combinationType;
+    }
+
+    public int getHazardousCargo() {
+        return hazardousCargo;
+    }
+
+    public void setHazardousCargo(int hazardousCargo) {
+        this.hazardousCargo = hazardousCargo;
+    }
+
+    public int getDraught() {
+        return draught;
+    }
+
+    public void setDraught(int draught) {
+        this.draught = draught;
+    }
+
+    public int getLoadedOrUnloaded() {
+        return loadedOrUnloaded;
+    }
+
+    public void setLoadedOrUnloaded(int loadedOrUnloaded) {
+        this.loadedOrUnloaded = loadedOrUnloaded;
+    }
+
+    public int getQualityOfSpeedData() {
+        return qualityOfSpeedData;
+    }
+
+    public void setQualityOfSpeedData(int qualityOfSpeedData) {
+        this.qualityOfSpeedData = qualityOfSpeedData;
+    }
+
+    public int getQualityOfCourseData() {
+        return qualityOfCourseData;
+    }
+
+    public void setQualityOfCourseData(int qualityOfCourseData) {
+        this.qualityOfCourseData = qualityOfCourseData;
+    }
+
+    public int getQualityOfHeadingData() {
+        return qualityOfHeadingData;
+    }
+
+    public void setQualityOfHeadingData(int qualityOfHeadingData) {
+        this.qualityOfHeadingData = qualityOfHeadingData;
+    }
+
+    public int getSpare() {
+        return spare;
+    }
+
+    public void setSpare(int spare) {
+        this.spare = spare;
+    }
+
+    public String getVesselId() {
+        return vesselId;
+    }
+
+    public void setVesselId(String vesselId) {
+        this.vesselId = vesselId;
+    }
+}


### PR DESCRIPTION
Support added for message: Inland ship static and voyage related data.
Can be found at: http://www.e-navigation.nl/content/inland-ship-static-and-voyage-related-data

Permitted as from 10/10/2007.