### PR TITLE
Message24 pos type

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage24.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage24.java
@@ -46,9 +46,16 @@ public class AisMessage24 extends AisStaticCommon {
     String vendorId; // 7x6 (42) bits
 
     /**
+     * Type of electronic position fixing device: 0 = undefined (default) 1 = GPS 2 = GLONASS 3 = combined GPS/GLONASS 4
+     * = Loran-C 5 = Chayka 6 = integrated navigation system 7 = surveyed 8 = Galileo, 9-14 = not used 15 = internal
+     * GNSS
+     */
+    int posType; // 4 bits
+
+    /**
      * Spare bits
      */
-    int spare; // 6 bits
+    int spare; // 2 bits
 
     public AisMessage24() {
         super(24);
@@ -87,7 +94,8 @@ public class AisMessage24 extends AisStaticCommon {
         this.dimStern = (int) binArray.getVal(9);
         this.dimPort = (int) binArray.getVal(6);
         this.dimStarboard = (int) binArray.getVal(6);
-        this.spare = (int) binArray.getVal(6);
+        this.posType = (int) binArray.getVal(4);
+        this.spare = (int) binArray.getVal(2);
     }
 
     @Override
@@ -109,7 +117,8 @@ public class AisMessage24 extends AisStaticCommon {
         encoder.addVal(dimStern, 9);
         encoder.addVal(dimPort, 6);
         encoder.addVal(dimStarboard, 6);
-        encoder.addVal(spare, 6);
+        encoder.addVal(posType, 4);
+        encoder.addVal(spare, 2);
         return encoder;
     }
 
@@ -127,6 +136,14 @@ public class AisMessage24 extends AisStaticCommon {
 
     public void setVendorId(String vendorId) {
         this.vendorId = vendorId;
+    }
+
+    public int getPosType() {
+        return posType;
+    }
+
+    public void setPosType(int posType) {
+        this.posType = posType;
     }
 
     public int getSpare() {
@@ -157,6 +174,8 @@ public class AisMessage24 extends AisStaticCommon {
         builder.append(name);
         builder.append(", shipType=");
         builder.append(shipType);
+        builder.append(", posType=");
+        builder.append(posType);
         builder.append(", spare=");
         builder.append(spare);
         builder.append("]");

--- a/ais-lib-messages/src/test/java/dk/dma/ais/message/AisMessage24Test.java
+++ b/ais-lib-messages/src/test/java/dk/dma/ais/message/AisMessage24Test.java
@@ -1,0 +1,74 @@
+package dk.dma.ais.message;
+
+import dk.dma.ais.binary.SixbitException;
+import dk.dma.ais.sentence.SentenceException;
+import dk.dma.ais.sentence.Vdm;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AisMessage24Test {
+
+    /* https://fossies.org/linux/gpsd/test/sample.aivdm
+        One pair of type A and Type B messages.
+        Checked against the Maritec decoder.
+        MessageID:         24
+        RepeatIndicator:   0
+        UserID:            271041815
+        partnum:           0
+        name:              PROGUY
+    */
+    private final String messagePartA = "!AIVDM,1,1,,A,H42O55i18tMET00000000000000,2*6D";
+
+    /*
+         MessageID:         24
+         RepeatIndicator:   0
+         UserID:            271041815
+         partnum:           0
+         shipandcargo:      60
+         vendorid:          1D00014
+         callsign:          TC6163
+         dimA:              0
+         dimB:              15
+         dimC:              0
+         dimD:              5
+    */
+    private final String messagePartB = "!AIVDM,1,1,,A,H42O55lti4hhhilD3nink000?050,0*40";
+
+    @Test
+    public void partATest() throws SentenceException, AisMessageException, SixbitException {
+        Vdm vdm = new Vdm();
+        vdm.parse(messagePartA);
+        AisMessage aisMessage = AisMessage.getInstance(vdm);
+
+        assertTrue(aisMessage instanceof AisMessage24);
+        assertEquals(24, aisMessage.getMsgId());
+        assertEquals(0, aisMessage.getRepeat());
+        assertEquals(271041815, aisMessage.getUserId());
+        assertEquals(0, ((AisMessage24)aisMessage).getPartNumber());
+        assertEquals("PROGUY@@@@@@@@@@@@@@", ((AisMessage24) aisMessage).getName());
+    }
+
+    @Test
+    public void partBTest() throws SentenceException, AisMessageException, SixbitException {
+        Vdm vdm = new Vdm();
+        vdm.parse(messagePartB);
+        AisMessage aisMessage = AisMessage.getInstance(vdm);
+
+        assertTrue(aisMessage instanceof AisMessage24);
+        assertEquals(24, aisMessage.getMsgId());
+        assertEquals(0, aisMessage.getRepeat());
+        assertEquals(271041815, aisMessage.getUserId());
+        assertEquals(1, ((AisMessage24) aisMessage).getPartNumber());
+        assertEquals(60, ((AisMessage24) aisMessage).getShipType());
+        assertEquals("1D00014", ((AisMessage24) aisMessage).getVendorId());
+        assertEquals("TC6163@", ((AisMessage24) aisMessage).getCallsign());
+        assertEquals(0, ((AisMessage24) aisMessage).getDimBow());
+        assertEquals(0, ((AisMessage24) aisMessage).getDimPort());
+        assertEquals(15, ((AisMessage24) aisMessage).getDimStern());
+        assertEquals(5, ((AisMessage24) aisMessage).getDimStarboard());
+        assertEquals(0, ((AisMessage24) aisMessage).getPosType());
+        assertEquals(0, ((AisMessage24) aisMessage).getSpare());
+    }
+}


### PR DESCRIPTION
Pull request regarding issue #44 
changing `AisMessage24` to follow the format, specified in the most recent [ITU spec](https://www.itu.int/rec/R-REC-M.1371/en).
Added test for AisMessage24, sample ais message of type 24 and decoded fields are taken from https://fossies.org/linux/gpsd/test/sample.aivdm.