### PR TITLE
Issue #20 - Fix message type 1 and 3 parsing from AisPacket Vdm

### DIFF
--- a/ais-lib-communication/src/test/java/dk/dma/ais/packet/AisPacketTest.java
+++ b/ais-lib-communication/src/test/java/dk/dma/ais/packet/AisPacketTest.java
@@ -14,14 +14,6 @@
  */
 package dk.dma.ais.packet;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Date;
-
-import org.junit.Assert;
-import org.junit.Test;
-
 import dk.dma.ais.binary.SixbitException;
 import dk.dma.ais.message.AisMessage;
 import dk.dma.ais.message.AisMessageException;
@@ -30,7 +22,20 @@ import dk.dma.ais.packet.AisPacketTags.SourceType;
 import dk.dma.ais.reader.AisReader;
 import dk.dma.ais.reader.AisReaders;
 import dk.dma.ais.sentence.SentenceException;
+import dk.dma.ais.sentence.Vdm;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
 import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 public class AisPacketTest {
 
@@ -156,4 +161,23 @@ public class AisPacketTest {
         Assert.assertEquals(tags.getSourceType(), SourceType.SATELLITE);
     }
 
+    @Test
+    public void packetVdmCanBeUsedToCreateMessage() throws SentenceException, AisMessageException, SixbitException {
+        String sentence = "!BSVDM,1,1,,B,33@nl?@01EPk<FDPw<2qW7`B07kh,0*5E";
+
+        Vdm vdm = new Vdm();
+        vdm.parse(sentence);
+
+        AisMessage messageFromDirectVdm = AisMessage.getInstance(vdm);
+
+        assertThat(messageFromDirectVdm, is(not(nullValue())));
+
+        AisPacket packet = AisPacket.readFromString(sentence);
+        AisMessage msg = packet.tryGetAisMessage();
+
+        Vdm packetVdm = msg.getVdm();
+        AisMessage messageFromPacketVdm = AisMessage.getInstance(packetVdm);
+
+        assertThat(messageFromPacketVdm, is(not(nullValue())));
+    }
 }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/binary/BinArray.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/binary/BinArray.java
@@ -268,4 +268,7 @@ public class BinArray {
         return builder.toString();
     }
 
+    public void doneReading() {
+        readPtr = 0;
+    }
 }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
@@ -221,17 +221,19 @@ public abstract class AisMessage implements Serializable {
      * @throws SixbitException
      */
     public static AisMessage getInstance(Vdm vdm) throws AisMessageException, SixbitException {
-        AisMessage message = null;
+        AisMessage message;
 
         switch (vdm.getMsgId()) {
         case 1:
             message = new AisMessage1(vdm);
+            vdm.getBinArray().doneReading();
             break;
         case 2:
             message = new AisMessage2(vdm);
             break;
         case 3:
             message = new AisMessage3(vdm);
+            vdm.getBinArray().doneReading();
             break;
         case 4:
             message = new AisMessage4(vdm);

--- a/ais-lib-messages/src/test/java/dk/dma/ais/sentence/VdmTest.java
+++ b/ais-lib-messages/src/test/java/dk/dma/ais/sentence/VdmTest.java
@@ -22,6 +22,9 @@ import dk.dma.ais.message.AisMessage;
 import dk.dma.ais.message.AisMessage12;
 import dk.dma.ais.message.AisMessageException;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class VdmTest {
 
     @Test
@@ -69,5 +72,18 @@ public class VdmTest {
         Assert.assertEquals("Wrong user id", 992199007, msg.getUserId());
 
     }
-    
+
+    @Test
+    public void canParseTwice() throws SentenceException {
+        String sentence = "!BSVDM,1,1,,B,33@nl?@01EPk<FDPw<2qW7`B07kh,0*5E";
+        Vdm vdm = new Vdm();
+
+        int parseResult = vdm.parse(sentence);
+
+        assertThat(parseResult, is(0));
+
+        int secondParseResult = vdm.parse(sentence);
+
+        assertThat(secondParseResult, is(0));
+    }
 }


### PR DESCRIPTION
The read pointer was not reinitialized after parsing the Vdm to create a
new message instance of AisMessage type 1 and 3.

This can't be done for all message types as some need further reading of
the underlying BinArray.

Fixes: https://github.com/dma-ais/AisLib/issues/20