### PR TITLE
add setters for message type 3

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage3.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage3.java
@@ -76,6 +76,18 @@ public class AisMessage3 extends AisPositionMessage {
         return keep;
     }
 
+    public void setSlotIncrement(int slotIncrement) {
+        this.slotIncrement = slotIncrement;
+    }
+
+    public void setNumSlots(int numSlots) {
+        this.numSlots = numSlots;
+    }
+
+    public void setKeep(int keep) {
+        this.keep = keep;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
For some reasons setters for fields related to type 3 ais message weren't implemented in the class `AisMessage3`. This pull requests add those setters.