### PR TITLE
Improvements on InlandVoyage Class, also adding a unit test.

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
@@ -27,16 +27,39 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class InlandVoyage extends AisApplicationMessage{
 
+    /** Unique European vessel identification number. */
     private String vesselId;  // 48 bits
+    
+    /** Length of ship 1-8000 in 0.1m. 0 = default. */
     private int lengthOfShip;  // 13 bits
+    
+    /** Beam of ship 1-1000 in 0.1m. 0 = default. */
     private int beamOfShip; // 10 bits
+    
+    /** Numeric ERI Classification. */
     private int combinationType; // 14 bits
+    
+    /** Number of blue cones 0-3. 4 = B-Flag, 5 = unknown. */
     private int hazardousCargo; // 3 bits
+    
+    /** Draught of ship 1-2000 in 0.01m. 0 = unknown. */
     private int draught; // 11 bits
+    
+    /** 
+     * Status of load on ship. 
+     * 1 = loaded, 2 = unloaded, 0 = not available/default. 3 should not be used. 
+     */
     private int loadedOrUnloaded; // 2 bits
+    
+    /** 1 = high, 0 = low/GNSS/ default. */
     private int qualityOfSpeedData; // 1 bit
+    
+    /** 1 = high, 0 = low/GNSS/ default. */
     private int qualityOfCourseData; // 1 bit
+    
+    /** 1 = high, 0 = low/GNSS/ default. */
     private int qualityOfHeadingData; // 1 bit
+    
     private int spare; // 8 bit
 
     public InlandVoyage(BinArray binArray) throws SixbitException {
@@ -52,6 +75,9 @@ public class InlandVoyage extends AisApplicationMessage{
             vesselIdBuilder.append((char) value);
         }
         this.vesselId = vesselIdBuilder.toString();
+        // remove all non numeric characters
+        this.vesselId = this.vesselId.replaceAll("[^\\d.]", "");
+        
         this.lengthOfShip = (int) binArray.getVal(13);
         this.beamOfShip = (int) binArray.getVal(10);
         this.combinationType = (int) binArray.getVal(14);

--- a/ais-lib-messages/src/test/java/dk/dma/ais/message/AisMessage8Test.java
+++ b/ais-lib-messages/src/test/java/dk/dma/ais/message/AisMessage8Test.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import dk.dma.ais.binary.SixbitException;
+import dk.dma.ais.message.binary.AisApplicationMessage;
+import dk.dma.ais.message.binary.InlandVoyage;
 import dk.dma.ais.sentence.SentenceException;
 import dk.dma.ais.sentence.Vdm;
 
@@ -22,5 +24,31 @@ public class AisMessage8Test {
         assertEquals(8, message.getMsgId());
         assertEquals(0, message.getUserId());
     }
-
+    
+    @Test
+    public void inlandVoyagetest() throws AisMessageException, SixbitException, SentenceException {
+        Vdm inlandVdm = new Vdm();
+        inlandVdm.parse("!AIVDM,1,1,,B,83aDoLPj2StdtMuN=Qb@ggbi00h0,0*7C");
+        AisMessage message = AisMessage.getInstance(inlandVdm);
+        
+        assertTrue(message instanceof AisMessage8);
+        
+        AisMessage8 message8 = (AisMessage8) message;
+        
+        assertEquals(200, message8.getDac());
+        assertEquals(10, message8.getFi());
+        
+        InlandVoyage inlandMessage = (InlandVoyage) AisApplicationMessage.getInstance(message8);
+        
+        assertEquals("2317586", inlandMessage.getVesselId());
+        assertEquals(850, inlandMessage.getLengthOfShip());
+        assertEquals(95, inlandMessage.getBeamOfShip());
+        assertEquals(8022, inlandMessage.getCombinationType());
+        assertEquals(1, inlandMessage.getHazardousCargo());
+        assertEquals(0, inlandMessage.getDraught());
+        assertEquals(1, inlandMessage.getLoadedOrUnloaded());
+        assertEquals(1, inlandMessage.getQualityOfSpeedData());
+        assertEquals(0, inlandMessage.getQualityOfCourseData());
+        assertEquals(0, inlandMessage.getQualityOfHeadingData());
+    }
 }


### PR DESCRIPTION
The vesselid now parses correctly by removing all non numeric characters
from the string(spaces, carriage return etc.). Added comments to all
variables of the InlandVoyage Class. A unit test has been added to the
AisMessage8Test class to test an example InlandVoyage message.