### PR TITLE
Adding or updating javadoc 

### DIFF
--- a/ais-lib-cli/pom.xml
+++ b/ais-lib-cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>dk.dma.ais.lib</groupId>
     <artifactId>ais-parent</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.4</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/ais-lib-communication/pom.xml
+++ b/ais-lib-communication/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dk.dma.ais.lib</groupId>
     <artifactId>ais-parent</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBus.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBus.java
@@ -33,7 +33,7 @@ import dk.dma.ais.queue.MessageQueueOverflowException;
 
 /**
  * Bus for exchanging AIS packets
- * 
+ * <p>
  * Thread safety by delegation
  */
 @ThreadSafe
@@ -60,6 +60,9 @@ public class AisBus extends AisBusComponent implements Runnable {
     private volatile int busPullMaxElements = 1000;
     private volatile int busQueueSize = 10000;
 
+    /**
+     * Instantiates a new Ais bus.
+     */
     public AisBus() {
 
     }
@@ -77,7 +80,6 @@ public class AisBus extends AisBusComponent implements Runnable {
     /**
      * Start AisBus thread
      * 
-     * @return thread
      */
     public synchronized void start() {
         // Start thread
@@ -135,10 +137,11 @@ public class AisBus extends AisBusComponent implements Runnable {
             provider.cancel();
         }
     }
-        
+
     /**
      * Push packets non-blocking on to the bus
-     * @param packet
+     *
+     * @param packet the packet
      * @return if pushing was a success
      */
     public boolean push(AisPacket packet) {
@@ -147,9 +150,9 @@ public class AisBus extends AisBusComponent implements Runnable {
 
     /**
      * Push element onto the bus. Returns false if the bus is overflowing
-     * 
-     * @param packet
-     * @param blocking
+     *
+     * @param packet   the packet
+     * @param blocking the blocking
      * @return if pushing was a success
      */
     public boolean push(AisPacket packet, boolean blocking) {
@@ -181,10 +184,11 @@ public class AisBus extends AisBusComponent implements Runnable {
         }
         return true;
     }
-    
+
     /**
      * Get the average overflow rate experienced by all providers
-     * @return
+     *
+     * @return double double
      */
     public double avgOverflowRate() {
         double sum = 0;
@@ -198,8 +202,8 @@ public class AisBus extends AisBusComponent implements Runnable {
 
     /**
      * Register a consumer
-     * 
-     * @param consumer
+     *
+     * @param consumer the consumer
      */
     public void registerConsumer(AisBusConsumer consumer) {
         // Tie aisbus to consumer
@@ -207,11 +211,12 @@ public class AisBus extends AisBusComponent implements Runnable {
         // Make consumer queue
         consumers.add(consumer);
     }
-    
+
     /**
      * Get consumer by name
-     * @param name
-     * @return
+     *
+     * @param name the name
+     * @return consumer consumer
      */
     public AisBusConsumer getConsumer(String name) {
         for (AisBusConsumer consumer : consumers) {
@@ -221,11 +226,12 @@ public class AisBus extends AisBusComponent implements Runnable {
         }
         return null;
     }
-    
+
     /**
      * Get provider by name
-     * @param name
-     * @return
+     *
+     * @param name the name
+     * @return provider provider
      */
     public AisBusProvider getProvider(String name) {
         for (AisBusProvider provider : providers) {
@@ -238,8 +244,8 @@ public class AisBus extends AisBusComponent implements Runnable {
 
     /**
      * Register a provider
-     * 
-     * @param provider
+     *
+     * @param provider the provider
      */
     public void registerProvider(AisBusProvider provider) {
         // Tie aisbus to provider
@@ -279,18 +285,38 @@ public class AisBus extends AisBusComponent implements Runnable {
         LOG.info("Stopped");
     }
 
+    /**
+     * Sets bus pull max elements.
+     *
+     * @param busPullMaxElements the bus pull max elements
+     */
     public void setBusPullMaxElements(int busPullMaxElements) {
         this.busPullMaxElements = busPullMaxElements;
     }
 
+    /**
+     * Sets bus queue size.
+     *
+     * @param busQueueSize the bus queue size
+     */
     public void setBusQueueSize(int busQueueSize) {
         this.busQueueSize = busQueueSize;
     }
 
+    /**
+     * Gets consumers.
+     *
+     * @return the consumers
+     */
     public Set<AisBusConsumer> getConsumers() {
         return Collections.unmodifiableSet(consumers);
     }
 
+    /**
+     * Gets providers.
+     *
+     * @return the providers
+     */
     public Set<AisBusProvider> getProviders() {
         return Collections.unmodifiableSet(providers);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusComponent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusComponent.java
@@ -29,7 +29,7 @@ import dk.dma.ais.transform.IAisPacketTransformer;
  */
 @ThreadSafe
 public abstract class AisBusComponent {
-    
+
     /**
      * Maximum time to wait for threads to stop after having been cancelled
      */
@@ -56,6 +56,9 @@ public abstract class AisBusComponent {
      */
     protected final CopyOnWriteArrayList<IAisPacketTransformer> packetTransformers = new CopyOnWriteArrayList<>();
 
+    /**
+     * Instantiates a new Ais bus component.
+     */
     public AisBusComponent() {
         this.status = new AisBusComponentStatus();
     }
@@ -73,22 +76,32 @@ public abstract class AisBusComponent {
     public void start() {
         status.setStarted();
     }
-        
+
+    /**
+     * Sets connected.
+     */
     public void setConnected() {
         status.setConnected();
     }
-    
+
+    /**
+     * Sets not connected.
+     */
     public void setNotConnected() {
         status.setNotConnected();
     }
-    
+
+    /**
+     * Sets stopped.
+     */
     public void setStopped() {
         status.setStopped();
     }
-    
+
     /**
      * Get component status
-     * @return
+     *
+     * @return status status
      */
     public AisBusComponentStatus getStatus() {
         return status;
@@ -96,8 +109,8 @@ public abstract class AisBusComponent {
 
     /**
      * Set component thread
-     * 
-     * @param thread
+     *
+     * @param thread the thread
      */
     protected synchronized void setThread(Thread thread) {
         this.thread = thread;
@@ -105,23 +118,23 @@ public abstract class AisBusComponent {
 
     /**
      * Get component thread
-     * 
-     * @return
+     *
+     * @return thread thread
      */
     public synchronized Thread getThread() {
         return thread;
     }
-    
+
     /**
-     * All components must implement a way to stop    
+     * All components must implement a way to stop
      */
     public abstract void cancel();
 
     /**
      * Method to handle incoming packet for all AisBus components. Will do filtering, transformation and tagging.
-     * 
-     * @param element
-     * @return
+     *
+     * @param packet the packet
+     * @return ais packet
      */
     protected AisPacket handleReceived(AisPacket packet) {
         status.receive();
@@ -148,8 +161,8 @@ public abstract class AisBusComponent {
 
     /**
      * Get filters collection
-     * 
-     * @return
+     *
+     * @return filters filters
      */
     public PacketFilterCollection getFilters() {
         return filters;
@@ -157,8 +170,8 @@ public abstract class AisBusComponent {
 
     /**
      * Get packet transformers list
-     * 
-     * @return
+     *
+     * @return packet transformers
      */
     public CopyOnWriteArrayList<IAisPacketTransformer> getPacketTransformers() {
         return packetTransformers;
@@ -174,7 +187,12 @@ public abstract class AisBusComponent {
         builder.append("]");
         return builder.toString();
     }
-    
+
+    /**
+     * Rate report string.
+     *
+     * @return the string
+     */
     public String rateReport() {
         return String.format("[received/filtered/overflow] %4.2f / %4.2f / %4.2f  (packets/sec)", status.getInRate(), status.getFilteredRate(), status.getOverflowRate());
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusConsumer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusConsumer.java
@@ -26,6 +26,9 @@ import dk.dma.ais.queue.IQueueEntryHandler;
 import dk.dma.ais.queue.MessageQueueOverflowException;
 import dk.dma.ais.queue.MessageQueueReader;
 
+/**
+ * The type Ais bus consumer.
+ */
 @ThreadSafe
 public abstract class AisBusConsumer extends AisBusSocket implements IQueueEntryHandler<AisBusElement> {
 
@@ -39,10 +42,18 @@ public abstract class AisBusConsumer extends AisBusSocket implements IQueueEntry
     @GuardedBy("this")
     private int consumerPullMaxElements = 1000;
 
+    /**
+     * Instantiates a new Ais bus consumer.
+     */
     public AisBusConsumer() {
         super();
     }
 
+    /**
+     * Instantiates a new Ais bus consumer.
+     *
+     * @param blocking the blocking
+     */
     public AisBusConsumer(boolean blocking) {
         super(blocking);
     }
@@ -63,8 +74,8 @@ public abstract class AisBusConsumer extends AisBusSocket implements IQueueEntry
 
     /**
      * Push elements onto the queue
-     * 
-     * @param element
+     *
+     * @param element the element
      */
     public final void push(AisBusElement element) {
         try {
@@ -109,15 +120,25 @@ public abstract class AisBusConsumer extends AisBusSocket implements IQueueEntry
 
     /**
      * All consumers must implement a method to get the filtered packet
-     * 
-     * @param queueElement
+     *
+     * @param queueElement the queue element
      */
     public abstract void receiveFiltered(AisBusElement queueElement);
 
+    /**
+     * Sets consumer queue size.
+     *
+     * @param consumerQueueSize the consumer queue size
+     */
     public synchronized void setConsumerQueueSize(int consumerQueueSize) {
         this.consumerQueueSize = consumerQueueSize;
     }
 
+    /**
+     * Sets consumer pull max elements.
+     *
+     * @param consumerPullMaxElements the consumer pull max elements
+     */
     public synchronized void setConsumerPullMaxElements(int consumerPullMaxElements) {
         this.consumerPullMaxElements = consumerPullMaxElements;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusElement.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusElement.java
@@ -22,21 +22,41 @@ import dk.dma.ais.packet.AisPacket;
 public final class AisBusElement {
 
     private final long timestamp;
-    private AisPacket packet;    
+    private AisPacket packet;
 
+    /**
+     * Instantiates a new Ais bus element.
+     *
+     * @param packet the packet
+     */
     public AisBusElement(AisPacket packet) {
         this.packet = packet;
         this.timestamp = System.currentTimeMillis();
     }
 
+    /**
+     * Gets packet.
+     *
+     * @return the packet
+     */
     public AisPacket getPacket() {
         return packet;
     }
-    
+
+    /**
+     * Sets packet.
+     *
+     * @param packet the packet
+     */
     public void setPacket(AisPacket packet) {
         this.packet = packet;
     }
-    
+
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     public long getTimestamp() {
         return timestamp;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusFactory.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusFactory.java
@@ -25,6 +25,14 @@ import dk.dma.ais.configuration.bus.AisBusConfiguration;
  */
 public class AisBusFactory {
 
+    /**
+     * Get ais bus.
+     *
+     * @param filename the filename
+     * @return the ais bus
+     * @throws JAXBException         the jaxb exception
+     * @throws FileNotFoundException the file not found exception
+     */
     public static AisBus get(String filename) throws JAXBException, FileNotFoundException {
         return AisBusConfiguration.load(filename).getInstance();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusProvider.java
@@ -17,13 +17,24 @@ package dk.dma.ais.bus;
 import net.jcip.annotations.ThreadSafe;
 import dk.dma.ais.packet.AisPacket;
 
+/**
+ * The type Ais bus provider.
+ */
 @ThreadSafe
 public abstract class AisBusProvider extends AisBusSocket {
 
+    /**
+     * Instantiates a new Ais bus provider.
+     */
     public AisBusProvider() {
         this(false);
     }
 
+    /**
+     * Instantiates a new Ais bus provider.
+     *
+     * @param blocking the blocking
+     */
     public AisBusProvider(boolean blocking) {
         super(blocking);
     }
@@ -40,8 +51,8 @@ public abstract class AisBusProvider extends AisBusSocket {
 
     /**
      * Helper method to push to bus
-     * 
-     * @param packet
+     *
+     * @param packet the packet
      */
     protected void push(AisPacket packet) {
         // Do filtering, transformation and filtering

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusSocket.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/AisBusSocket.java
@@ -29,13 +29,24 @@ public abstract class AisBusSocket extends AisBusComponent {
     private String name;
     @GuardedBy("this")
     private String description;
-    
+
+    /**
+     * The Blocking.
+     */
     protected final boolean blocking;
-    
+
+    /**
+     * Instantiates a new Ais bus socket.
+     */
     public AisBusSocket() {
         this(false);
     }
-    
+
+    /**
+     * Instantiates a new Ais bus socket.
+     *
+     * @param blocking the blocking
+     */
     public AisBusSocket(boolean blocking) {
         super();
         this.blocking = blocking;
@@ -51,10 +62,20 @@ public abstract class AisBusSocket extends AisBusComponent {
         super.start();
     }
 
+    /**
+     * Gets ais bus.
+     *
+     * @return the ais bus
+     */
     public synchronized AisBus getAisBus() {
         return aisBus;
     }
-    
+
+    /**
+     * Sets ais bus.
+     *
+     * @param aisBus the ais bus
+     */
     public synchronized void setAisBus(AisBus aisBus) {
         if (this.aisBus != null) {
             throw new IllegalStateException("AisBus already defined");
@@ -62,18 +83,38 @@ public abstract class AisBusSocket extends AisBusComponent {
         this.aisBus = aisBus;
     }
 
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
     public synchronized String getName() {
         return name == null ? getClass().getSimpleName() : name;
     }
 
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
     public synchronized void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets description.
+     *
+     * @return the description
+     */
     public synchronized String getDescription() {
         return description;
     }
 
+    /**
+     * Sets description.
+     *
+     * @param description the description
+     */
     public synchronized void setDescription(String description) {
         this.description = description;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/OverflowLogger.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/OverflowLogger.java
@@ -24,16 +24,32 @@ public class OverflowLogger {
     private long lastLogging;
     private final long interval;
     private final Logger logger;
-    
+
+    /**
+     * Instantiates a new Overflow logger.
+     *
+     * @param logger the logger
+     */
     public OverflowLogger(Logger logger) {
         this(logger, 10000);
     }
 
+    /**
+     * Instantiates a new Overflow logger.
+     *
+     * @param logger   the logger
+     * @param interval the interval
+     */
     public OverflowLogger(Logger logger, long interval) {
         this.logger = logger;
         this.interval = interval;
     }
-    
+
+    /**
+     * Log.
+     *
+     * @param message the message
+     */
     public void log(String message) {
         long now = System.currentTimeMillis();
         if (now - lastLogging > interval) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/DistributerConsumer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/DistributerConsumer.java
@@ -25,17 +25,25 @@ import java.util.function.Consumer;
 
 /**
  * Consumer that distributes consumed packets from the bus to
- * a set of packet consumers 
+ * a set of packet consumers
  */
 @ThreadSafe
 public class DistributerConsumer extends AisBusConsumer {
     
     private final List<Consumer<AisPacket>> consumers = new CopyOnWriteArrayList<>();
-    
+
+    /**
+     * Instantiates a new Distributer consumer.
+     */
     public DistributerConsumer() {
         this(false);
     }
-    
+
+    /**
+     * Instantiates a new Distributer consumer.
+     *
+     * @param blocking the blocking
+     */
     public DistributerConsumer(boolean blocking) {
         super(blocking);
     }
@@ -46,7 +54,12 @@ public class DistributerConsumer extends AisBusConsumer {
             consumer.accept(queueElement.getPacket());
         }
     }
-    
+
+    /**
+     * Gets consumers.
+     *
+     * @return the consumers
+     */
     public List<Consumer<AisPacket>> getConsumers() {
         return consumers;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/StdoutConsumer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/StdoutConsumer.java
@@ -24,6 +24,9 @@ import dk.dma.ais.bus.AisBusElement;
 @ThreadSafe
 public class StdoutConsumer extends AisBusConsumer {
 
+    /**
+     * Instantiates a new Stdout consumer.
+     */
     public StdoutConsumer() {
         super();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/TcpServerConsumer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/TcpServerConsumer.java
@@ -28,6 +28,9 @@ public class TcpServerConsumer extends AisBusConsumer {
 
     private final TcpWriteServer server = new TcpWriteServer();
 
+    /**
+     * Instantiates a new Tcp server consumer.
+     */
     public TcpServerConsumer() {
 
     }
@@ -60,15 +63,30 @@ public class TcpServerConsumer extends AisBusConsumer {
     public void receiveFiltered(AisBusElement queueElement) {
         server.send(queueElement.getPacket().getStringMessage());
     }
-    
+
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         server.setClientConf(clientConf);        
     }
-    
+
+    /**
+     * Sets server conf.
+     *
+     * @param serverConf the server conf
+     */
     public void setServerConf(TcpServerConf serverConf) {
         server.setServerConf(serverConf);
     }
-    
+
+    /**
+     * Gets server.
+     *
+     * @return the server
+     */
     public TcpServer getServer() {
         return server;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/TcpWriterConsumer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/consumer/TcpWriterConsumer.java
@@ -47,6 +47,9 @@ public class TcpWriterConsumer extends AisBusConsumer implements Runnable, IClie
     private String host;
     private int port;
 
+    /**
+     * Instantiates a new Tcp writer consumer.
+     */
     public TcpWriterConsumer() {
 
     }
@@ -125,34 +128,74 @@ public class TcpWriterConsumer extends AisBusConsumer implements Runnable, IClie
         super.cancel();
     }
 
+    /**
+     * Gets port.
+     *
+     * @return the port
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets port.
+     *
+     * @param port the port
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * Gets host.
+     *
+     * @return the host
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets host.
+     *
+     * @param host the host
+     */
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * Gets reconnect interval.
+     *
+     * @return the reconnect interval
+     */
     public int getReconnectInterval() {
         return reconnectInterval;
     }
 
+    /**
+     * Sets reconnect interval.
+     *
+     * @param reconnectInterval the reconnect interval
+     */
     public void setReconnectInterval(int reconnectInterval) {
         this.reconnectInterval = reconnectInterval;
     }
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/AisReaderProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/AisReaderProvider.java
@@ -32,11 +32,21 @@ public class AisReaderProvider extends AisBusProvider implements Consumer<AisPac
      * The AIS reader to provide packets
      */
     private AtomicReference<AisReader> aisReader = new AtomicReference<>();
-    
+
+    /**
+     * Instantiates a new Ais reader provider.
+     *
+     * @param blocking the blocking
+     */
     public AisReaderProvider(boolean blocking) {
         super(blocking);
     }
-    
+
+    /**
+     * Instantiates a new Ais reader provider.
+     *
+     * @param aisReader the ais reader
+     */
     public AisReaderProvider(AisReader aisReader) {
         setAisReader(aisReader);
     }
@@ -67,7 +77,12 @@ public class AisReaderProvider extends AisBusProvider implements Consumer<AisPac
             e.printStackTrace();
         }
     }
-    
+
+    /**
+     * Sets ais reader.
+     *
+     * @param aisReader the ais reader
+     */
     public void setAisReader(AisReader aisReader) {
         if (this.aisReader.get() != null) {
             throw new IllegalStateException("AisReader already defined");

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/CollectorProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/CollectorProvider.java
@@ -20,11 +20,14 @@ import dk.dma.ais.packet.AisPacket;
 import java.util.function.Consumer;
 
 /**
- * Provider that allows to push packets onto the bus 
+ * Provider that allows to push packets onto the bus
  */
 @ThreadSafe
 public class CollectorProvider extends AisBusProvider implements Consumer<AisPacket> {
-    
+
+    /**
+     * Instantiates a new Collector provider.
+     */
     public CollectorProvider() {
         super();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/FileReaderProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/FileReaderProvider.java
@@ -26,11 +26,24 @@ import net.jcip.annotations.ThreadSafe;
  */
 @ThreadSafe
 public class FileReaderProvider extends StreamReaderProvider {
-    
+
+    /**
+     * Instantiates a new File reader provider.
+     *
+     * @param filename the filename
+     * @throws IOException the io exception
+     */
     public FileReaderProvider(String filename) throws IOException {
         this(filename, false);
     }
-    
+
+    /**
+     * Instantiates a new File reader provider.
+     *
+     * @param filename the filename
+     * @param gzip     the gzip
+     * @throws IOException the io exception
+     */
     public FileReaderProvider(String filename, boolean gzip) throws IOException {
         super(true);
         InputStream stream = new FileInputStream(filename);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/RepeatingFileReaderProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/RepeatingFileReaderProvider.java
@@ -48,6 +48,12 @@ public class RepeatingFileReaderProvider extends AisBusProvider implements Consu
     private final String filename;
     private final boolean gzip;
 
+    /**
+     * Instantiates a new Repeating file reader provider.
+     *
+     * @param filename the filename
+     * @param gzip     the gzip
+     */
     public RepeatingFileReaderProvider(String filename, boolean gzip) {
         this.filename = filename;
         this.gzip = gzip;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/StreamReaderProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/StreamReaderProvider.java
@@ -29,19 +29,40 @@ public class StreamReaderProvider extends AisReaderProvider {
     @GuardedBy("this")
     private InputStream stream;
 
+    /**
+     * Instantiates a new Stream reader provider.
+     *
+     * @param blocking the blocking
+     */
     public StreamReaderProvider(boolean blocking) {
         super(blocking);
     }
 
+    /**
+     * Instantiates a new Stream reader provider.
+     *
+     * @param stream   the stream
+     * @param blocking the blocking
+     */
     public StreamReaderProvider(InputStream stream, boolean blocking) {
         super(blocking);
         this.stream = stream;
     }
-    
+
+    /**
+     * Instantiates a new Stream reader provider.
+     *
+     * @param stream the stream
+     */
     public StreamReaderProvider(InputStream stream) {
         this(stream, false);
     }
 
+    /**
+     * Sets stream.
+     *
+     * @param stream the stream
+     */
     protected synchronized void setStream(InputStream stream) {
         this.stream = stream;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/TcpClientProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/TcpClientProvider.java
@@ -52,6 +52,9 @@ public final class TcpClientProvider extends AisBusProvider implements Runnable,
     private int currentHost = -1;
     private volatile Socket socket;
 
+    /**
+     * Instantiates a new Tcp client provider.
+     */
     public TcpClientProvider() {
         super();
     }
@@ -149,22 +152,47 @@ public final class TcpClientProvider extends AisBusProvider implements Runnable,
         super.init();
     }
 
+    /**
+     * Gets hosts ports.
+     *
+     * @return the hosts ports
+     */
     public List<String> getHostsPorts() {
         return hostsPorts;
     }
 
+    /**
+     * Sets hosts ports.
+     *
+     * @param hostsPorts the hosts ports
+     */
     public void setHostsPorts(List<String> hostsPorts) {
         this.hostsPorts = hostsPorts;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }
 
+    /**
+     * Sets timeout.
+     *
+     * @param timeout the timeout
+     */
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }
 
+    /**
+     * Sets reconnect interval.
+     *
+     * @param reconnectInterval the reconnect interval
+     */
     public void setReconnectInterval(int reconnectInterval) {
         this.reconnectInterval = reconnectInterval;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/TcpServerProvider.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/provider/TcpServerProvider.java
@@ -29,6 +29,9 @@ public class TcpServerProvider extends AisBusProvider implements Consumer<AisPac
 
     private final TcpReadServer server;
 
+    /**
+     * Instantiates a new Tcp server provider.
+     */
     public TcpServerProvider() {
         server = new TcpReadServer(this);
     }
@@ -64,14 +67,29 @@ public class TcpServerProvider extends AisBusProvider implements Consumer<AisPac
         setStopped();
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         server.setClientConf(clientConf);
     }
 
+    /**
+     * Sets server conf.
+     *
+     * @param serverConf the server conf
+     */
     public void setServerConf(TcpServerConf serverConf) {
         server.setServerConf(serverConf);
     }
-    
+
+    /**
+     * Gets server.
+     *
+     * @return the server
+     */
     public TcpServer getServer() {
         return server;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/status/AisBusComponentStatus.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/status/AisBusComponentStatus.java
@@ -18,14 +18,40 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Status of a bus component
- * 
+ * <p>
  * TODO: Flow history
  */
 @ThreadSafe
 public class AisBusComponentStatus {
 
+    /**
+     * The enum State.
+     */
     public enum State {
-        CREATED, INITIALIZED, STARTED, CONNECTED, NOT_CONNECTED, STOPPED;
+        /**
+         * Created state.
+         */
+        CREATED,
+        /**
+         * Initialized state.
+         */
+        INITIALIZED,
+        /**
+         * Started state.
+         */
+        STARTED,
+        /**
+         * Connected state.
+         */
+        CONNECTED,
+        /**
+         * Not connected state.
+         */
+        NOT_CONNECTED,
+        /**
+         * Stopped state.
+         */
+        STOPPED;
     }
 
     /**
@@ -71,11 +97,19 @@ public class AisBusComponentStatus {
      */
     private final FlowStat filteredCountStat;
 
+    /**
+     * Instantiates a new Ais bus component status.
+     */
     public AisBusComponentStatus() {
         // Default one minute interval
         this(60000);
     }
 
+    /**
+     * Instantiates a new Ais bus component status.
+     *
+     * @param flowStatInterval the flow stat interval
+     */
     public AisBusComponentStatus(long flowStatInterval) {
         this.state = State.CREATED;
         this.startTime = System.currentTimeMillis();
@@ -109,10 +143,18 @@ public class AisBusComponentStatus {
         overflowCount++;
     }
 
+    /**
+     * Gets state.
+     *
+     * @return the state
+     */
     public synchronized State getState() {
         return state;
     }
 
+    /**
+     * Sets initialized.
+     */
     public synchronized void setInitialized() {
         if (state != State.CREATED) {
             throw new IllegalStateException("Component must be in state CREATED to be initialized");
@@ -120,61 +162,123 @@ public class AisBusComponentStatus {
         state = State.INITIALIZED;
     }
 
+    /**
+     * Sets started.
+     */
     public synchronized void setStarted() {
         if (state == State.CREATED ) {
             throw new IllegalStateException("Component must be initialized to be started");
         }
         state = State.STARTED;
     }
-    
+
+    /**
+     * Is started boolean.
+     *
+     * @return the boolean
+     */
     public synchronized boolean isStarted() {
         return state == State.STARTED || state == State.CONNECTED || state == State.NOT_CONNECTED;
     }
-    
+
+    /**
+     * Sets connected.
+     */
     public synchronized void setConnected() {
         state = State.CONNECTED;
     }
-    
+
+    /**
+     * Is connected boolean.
+     *
+     * @return the boolean
+     */
     public synchronized boolean isConnected() {
         return state == State.CONNECTED;
     }
-    
+
+    /**
+     * Sets not connected.
+     */
     public synchronized void setNotConnected() {
         state = State.NOT_CONNECTED;
     }
-    
+
+    /**
+     * Sets stopped.
+     */
     public synchronized void setStopped() {
         state = State.STOPPED;
     }
 
+    /**
+     * Gets start time.
+     *
+     * @return the start time
+     */
     public long getStartTime() {
         return startTime;
     }
 
+    /**
+     * Gets flow stat interval.
+     *
+     * @return the flow stat interval
+     */
     public long getFlowStatInterval() {
         return flowStatInterval;
     }
 
+    /**
+     * Gets in count.
+     *
+     * @return the in count
+     */
     public synchronized long getInCount() {
         return inCount;
     }
-    
+
+    /**
+     * Gets in rate.
+     *
+     * @return the in rate
+     */
     public synchronized double getInRate() {
         return inCountStat.getRate();
     }
 
+    /**
+     * Gets filtered count.
+     *
+     * @return the filtered count
+     */
     public synchronized long getFilteredCount() {
         return filteredCount;
     }
-    
+
+    /**
+     * Gets filtered rate.
+     *
+     * @return the filtered rate
+     */
     public synchronized double getFilteredRate() {
         return filteredCountStat.getRate();
     }
 
+    /**
+     * Gets overflow count.
+     *
+     * @return the overflow count
+     */
     public synchronized long getOverflowCount() {
         return overflowCount;
     }
-    
+
+    /**
+     * Gets overflow rate.
+     *
+     * @return the overflow rate
+     */
     public synchronized double getOverflowRate() {
         return overflowCountStat.getRate();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/status/FlowStat.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/status/FlowStat.java
@@ -39,6 +39,7 @@ public class FlowStat {
 
     /**
      * Constructor given the interval to calculate rate for
+     *
      * @param interval in milliseconds
      */
     public FlowStat(long interval) {
@@ -48,7 +49,8 @@ public class FlowStat {
 
     /**
      * Get the last received time
-     * @return
+     *
+     * @return last received
      */
     public Long getLastReceived() {
         return lastReceived;
@@ -56,7 +58,8 @@ public class FlowStat {
 
     /**
      * Get time of creation
-     * @return
+     *
+     * @return created created
      */
     public long getCreated() {
         return created;
@@ -64,7 +67,8 @@ public class FlowStat {
 
     /**
      * Get rate as receives/seconds
-     * @return
+     *
+     * @return rate rate
      */
     public double getRate() {
         long now = System.currentTimeMillis();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/IClientStoppedListener.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/IClientStoppedListener.java
@@ -18,7 +18,12 @@ package dk.dma.ais.bus.tcp;
  * Interface for classes wanting to be notified of a client stopping
  */
 public interface IClientStoppedListener {
-    
+
+    /**
+     * Client stopped.
+     *
+     * @param client the client
+     */
     void clientStopped(TcpClient client);
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpClient.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpClient.java
@@ -27,12 +27,28 @@ import dk.dma.ais.bus.status.AisBusComponentStatus;
 @ThreadSafe
 public abstract class TcpClient extends Thread {
 
+    /**
+     * The Conf.
+     */
     protected final TcpClientConf conf;
+    /**
+     * The Socket.
+     */
     protected final Socket socket;
     private final IClientStoppedListener stopListener;
-    
+
+    /**
+     * The Status.
+     */
     protected final AisBusComponentStatus status = new AisBusComponentStatus();
 
+    /**
+     * Instantiates a new Tcp client.
+     *
+     * @param stopListener the stop listener
+     * @param socket       the socket
+     * @param conf         the conf
+     */
     public TcpClient(IClientStoppedListener stopListener, Socket socket, TcpClientConf conf) {
         status.setInitialized();
         this.stopListener = stopListener;
@@ -42,12 +58,18 @@ public abstract class TcpClient extends Thread {
 
     /**
      * Get status for "component"
-     * @return
+     *
+     * @return status status
      */
     public AisBusComponentStatus getStatus() {
         return status;
     }
-    
+
+    /**
+     * Gets remote host.
+     *
+     * @return the remote host
+     */
     public String getRemoteHost() {
         InetSocketAddress address = (InetSocketAddress)socket.getRemoteSocketAddress();
         if (address == null) {
@@ -77,6 +99,11 @@ public abstract class TcpClient extends Thread {
         }
     }
 
+    /**
+     * Rate report string.
+     *
+     * @return the string
+     */
     public String rateReport() {
         return String.format("[count/overflow] %4.2f / %4.2f  (packets/sec)", status.getInRate(), status.getOverflowRate());
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpClientConf.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpClientConf.java
@@ -23,30 +23,63 @@ public class TcpClientConf {
     private int gzipBufferSize = 2048;
     private int bufferSize = 8192;
 
+    /**
+     * Instantiates a new Tcp client conf.
+     */
     public TcpClientConf() {
 
     }
 
+    /**
+     * Is gzip compress boolean.
+     *
+     * @return the boolean
+     */
     public boolean isGzipCompress() {
         return gzipCompress;
     }
 
+    /**
+     * Sets gzip compress.
+     *
+     * @param gzipCompress the gzip compress
+     */
     public void setGzipCompress(boolean gzipCompress) {
         this.gzipCompress = gzipCompress;
     }
 
+    /**
+     * Gets gzip buffer size.
+     *
+     * @return the gzip buffer size
+     */
     public int getGzipBufferSize() {
         return gzipBufferSize;
     }
 
+    /**
+     * Sets gzip buffer size.
+     *
+     * @param gzipBufferSize the gzip buffer size
+     */
     public void setGzipBufferSize(int gzipBufferSize) {
         this.gzipBufferSize = gzipBufferSize;
     }
 
+    /**
+     * Gets buffer size.
+     *
+     * @return the buffer size
+     */
     public int getBufferSize() {
         return bufferSize;
     }
 
+    /**
+     * Sets buffer size.
+     *
+     * @param bufferSize the buffer size
+     */
     public void setBufferSize(int bufferSize) {
         this.bufferSize = bufferSize;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpReadClient.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpReadClient.java
@@ -38,6 +38,14 @@ public class TcpReadClient extends TcpClient implements Consumer<AisPacket> {
     private final Consumer<AisPacket> packetConsumer;
     private final AtomicReference<AisReader> reader = new AtomicReference<>();
 
+    /**
+     * Instantiates a new Tcp read client.
+     *
+     * @param packetConsumer the packet consumer
+     * @param stopListener   the stop listener
+     * @param socket         the socket
+     * @param conf           the conf
+     */
     public TcpReadClient(Consumer<AisPacket> packetConsumer, IClientStoppedListener stopListener, Socket socket,
             TcpClientConf conf) {
         super(stopListener, socket, conf);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpReadServer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpReadServer.java
@@ -25,7 +25,12 @@ import java.util.function.Consumer;
 public class TcpReadServer extends TcpServer {
     
     private final Consumer<AisPacket> packetConsumer;
-    
+
+    /**
+     * Instantiates a new Tcp read server.
+     *
+     * @param packetConsumer the packet consumer
+     */
     public TcpReadServer(Consumer<AisPacket> packetConsumer) {
         super();
         this.packetConsumer = packetConsumer;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpServer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpServer.java
@@ -35,29 +35,44 @@ public abstract class TcpServer extends Thread implements IClientStoppedListener
 
     private static final Logger LOG = LoggerFactory.getLogger(TcpServer.class);
 
+    /**
+     * The Server socket.
+     */
     protected final AtomicReference<ServerSocket> serverSocket = new AtomicReference<>();
 
+    /**
+     * The Server conf.
+     */
     protected TcpServerConf serverConf = new TcpServerConf();
+    /**
+     * The Client conf.
+     */
     protected TcpClientConf clientConf = new TcpClientConf();
 
     private Semaphore semaphore;
+    /**
+     * The Clients.
+     */
     protected final Set<TcpClient> clients = Collections.newSetFromMap(new ConcurrentHashMap<TcpClient, Boolean>());
 
+    /**
+     * Instantiates a new Tcp server.
+     */
     public TcpServer() {
     }
 
     /**
      * Inheriting classes must be able to provide a new client
-     * 
-     * @param socket
-     * @return
+     *
+     * @param socket the socket
+     * @return tcp client
      */
     protected abstract TcpClient newClient(Socket socket);
 
     /**
      * Clients notify them self when they are done
      * 
-     * @param client
+     * @param client tcpclient
      */
     @Override
     public void clientStopped(TcpClient client) {
@@ -121,7 +136,10 @@ public abstract class TcpServer extends Thread implements IClientStoppedListener
         LOG.info("Stopped");
 
     }
-    
+
+    /**
+     * Cancel.
+     */
     public void cancel() {
         this.interrupt();
         if (serverSocket.get() != null) {
@@ -137,22 +155,47 @@ public abstract class TcpServer extends Thread implements IClientStoppedListener
         }
     }
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }
 
+    /**
+     * Gets server conf.
+     *
+     * @return the server conf
+     */
     public TcpServerConf getServerConf() {
         return serverConf;
     }
 
+    /**
+     * Sets server conf.
+     *
+     * @param serverConf the server conf
+     */
     public void setServerConf(TcpServerConf serverConf) {
         this.serverConf = serverConf;
     }
-    
+
+    /**
+     * Gets clients.
+     *
+     * @return the clients
+     */
     public Set<TcpClient> getClients() {
         return clients;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpServerConf.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpServerConf.java
@@ -22,22 +22,45 @@ public class TcpServerConf {
     private int port = 8090;
     private int maxClients = 1000;
 
+    /**
+     * Instantiates a new Tcp server conf.
+     */
     public TcpServerConf() {
 
     }
 
+    /**
+     * Gets port.
+     *
+     * @return the port
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets port.
+     *
+     * @param port the port
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * Gets max clients.
+     *
+     * @return the max clients
+     */
     public int getMaxClients() {
         return maxClients;
     }
 
+    /**
+     * Sets max clients.
+     *
+     * @param maxClients the max clients
+     */
     public void setMaxClients(int maxClients) {
         this.maxClients = maxClients;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpWriteClient.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpWriteClient.java
@@ -39,6 +39,13 @@ public class TcpWriteClient extends TcpClient {
 
     private final BlockingQueue<String> buffer;
 
+    /**
+     * Instantiates a new Tcp write client.
+     *
+     * @param stopListener the stop listener
+     * @param socket       the socket
+     * @param conf         the conf
+     */
     public TcpWriteClient(IClientStoppedListener stopListener, Socket socket, TcpClientConf conf) {
         super(stopListener, socket, conf);
         this.buffer = new ArrayBlockingQueue<>(conf.getBufferSize());
@@ -46,8 +53,9 @@ public class TcpWriteClient extends TcpClient {
 
     /**
      * Send message
-     * 
-     * @param sentenceStr
+     *
+     * @param msg the msg
+     * @return the boolean
      */
     public boolean send(String msg) {
         status.receive();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpWriteServer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/bus/tcp/TcpWriteServer.java
@@ -21,6 +21,9 @@ import java.net.Socket;
  */
 public class TcpWriteServer extends TcpServer {
 
+    /**
+     * Instantiates a new Tcp write server.
+     */
     public TcpWriteServer() {
         super();
     }
@@ -32,8 +35,8 @@ public class TcpWriteServer extends TcpServer {
 
     /**
      * Send message to all clients
-     * 
-     * @param sentenceStr
+     *
+     * @param msg the msg
      */
     public void send(String msg) {
         for (TcpClient client : clients) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusComponentConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusComponentConfiguration.java
@@ -23,36 +23,72 @@ import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.configuration.filter.FilterConfiguration;
 import dk.dma.ais.configuration.transform.TransformerConfiguration;
 
+/**
+ * The type Ais bus component configuration.
+ */
 public abstract class AisBusComponentConfiguration {
 
     private List<FilterConfiguration> filters = new ArrayList<>();
         
     private List<TransformerConfiguration> transformers = new ArrayList<>();
 
+    /**
+     * Instantiates a new Ais bus component configuration.
+     */
     public AisBusComponentConfiguration() {
 
     }
 
+    /**
+     * Gets filters.
+     *
+     * @return the filters
+     */
     @XmlElement(name = "filter")
     public List<FilterConfiguration> getFilters() {
         return filters;
     }
 
+    /**
+     * Sets filters.
+     *
+     * @param filters the filters
+     */
     public void setFilters(List<FilterConfiguration> filters) {
         this.filters = filters;
     }
-    
+
+    /**
+     * Gets transformers.
+     *
+     * @return the transformers
+     */
     @XmlElement(name = "transformer")
     public List<TransformerConfiguration> getTransformers() {
         return transformers;
     }
-    
+
+    /**
+     * Sets transformers.
+     *
+     * @param transformers the transformers
+     */
     public void setTransformers(List<TransformerConfiguration> transformers) {
         this.transformers = transformers;
     }
-    
+
+    /**
+     * Gets instance.
+     *
+     * @return the instance
+     */
     public abstract AisBusComponent getInstance();
-    
+
+    /**
+     * Configure.
+     *
+     * @param comp the comp
+     */
     protected void configure(AisBusComponent comp) {
         // Add filters
         for (FilterConfiguration filterConf : filters) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusConfiguration.java
@@ -37,6 +37,9 @@ import dk.dma.ais.bus.AisBusProvider;
 import dk.dma.ais.configuration.bus.consumer.AisBusConsumerConfiguration;
 import dk.dma.ais.configuration.bus.provider.AisBusProviderConfiguration;
 
+/**
+ * The type Ais bus configuration.
+ */
 @XmlRootElement
 public class AisBusConfiguration extends AisBusComponentConfiguration {
 
@@ -46,40 +49,83 @@ public class AisBusConfiguration extends AisBusComponentConfiguration {
     private List<AisBusProviderConfiguration> providers = new ArrayList<>();
     private List<AisBusConsumerConfiguration> consumers = new ArrayList<>();
 
+    /**
+     * Instantiates a new Ais bus configuration.
+     */
     public AisBusConfiguration() {
 
     }
 
+    /**
+     * Gets bus pull max elements.
+     *
+     * @return the bus pull max elements
+     */
     public int getBusPullMaxElements() {
         return busPullMaxElements;
     }
 
+    /**
+     * Sets bus pull max elements.
+     *
+     * @param busPullMaxElements the bus pull max elements
+     */
     public void setBusPullMaxElements(int busPullMaxElements) {
         this.busPullMaxElements = busPullMaxElements;
     }
 
+    /**
+     * Gets bus queue size.
+     *
+     * @return the bus queue size
+     */
     public int getBusQueueSize() {
         return busQueueSize;
     }
 
+    /**
+     * Sets bus queue size.
+     *
+     * @param busQueueSize the bus queue size
+     */
     public void setBusQueueSize(int busQueueSize) {
         this.busQueueSize = busQueueSize;
     }
 
+    /**
+     * Gets providers.
+     *
+     * @return the providers
+     */
     @XmlElement(name = "provider")
     public List<AisBusProviderConfiguration> getProviders() {
         return providers;
     }
 
+    /**
+     * Sets providers.
+     *
+     * @param providers the providers
+     */
     public void setProviders(List<AisBusProviderConfiguration> providers) {
         this.providers = providers;
     }
 
+    /**
+     * Gets consumers.
+     *
+     * @return the consumers
+     */
     @XmlElement(name = "consumer")
     public List<AisBusConsumerConfiguration> getConsumers() {
         return consumers;
     }
 
+    /**
+     * Sets consumers.
+     *
+     * @param consumers the consumers
+     */
     public void setConsumers(List<AisBusConsumerConfiguration> consumers) {
         this.consumers = consumers;
     }
@@ -109,6 +155,13 @@ public class AisBusConfiguration extends AisBusComponentConfiguration {
         return aisBus;
     }
 
+    /**
+     * Save.
+     *
+     * @param out  the out
+     * @param conf the conf
+     * @throws JAXBException the jaxb exception
+     */
     public static void save(OutputStream out, final AisBusConfiguration conf) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(AisBusConfiguration.class);
         Marshaller m = context.createMarshaller();
@@ -117,16 +170,39 @@ public class AisBusConfiguration extends AisBusComponentConfiguration {
         m.marshal(conf, out);
     }
 
+    /**
+     * Load ais bus configuration.
+     *
+     * @param in the in
+     * @return the ais bus configuration
+     * @throws JAXBException the jaxb exception
+     */
     public static AisBusConfiguration load(InputStream in) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(AisBusConfiguration.class);
         Unmarshaller um = context.createUnmarshaller();
         return (AisBusConfiguration) um.unmarshal(in);
     }
-    
+
+    /**
+     * Save.
+     *
+     * @param filename the filename
+     * @param conf     the conf
+     * @throws JAXBException         the jaxb exception
+     * @throws FileNotFoundException the file not found exception
+     */
     public static void save(String filename, final AisBusConfiguration conf) throws JAXBException, FileNotFoundException {
         save(new FileOutputStream(new File(filename)), conf);
     }
-    
+
+    /**
+     * Load ais bus configuration.
+     *
+     * @param filename the filename
+     * @return the ais bus configuration
+     * @throws FileNotFoundException the file not found exception
+     * @throws JAXBException         the jaxb exception
+     */
     public static AisBusConfiguration load(String filename) throws FileNotFoundException, JAXBException {
         return load(new FileInputStream(new File(filename)));
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusSocketConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/AisBusSocketConfiguration.java
@@ -16,31 +16,62 @@ package dk.dma.ais.configuration.bus;
 
 import dk.dma.ais.bus.AisBusSocket;
 
+/**
+ * The type Ais bus socket configuration.
+ */
 public abstract class AisBusSocketConfiguration extends AisBusComponentConfiguration {
 
     private String name;
     private String description;
 
+    /**
+     * Instantiates a new Ais bus socket configuration.
+     */
     public AisBusSocketConfiguration() {
 
     }
 
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets description.
+     *
+     * @return the description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Sets description.
+     *
+     * @param description the description
+     */
     public void setDescription(String description) {
         this.description = description;
     }
-    
+
+    /**
+     * Configure.
+     *
+     * @param socket the socket
+     */
     protected void configure(AisBusSocket socket) {
         socket.setName(name);
         socket.setDescription(description);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/AisBusConsumerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/AisBusConsumerConfiguration.java
@@ -19,6 +19,9 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 import dk.dma.ais.bus.AisBusConsumer;
 import dk.dma.ais.configuration.bus.AisBusSocketConfiguration;
 
+/**
+ * The type Ais bus consumer configuration.
+ */
 @XmlSeeAlso({ StdoutConsumerConfiguration.class, TcpWriterConsumerConfiguration.class, TcpServerConsumerConfiguration.class,
         DistributerConsumerConfiguration.class })
 public abstract class AisBusConsumerConfiguration extends AisBusSocketConfiguration {
@@ -26,26 +29,55 @@ public abstract class AisBusConsumerConfiguration extends AisBusSocketConfigurat
     private int consumerPullMaxElements = 1000;
     private int consumerQueueSize = 10000;
 
+    /**
+     * Instantiates a new Ais bus consumer configuration.
+     */
     public AisBusConsumerConfiguration() {
 
     }
 
+    /**
+     * Gets consumer queue size.
+     *
+     * @return the consumer queue size
+     */
     public int getConsumerQueueSize() {
         return consumerQueueSize;
     }
 
+    /**
+     * Sets consumer queue size.
+     *
+     * @param consumerQueueSize the consumer queue size
+     */
     public void setConsumerQueueSize(int consumerQueueSize) {
         this.consumerQueueSize = consumerQueueSize;
     }
 
+    /**
+     * Gets consumer pull max elements.
+     *
+     * @return the consumer pull max elements
+     */
     public int getConsumerPullMaxElements() {
         return consumerPullMaxElements;
     }
 
+    /**
+     * Sets consumer pull max elements.
+     *
+     * @param consumerPullMaxElements the consumer pull max elements
+     */
     public void setConsumerPullMaxElements(int consumerPullMaxElements) {
         this.consumerPullMaxElements = consumerPullMaxElements;
     }
 
+    /**
+     * Configure ais bus consumer.
+     *
+     * @param consumer the consumer
+     * @return the ais bus consumer
+     */
     protected AisBusConsumer configure(AisBusConsumer consumer) {
         consumer.setConsumerPullMaxElements(consumerPullMaxElements);
         consumer.setConsumerQueueSize(consumerQueueSize);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/DistributerConsumerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/DistributerConsumerConfiguration.java
@@ -19,6 +19,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.consumer.DistributerConsumer;
 
+/**
+ * The type Distributer consumer configuration.
+ */
 @XmlRootElement
 public class DistributerConsumerConfiguration extends AisBusConsumerConfiguration {
     

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/StdoutConsumerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/StdoutConsumerConfiguration.java
@@ -20,9 +20,15 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.consumer.StdoutConsumer;
 
+/**
+ * The type Stdout consumer configuration.
+ */
 @XmlRootElement
 public class StdoutConsumerConfiguration extends AisBusConsumerConfiguration {
-    
+
+    /**
+     * Instantiates a new Stdout consumer configuration.
+     */
     public StdoutConsumerConfiguration() {
         
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/TcpServerConsumerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/TcpServerConsumerConfiguration.java
@@ -22,28 +22,54 @@ import dk.dma.ais.bus.consumer.TcpServerConsumer;
 import dk.dma.ais.bus.tcp.TcpClientConf;
 import dk.dma.ais.bus.tcp.TcpServerConf;
 
+/**
+ * The type Tcp server consumer configuration.
+ */
 @XmlRootElement
 public class TcpServerConsumerConfiguration extends AisBusConsumerConfiguration {
 
     private TcpClientConf clientConf = new TcpClientConf();
     private TcpServerConf serverConf = new TcpServerConf();
 
+    /**
+     * Instantiates a new Tcp server consumer configuration.
+     */
     public TcpServerConsumerConfiguration() {
 
     }
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }
 
+    /**
+     * Gets server conf.
+     *
+     * @return the server conf
+     */
     public TcpServerConf getServerConf() {
         return serverConf;
     }
 
+    /**
+     * Sets server conf.
+     *
+     * @param serverConf the server conf
+     */
     public void setServerConf(TcpServerConf serverConf) {
         this.serverConf = serverConf;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/TcpWriterConsumerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/consumer/TcpWriterConsumerConfiguration.java
@@ -21,6 +21,9 @@ import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.consumer.TcpWriterConsumer;
 import dk.dma.ais.bus.tcp.TcpClientConf;
 
+/**
+ * The type Tcp writer consumer configuration.
+ */
 @XmlRootElement
 public class TcpWriterConsumerConfiguration extends AisBusConsumerConfiguration {
 
@@ -29,38 +32,81 @@ public class TcpWriterConsumerConfiguration extends AisBusConsumerConfiguration 
     private int reconnectInterval = 10;
     private TcpClientConf clientConf = new TcpClientConf();
 
+    /**
+     * Instantiates a new Tcp writer consumer configuration.
+     */
     public TcpWriterConsumerConfiguration() {
 
     }
 
+    /**
+     * Gets port.
+     *
+     * @return the port
+     */
     public int getPort() {
         return port;
     }
 
+    /**
+     * Sets port.
+     *
+     * @param port the port
+     */
     public void setPort(int port) {
         this.port = port;
     }
 
+    /**
+     * Gets host.
+     *
+     * @return the host
+     */
     public String getHost() {
         return host;
     }
 
+    /**
+     * Sets host.
+     *
+     * @param host the host
+     */
     public void setHost(String host) {
         this.host = host;
     }
 
+    /**
+     * Gets reconnect interval.
+     *
+     * @return the reconnect interval
+     */
     public int getReconnectInterval() {
         return reconnectInterval;
     }
 
+    /**
+     * Sets reconnect interval.
+     *
+     * @param reconnectInterval the reconnect interval
+     */
     public void setReconnectInterval(int reconnectInterval) {
         this.reconnectInterval = reconnectInterval;
     }
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/AisBusProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/AisBusProviderConfiguration.java
@@ -19,14 +19,26 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 import dk.dma.ais.bus.AisBusProvider;
 import dk.dma.ais.configuration.bus.AisBusSocketConfiguration;
 
+/**
+ * The type Ais bus provider configuration.
+ */
 @XmlSeeAlso({ TcpClientProviderConfiguration.class, TcpServerProviderConfiguration.class, FileReaderProviderConfiguration.class,
         CollectorProviderConfiguration.class, RepeatingFileReaderProviderConfiguration.class })
 public abstract class AisBusProviderConfiguration extends AisBusSocketConfiguration {
 
+    /**
+     * Instantiates a new Ais bus provider configuration.
+     */
     public AisBusProviderConfiguration() {
 
     }
 
+    /**
+     * Configure ais bus provider.
+     *
+     * @param provider the provider
+     * @return the ais bus provider
+     */
     protected AisBusProvider configure(AisBusProvider provider) {
         super.configure(provider);
         return provider;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/CollectorProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/CollectorProviderConfiguration.java
@@ -19,6 +19,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.provider.CollectorProvider;
 
+/**
+ * The type Collector provider configuration.
+ */
 @XmlRootElement
 public class CollectorProviderConfiguration extends AisBusProviderConfiguration {
     

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/FileReaderProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/FileReaderProviderConfiguration.java
@@ -25,6 +25,9 @@ import org.slf4j.LoggerFactory;
 import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.provider.FileReaderProvider;
 
+/**
+ * The type File reader provider configuration.
+ */
 @XmlRootElement
 public class FileReaderProviderConfiguration extends AisBusProviderConfiguration {
 
@@ -33,22 +36,45 @@ public class FileReaderProviderConfiguration extends AisBusProviderConfiguration
     private String filename;
     private boolean gzip;
 
+    /**
+     * Instantiates a new File reader provider configuration.
+     */
     public FileReaderProviderConfiguration() {
 
     }
 
+    /**
+     * Gets filename.
+     *
+     * @return the filename
+     */
     public String getFilename() {
         return filename;
     }
 
+    /**
+     * Sets filename.
+     *
+     * @param filename the filename
+     */
     public void setFilename(String filename) {
         this.filename = filename;
     }
 
+    /**
+     * Is gzip boolean.
+     *
+     * @return the boolean
+     */
     public boolean isGzip() {
         return gzip;
     }
 
+    /**
+     * Sets gzip.
+     *
+     * @param gzip the gzip
+     */
     public void setGzip(boolean gzip) {
         this.gzip = gzip;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/RepeatingFileReaderProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/RepeatingFileReaderProviderConfiguration.java
@@ -20,28 +20,54 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.provider.RepeatingFileReaderProvider;
 
+/**
+ * The type Repeating file reader provider configuration.
+ */
 @XmlRootElement
 public class RepeatingFileReaderProviderConfiguration extends AisBusProviderConfiguration {
 
     private String filename;
     private boolean gzip;
 
+    /**
+     * Instantiates a new Repeating file reader provider configuration.
+     */
     public RepeatingFileReaderProviderConfiguration() {
 
     }
 
+    /**
+     * Gets filename.
+     *
+     * @return the filename
+     */
     public String getFilename() {
         return filename;
     }
 
+    /**
+     * Sets filename.
+     *
+     * @param filename the filename
+     */
     public void setFilename(String filename) {
         this.filename = filename;
     }
 
+    /**
+     * Is gzip boolean.
+     *
+     * @return the boolean
+     */
     public boolean isGzip() {
         return gzip;
     }
 
+    /**
+     * Sets gzip.
+     *
+     * @param gzip the gzip
+     */
     public void setGzip(boolean gzip) {
         this.gzip = gzip;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/TcpClientProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/TcpClientProviderConfiguration.java
@@ -24,6 +24,9 @@ import dk.dma.ais.bus.AisBusComponent;
 import dk.dma.ais.bus.provider.TcpClientProvider;
 import dk.dma.ais.bus.tcp.TcpClientConf;
 
+/**
+ * The type Tcp client provider configuration.
+ */
 @XmlRootElement
 public class TcpClientProviderConfiguration extends AisBusProviderConfiguration {
 
@@ -32,39 +35,82 @@ public class TcpClientProviderConfiguration extends AisBusProviderConfiguration 
     private int reconnectInterval = 10;
     private int timeout = 10;
 
+    /**
+     * Instantiates a new Tcp client provider configuration.
+     */
     public TcpClientProviderConfiguration() {
 
     }
 
+    /**
+     * Gets host port.
+     *
+     * @return the host port
+     */
     public List<String> getHostPort() {
         return hostPort;
     }
 
+    /**
+     * Sets host port.
+     *
+     * @param hostPort the host port
+     */
     public void setHostPort(List<String> hostPort) {
         this.hostPort = hostPort;
     }
 
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }
 
+    /**
+     * Gets reconnect interval.
+     *
+     * @return the reconnect interval
+     */
     public int getReconnectInterval() {
         return reconnectInterval;
     }
 
+    /**
+     * Sets reconnect interval.
+     *
+     * @param reconnectInterval the reconnect interval
+     */
     public void setReconnectInterval(int reconnectInterval) {
         this.reconnectInterval = reconnectInterval;
     }
 
+    /**
+     * Gets timeout.
+     *
+     * @return the timeout
+     */
     public int getTimeout() {
         return timeout;
     }
 
+    /**
+     * Sets timeout.
+     *
+     * @param timeout the timeout
+     */
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/TcpServerProviderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/bus/provider/TcpServerProviderConfiguration.java
@@ -22,28 +22,54 @@ import dk.dma.ais.bus.provider.TcpServerProvider;
 import dk.dma.ais.bus.tcp.TcpClientConf;
 import dk.dma.ais.bus.tcp.TcpServerConf;
 
+/**
+ * The type Tcp server provider configuration.
+ */
 @XmlRootElement
 public class TcpServerProviderConfiguration extends AisBusProviderConfiguration {
 
     private TcpClientConf clientConf = new TcpClientConf();
     private TcpServerConf serverConf = new TcpServerConf();
 
+    /**
+     * Instantiates a new Tcp server provider configuration.
+     */
     public TcpServerProviderConfiguration() {
 
     }
 
+    /**
+     * Gets client conf.
+     *
+     * @return the client conf
+     */
     public TcpClientConf getClientConf() {
         return clientConf;
     }
 
+    /**
+     * Sets client conf.
+     *
+     * @param clientConf the client conf
+     */
     public void setClientConf(TcpClientConf clientConf) {
         this.clientConf = clientConf;
     }
 
+    /**
+     * Gets server conf.
+     *
+     * @return the server conf
+     */
     public TcpServerConf getServerConf() {
         return serverConf;
     }
 
+    /**
+     * Sets server conf.
+     *
+     * @param serverConf the server conf
+     */
     public void setServerConf(TcpServerConf serverConf) {
         this.serverConf = serverConf;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/DownSampleFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/DownSampleFilterConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.DownSampleFilter;
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Down sample filter configuration.
+ */
 @XmlRootElement
 public class DownSampleFilterConfiguration extends FilterConfiguration {
 
@@ -28,18 +31,36 @@ public class DownSampleFilterConfiguration extends FilterConfiguration {
      */
     private long samplingRate = 60;
 
+    /**
+     * Instantiates a new Down sample filter configuration.
+     */
     public DownSampleFilterConfiguration() {
 
     }
 
+    /**
+     * Instantiates a new Down sample filter configuration.
+     *
+     * @param samplingRate the sampling rate
+     */
     public DownSampleFilterConfiguration(long samplingRate) {
         this.samplingRate = samplingRate;
     }
 
+    /**
+     * Gets sampling rate.
+     *
+     * @return the sampling rate
+     */
     public long getSamplingRate() {
         return samplingRate;
     }
 
+    /**
+     * Sets sampling rate.
+     *
+     * @param samplingRate the sampling rate
+     */
     public void setSamplingRate(long samplingRate) {
         this.samplingRate = samplingRate;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/DuplicateFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/DuplicateFilterConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.DuplicateFilter;
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Duplicate filter configuration.
+ */
 @XmlRootElement
 public class DuplicateFilterConfiguration extends FilterConfiguration {
 
@@ -28,14 +31,27 @@ public class DuplicateFilterConfiguration extends FilterConfiguration {
      */
     private long windowSize = 10000;
 
+    /**
+     * Instantiates a new Duplicate filter configuration.
+     */
     public DuplicateFilterConfiguration() {
 
     }
 
+    /**
+     * Gets window size.
+     *
+     * @return the window size
+     */
     public long getWindowSize() {
         return windowSize;
     }
 
+    /**
+     * Sets window size.
+     *
+     * @param windowSize the window size
+     */
     public void setWindowSize(long windowSize) {
         this.windowSize = windowSize;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/ExpressionFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/ExpressionFilterConfiguration.java
@@ -19,19 +19,35 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.filter.ExpressionFilter;
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Expression filter configuration.
+ */
 @XmlRootElement
 public class ExpressionFilterConfiguration extends FilterConfiguration {
 
     private String expression;
 
+    /**
+     * Instantiates a new Expression filter configuration.
+     */
     public ExpressionFilterConfiguration() {
 
     }
 
+    /**
+     * Gets expression.
+     *
+     * @return the expression
+     */
     public String getExpression() {
         return expression;
     }
 
+    /**
+     * Sets expression.
+     *
+     * @param expression the expression
+     */
     public void setExpression(String expression) {
         this.expression = expression;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/FilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/FilterConfiguration.java
@@ -18,12 +18,20 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Filter configuration.
+ */
 @XmlSeeAlso({ PacketFilterCollectionConfiguration.class, DownSampleFilterConfiguration.class,
         ReplayDownSampleFilterConfiguration.class, DuplicateFilterConfiguration.class, GatehouseSourceFilterConfiguration.class,
         TargetCountryFilterConfiguration.class, TaggingFilterConfiguration.class, LocationFilterConfiguration.class,
         MessageTypeFilterConfiguration.class, ExpressionFilterConfiguration.class, SanityFilterConfiguration.class, FutureFilterConfiguration.class, PastFilterConfiguration.class })
 public abstract class FilterConfiguration {
 
+    /**
+     * Gets instance.
+     *
+     * @return the instance
+     */
     public abstract IPacketFilter getInstance();
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/FutureFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/FutureFilterConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.FutureFilter;
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Future filter configuration.
+ */
 @XmlRootElement
 public class FutureFilterConfiguration extends FilterConfiguration {
 
@@ -29,10 +32,18 @@ public class FutureFilterConfiguration extends FilterConfiguration {
      */
     private long threshold = 60000;
 
+    /**
+     * Instantiates a new Future filter configuration.
+     */
     public FutureFilterConfiguration() {
 
     }
 
+    /**
+     * Instantiates a new Future filter configuration.
+     *
+     * @param threshold the threshold
+     */
     public FutureFilterConfiguration(long threshold) {
         this.threshold = threshold;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/GatehouseSourceFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/GatehouseSourceFilterConfiguration.java
@@ -22,19 +22,35 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.filter.GatehouseSourceFilter;
 import dk.dma.ais.filter.IPacketFilter;
 
+/**
+ * The type Gatehouse source filter configuration.
+ */
 @XmlRootElement
 public class GatehouseSourceFilterConfiguration extends FilterConfiguration {
 
     private HashMap<String, String> filterEntries = new HashMap<>();
 
+    /**
+     * Instantiates a new Gatehouse source filter configuration.
+     */
     public GatehouseSourceFilterConfiguration() {
 
     }
-    
+
+    /**
+     * Gets filter entries.
+     *
+     * @return the filter entries
+     */
     public HashMap<String, String> getFilterEntries() {
         return filterEntries;
     }
-    
+
+    /**
+     * Sets filter entries.
+     *
+     * @param filterEntries the filter entries
+     */
     public void setFilterEntries(HashMap<String, String> filterEntries) {
         this.filterEntries = filterEntries;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/LocationFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/LocationFilterConfiguration.java
@@ -25,20 +25,36 @@ import dk.dma.ais.configuration.filter.geometry.GeometryConfiguration;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.LocationFilter;
 
+/**
+ * The type Location filter configuration.
+ */
 @XmlRootElement
 public class LocationFilterConfiguration extends FilterConfiguration {
 
     private List<GeometryConfiguration> geometries = new ArrayList<>();
 
+    /**
+     * Instantiates a new Location filter configuration.
+     */
     public LocationFilterConfiguration() {
 
     }
 
+    /**
+     * Gets geometries.
+     *
+     * @return the geometries
+     */
     @XmlElement(name = "geometry")
     public List<GeometryConfiguration> getGeometries() {
         return geometries;
     }
 
+    /**
+     * Sets geometries.
+     *
+     * @param geometries the geometries
+     */
     public void setGeometries(List<GeometryConfiguration> geometries) {
         this.geometries = geometries;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/MessageTypeFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/MessageTypeFilterConfiguration.java
@@ -23,29 +23,55 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.MessageTypeFilter;
 
+/**
+ * The type Message type filter configuration.
+ */
 @XmlRootElement
 public class MessageTypeFilterConfiguration extends FilterConfiguration {
 
     private List<Integer> messageTypes = new ArrayList<>();
     private boolean disallowed;
 
+    /**
+     * Instantiates a new Message type filter configuration.
+     */
     public MessageTypeFilterConfiguration() {
 
     }
 
+    /**
+     * Gets message types.
+     *
+     * @return the message types
+     */
     @XmlElement(name = "message_type")
     public List<Integer> getMessageTypes() {
         return messageTypes;
     }
 
+    /**
+     * Sets message types.
+     *
+     * @param messageTypes the message types
+     */
     public void setMessageTypes(List<Integer> messageTypes) {
         this.messageTypes = messageTypes;
     }
 
+    /**
+     * Is disallowed boolean.
+     *
+     * @return the boolean
+     */
     public boolean isDisallowed() {
         return disallowed;
     }
 
+    /**
+     * Sets disallowed.
+     *
+     * @param disallowed the disallowed
+     */
     public void setDisallowed(boolean disallowed) {
         this.disallowed = disallowed;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/PacketFilterCollectionConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/PacketFilterCollectionConfiguration.java
@@ -24,6 +24,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.PacketFilterCollection;
 
+/**
+ * The type Packet filter collection configuration.
+ */
 @XmlRootElement
 public class PacketFilterCollectionConfiguration extends FilterConfiguration {
     //TODO fix this into an enumeration type or something usable in PacketFilterCollection aswell
@@ -33,22 +36,47 @@ public class PacketFilterCollectionConfiguration extends FilterConfiguration {
     @XmlElement(name = "filterCollection")
     private List<FilterConfiguration> collection = new ArrayList<>();
 
+    /**
+     * Gets filter type.
+     *
+     * @return the filter type
+     */
     public int getFilterType() {
         return filterType;
     }
 
+    /**
+     * Sets filter type.
+     *
+     * @param filterType the filter type
+     */
     public void setFilterType(int filterType) {
         this.filterType = filterType;
     }
 
+    /**
+     * Gets collection.
+     *
+     * @return the collection
+     */
     public List<FilterConfiguration> getCollection() {
         return collection;
     }
 
+    /**
+     * Set.
+     *
+     * @param filters the filters
+     */
     public void set(List<FilterConfiguration> filters) {
         this.collection = filters;
     }
 
+    /**
+     * Add filter configuration.
+     *
+     * @param c the c
+     */
     public void addFilterConfiguration(FilterConfiguration c) {
         this.collection.add(c);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/PastFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/PastFilterConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.PastFilter;
 
+/**
+ * The type Past filter configuration.
+ */
 @XmlRootElement
 public class PastFilterConfiguration extends FilterConfiguration {
 
@@ -29,10 +32,18 @@ public class PastFilterConfiguration extends FilterConfiguration {
      */
     private long threshold = 24*60*60*1000;
 
+    /**
+     * Instantiates a new Past filter configuration.
+     */
     public PastFilterConfiguration() {
 
     }
 
+    /**
+     * Instantiates a new Past filter configuration.
+     *
+     * @param threshold the threshold
+     */
     public PastFilterConfiguration(long threshold) {
         this.threshold = threshold;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/ReplayDownSampleFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/ReplayDownSampleFilterConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.ReplayDownSampleFilter;
 
+/**
+ * The type Replay down sample filter configuration.
+ */
 @XmlRootElement
 public class ReplayDownSampleFilterConfiguration extends FilterConfiguration {
 
@@ -28,18 +31,36 @@ public class ReplayDownSampleFilterConfiguration extends FilterConfiguration {
      */
     private long samplingRate = 60;
 
+    /**
+     * Instantiates a new Replay down sample filter configuration.
+     */
     public ReplayDownSampleFilterConfiguration() {
 
     }
 
+    /**
+     * Instantiates a new Replay down sample filter configuration.
+     *
+     * @param samplingRate the sampling rate
+     */
     public ReplayDownSampleFilterConfiguration(long samplingRate) {
         this.samplingRate = samplingRate;
     }
 
+    /**
+     * Gets sampling rate.
+     *
+     * @return the sampling rate
+     */
     public long getSamplingRate() {
         return samplingRate;
     }
 
+    /**
+     * Sets sampling rate.
+     *
+     * @param samplingRate the sampling rate
+     */
     public void setSamplingRate(long samplingRate) {
         this.samplingRate = samplingRate;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/SanityFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/SanityFilterConfiguration.java
@@ -20,9 +20,15 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.SanityFilter;
 
+/**
+ * The type Sanity filter configuration.
+ */
 @XmlRootElement
 public class SanityFilterConfiguration extends FilterConfiguration {
 
+    /**
+     * Instantiates a new Sanity filter configuration.
+     */
     public SanityFilterConfiguration() {
 
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/TaggingFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/TaggingFilterConfiguration.java
@@ -20,19 +20,35 @@ import dk.dma.ais.configuration.transform.PacketTaggingConfiguration;
 import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.TaggingFilter;
 
+/**
+ * The type Tagging filter configuration.
+ */
 @XmlRootElement
 public class TaggingFilterConfiguration extends FilterConfiguration {
     
     private PacketTaggingConfiguration filterTagging = new PacketTaggingConfiguration();
-    
+
+    /**
+     * Instantiates a new Tagging filter configuration.
+     */
     public TaggingFilterConfiguration() {
         
     }
-    
+
+    /**
+     * Gets filter tagging.
+     *
+     * @return the filter tagging
+     */
     public PacketTaggingConfiguration getFilterTagging() {
         return filterTagging;
     }
-    
+
+    /**
+     * Sets filter tagging.
+     *
+     * @param filterTagging the filter tagging
+     */
     public void setFilterTagging(PacketTaggingConfiguration filterTagging) {
         this.filterTagging = filterTagging;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/TargetCountryFilterConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/TargetCountryFilterConfiguration.java
@@ -23,20 +23,36 @@ import dk.dma.ais.filter.IPacketFilter;
 import dk.dma.ais.filter.TargetCountryFilter;
 import dk.dma.enav.model.Country;
 
+/**
+ * The type Target country filter configuration.
+ */
 @XmlRootElement
 public class TargetCountryFilterConfiguration extends FilterConfiguration {
     
     private HashSet<String> allowedCountries = new HashSet<>();
-    
+
+    /**
+     * Instantiates a new Target country filter configuration.
+     */
     public TargetCountryFilterConfiguration() {
         
     }
-    
+
+    /**
+     * Gets allowed countries.
+     *
+     * @return the allowed countries
+     */
     @XmlElement(name = "allowed")
     public HashSet<String> getAllowedCountries() {
         return allowedCountries;
     }
-    
+
+    /**
+     * Sets allowed countries.
+     *
+     * @param allowedCountries the allowed countries
+     */
     public void setAllowedCountries(HashSet<String> allowedCountries) {
         this.allowedCountries = allowedCountries;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/geometry/CircleGeometryConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/geometry/CircleGeometryConfiguration.java
@@ -23,6 +23,9 @@ import dk.dma.enav.model.geometry.Circle;
 import dk.dma.enav.model.geometry.CoordinateSystem;
 import dk.dma.enav.model.geometry.Position;
 
+/**
+ * The type Circle geometry configuration.
+ */
 @XmlRootElement
 public class CircleGeometryConfiguration extends GeometryConfiguration {
 
@@ -32,30 +35,63 @@ public class CircleGeometryConfiguration extends GeometryConfiguration {
 
     private double radius;
 
+    /**
+     * Instantiates a new Circle geometry configuration.
+     */
     public CircleGeometryConfiguration() {
 
     }
 
+    /**
+     * Gets lat.
+     *
+     * @return the lat
+     */
     public double getLat() {
         return lat;
     }
 
+    /**
+     * Sets lat.
+     *
+     * @param lat the lat
+     */
     public void setLat(double lat) {
         this.lat = lat;
     }
 
+    /**
+     * Gets lon.
+     *
+     * @return the lon
+     */
     public double getLon() {
         return lon;
     }
 
+    /**
+     * Sets lon.
+     *
+     * @param lon the lon
+     */
     public void setLon(double lon) {
         this.lon = lon;
     }
 
+    /**
+     * Gets radius.
+     *
+     * @return the radius
+     */
     public double getRadius() {
         return radius;
     }
 
+    /**
+     * Sets radius.
+     *
+     * @param radius the radius
+     */
     public void setRadius(double radius) {
         this.radius = radius;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/geometry/GeometryConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/filter/geometry/GeometryConfiguration.java
@@ -19,9 +19,17 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 import dk.dma.enav.model.geometry.Position;
 import java.util.function.Predicate;
 
+/**
+ * The type Geometry configuration.
+ */
 @XmlSeeAlso({ CircleGeometryConfiguration.class })
 public abstract class GeometryConfiguration {
 
+    /**
+     * Gets predicate.
+     *
+     * @return the predicate
+     */
     public abstract Predicate<? super Position> getPredicate();
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisFileReaderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisFileReaderConfiguration.java
@@ -20,6 +20,9 @@ import java.io.FileNotFoundException;
 import dk.dma.ais.reader.AisReader;
 import dk.dma.ais.reader.AisReaders;
 
+/**
+ * The type Ais file reader configuration.
+ */
 public class AisFileReaderConfiguration extends AisReaderConfiguration {
     private String filePath;
 
@@ -29,11 +32,21 @@ public class AisFileReaderConfiguration extends AisReaderConfiguration {
         return aisStreamReader;
     }
 
+    /**
+     * Sets file path.
+     *
+     * @param filePath the file path
+     */
     public void setFilePath(String filePath) {
         this.filePath = filePath;
 
     }
 
+    /**
+     * Gets file path.
+     *
+     * @return the file path
+     */
     public String getFilePath() {
         return filePath;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisReaderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisReaderConfiguration.java
@@ -21,9 +21,18 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import dk.dma.ais.reader.AisReader;
 
+/**
+ * The type Ais reader configuration.
+ */
 @XmlRootElement
 @XmlSeeAlso({ AisFileReaderConfiguration.class, AisTcpReaderConfiguration.class})
 public abstract class AisReaderConfiguration {
 
+    /**
+     * Gets instance.
+     *
+     * @return the instance
+     * @throws FileNotFoundException the file not found exception
+     */
     public abstract AisReader getInstance() throws FileNotFoundException;
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisTcpReaderConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/reader/AisTcpReaderConfiguration.java
@@ -20,6 +20,9 @@ import dk.dma.ais.reader.AisReader;
 import dk.dma.ais.reader.AisReaders;
 import dk.dma.ais.reader.AisTcpReader;
 
+/**
+ * The type Ais tcp reader configuration.
+ */
 public class AisTcpReaderConfiguration extends AisReaderConfiguration {
 
     private long reconnectInterval = 5000; // Default 5 sec

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/AnonymousTransfomerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/AnonymousTransfomerConfiguration.java
@@ -17,8 +17,14 @@ package dk.dma.ais.configuration.transform;
 import dk.dma.ais.transform.AnonymousTransformer;
 import dk.dma.ais.transform.IAisPacketTransformer;
 
+/**
+ * The type Anonymous transfomer configuration.
+ */
 public class AnonymousTransfomerConfiguration extends TransformerConfiguration {
-    
+
+    /**
+     * Instantiates a new Anonymous transfomer configuration.
+     */
     public AnonymousTransfomerConfiguration() {
         
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/CropVdmTransformerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/CropVdmTransformerConfiguration.java
@@ -20,9 +20,15 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.transform.CropVdmTransformer;
 import dk.dma.ais.transform.IAisPacketTransformer;
 
+/**
+ * The type Crop vdm transformer configuration.
+ */
 @XmlRootElement
 public class CropVdmTransformerConfiguration extends TransformerConfiguration {
 
+    /**
+     * Instantiates a new Crop vdm transformer configuration.
+     */
     public CropVdmTransformerConfiguration() {
 
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/PacketTaggingConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/PacketTaggingConfiguration.java
@@ -20,6 +20,9 @@ import dk.dma.ais.packet.AisPacketTags;
 import dk.dma.ais.packet.AisPacketTags.SourceType;
 import dk.dma.enav.model.Country;
 
+/**
+ * The type Packet tagging configuration.
+ */
 public class PacketTaggingConfiguration {
 
     private String sourceId;
@@ -27,42 +30,90 @@ public class PacketTaggingConfiguration {
     private String sourceCountry;
     private String sourceType;
 
+    /**
+     * Instantiates a new Packet tagging configuration.
+     */
     public PacketTaggingConfiguration() {
 
     }
 
+    /**
+     * Gets source id.
+     *
+     * @return the source id
+     */
     public String getSourceId() {
         return sourceId;
     }
 
+    /**
+     * Sets source id.
+     *
+     * @param sourceId the source id
+     */
     public void setSourceId(String sourceId) {
         this.sourceId = sourceId;
     }
 
+    /**
+     * Gets source bs.
+     *
+     * @return the source bs
+     */
     public Integer getSourceBs() {
         return sourceBs;
     }
 
+    /**
+     * Sets source bs.
+     *
+     * @param sourceBs the source bs
+     */
     public void setSourceBs(Integer sourceBs) {
         this.sourceBs = sourceBs;
     }
 
+    /**
+     * Gets source country.
+     *
+     * @return the source country
+     */
     public String getSourceCountry() {
         return sourceCountry;
     }
 
+    /**
+     * Sets source country.
+     *
+     * @param sourceCountry the source country
+     */
     public void setSourceCountry(String sourceCountry) {
         this.sourceCountry = sourceCountry;
     }
 
+    /**
+     * Gets source type.
+     *
+     * @return the source type
+     */
     public String getSourceType() {
         return sourceType;
     }
 
+    /**
+     * Sets source type.
+     *
+     * @param sourceType the source type
+     */
     public void setSourceType(String sourceType) {
         this.sourceType = sourceType;
     }
-    
+
+    /**
+     * Gets instance.
+     *
+     * @return the instance
+     */
     @XmlTransient
     public AisPacketTags getInstance() {
         AisPacketTags tagging = new AisPacketTags();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/PacketTransformerCollectionConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/PacketTransformerCollectionConfiguration.java
@@ -22,16 +22,29 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.transform.IAisPacketTransformer;
 import dk.dma.ais.transform.PacketTransformerCollection;
 
+/**
+ * The type Packet transformer collection configuration.
+ */
 public class PacketTransformerCollectionConfiguration extends
         TransformerConfiguration {
 
     //@XmlElement(name="transformerCollection")
     private List<TransformerConfiguration> collection = new ArrayList<>();
-    
+
+    /**
+     * Gets collection.
+     *
+     * @return the collection
+     */
     public List<TransformerConfiguration> getCollection() {
         return collection;
     }
 
+    /**
+     * Sets collection.
+     *
+     * @param collection the collection
+     */
     public void setCollection(List<TransformerConfiguration> collection) {
         this.collection = collection;
     }
@@ -47,7 +60,12 @@ public class PacketTransformerCollectionConfiguration extends
         
         return packetTransformerCollection;
     }
-    
+
+    /**
+     * Add transformer configuration.
+     *
+     * @param transformerConfiguration the transformer configuration
+     */
     public void addTransformerConfiguration(TransformerConfiguration transformerConfiguration) {
         this.collection.add(transformerConfiguration);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/ReplayTransformConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/ReplayTransformConfiguration.java
@@ -20,19 +20,35 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.transform.IAisPacketTransformer;
 import dk.dma.ais.transform.ReplayTransformer;
 
+/**
+ * The type Replay transform configuration.
+ */
 @XmlRootElement
 public class ReplayTransformConfiguration extends TransformerConfiguration {
 
     private double speedup = 1;
 
+    /**
+     * Instantiates a new Replay transform configuration.
+     */
     public ReplayTransformConfiguration() {
         super();
     }
 
+    /**
+     * Gets speedup.
+     *
+     * @return the speedup
+     */
     public double getSpeedup() {
         return speedup;
     }
 
+    /**
+     * Sets speedup.
+     *
+     * @param speedup the speedup
+     */
     public void setSpeedup(double speedup) {
         this.speedup = speedup;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/SourceTypeSatTransformerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/SourceTypeSatTransformerConfiguration.java
@@ -23,30 +23,56 @@ import javax.xml.bind.annotation.XmlRootElement;
 import dk.dma.ais.transform.IAisPacketTransformer;
 import dk.dma.ais.transform.SourceTypeSatTransformer;
 
+/**
+ * The type Source type sat transformer configuration.
+ */
 @XmlRootElement
 public class SourceTypeSatTransformerConfiguration extends TransformerConfiguration {
 
     private List<String> satGhRegions = new ArrayList<>();
     private List<String> satSources = new ArrayList<>();
 
+    /**
+     * Instantiates a new Source type sat transformer configuration.
+     */
     public SourceTypeSatTransformerConfiguration() {
 
     }
 
+    /**
+     * Gets sat gh regions.
+     *
+     * @return the sat gh regions
+     */
     @XmlElement(name = "gh_region")
     public List<String> getSatGhRegions() {
         return satGhRegions;
     }
 
+    /**
+     * Sets sat gh regions.
+     *
+     * @param satGhRegions the sat gh regions
+     */
     public void setSatGhRegions(List<String> satGhRegions) {
         this.satGhRegions = satGhRegions;
     }
 
+    /**
+     * Gets sat sources.
+     *
+     * @return the sat sources
+     */
     @XmlElement(name = "source")
     public List<String> getSatSources() {
         return satSources;
     }
 
+    /**
+     * Sets sat sources.
+     *
+     * @param satSources the sat sources
+     */
     public void setSatSources(List<String> satSources) {
         this.satSources = satSources;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TaggingTransformerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TaggingTransformerConfiguration.java
@@ -23,6 +23,9 @@ import dk.dma.ais.transform.AisPacketTaggingTransformer;
 import dk.dma.ais.transform.IAisPacketTransformer;
 import dk.dma.ais.transform.AisPacketTaggingTransformer.Policy;
 
+/**
+ * The type Tagging transformer configuration.
+ */
 @XmlRootElement
 public class TaggingTransformerConfiguration extends TransformerConfiguration {
 
@@ -30,32 +33,65 @@ public class TaggingTransformerConfiguration extends TransformerConfiguration {
     private PacketTaggingConfiguration tagging = new PacketTaggingConfiguration();
     private HashMap<String, String> extraTags = new HashMap<>();
 
+    /**
+     * Instantiates a new Tagging transformer configuration.
+     */
     public TaggingTransformerConfiguration() {
 
     }
 
+    /**
+     * Gets tag policy.
+     *
+     * @return the tag policy
+     */
     @XmlElement(required = true)
     public Policy getTagPolicy() {
         return tagPolicy;
     }
 
+    /**
+     * Sets tag policy.
+     *
+     * @param tagPolicy the tag policy
+     */
     public void setTagPolicy(Policy tagPolicy) {
         this.tagPolicy = tagPolicy;
     }
-    
+
+    /**
+     * Gets tagging.
+     *
+     * @return the tagging
+     */
     public PacketTaggingConfiguration getTagging() {
         return tagging;
     }
-    
+
+    /**
+     * Sets tagging.
+     *
+     * @param tagging the tagging
+     */
     public void setTagging(PacketTaggingConfiguration tagging) {
         this.tagging = tagging;
     }
 
+    /**
+     * Gets extra tags.
+     *
+     * @return the extra tags
+     */
     @XmlElement(name = "extraTag")
     public HashMap<String, String> getExtraTags() {
         return extraTags;
     }
 
+    /**
+     * Sets extra tags.
+     *
+     * @param extraTags the extra tags
+     */
     public void setExtraTags(HashMap<String, String> extraTags) {
         this.extraTags = extraTags;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TimestampTaggingTransformerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TimestampTaggingTransformerConfiguration.java
@@ -20,6 +20,9 @@ import javax.xml.bind.annotation.XmlTransient;
 import dk.dma.ais.transform.IAisPacketTransformer;
 import dk.dma.ais.transform.TimestampTaggingTransformer;
 
+/**
+ * The type Timestamp tagging transformer configuration.
+ */
 @XmlRootElement
 public class TimestampTaggingTransformerConfiguration extends TransformerConfiguration {
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TransformerConfiguration.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/configuration/transform/TransformerConfiguration.java
@@ -18,14 +18,25 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import dk.dma.ais.transform.IAisPacketTransformer;
 
+/**
+ * The type Transformer configuration.
+ */
 @XmlSeeAlso({ CropVdmTransformerConfiguration.class, TaggingTransformerConfiguration.class, ReplayTransformConfiguration.class,
         SourceTypeSatTransformerConfiguration.class, AnonymousTransfomerConfiguration.class, PacketTransformerCollectionConfiguration.class, TimestampTaggingTransformerConfiguration.class  })
 public abstract class TransformerConfiguration {
 
+    /**
+     * Instantiates a new Transformer configuration.
+     */
     public TransformerConfiguration() {
 
     }
 
+    /**
+     * Gets instance.
+     *
+     * @return the instance
+     */
     public abstract IAisPacketTransformer getInstance();
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisAtonTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisAtonTarget.java
@@ -45,9 +45,9 @@ public class AisAtonTarget extends AisTarget {
 
     /**
      * Determine if message is AtoN report
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return boolean boolean
      */
     public static boolean isAtonReport(AisMessage aisMessage) {
         return aisMessage instanceof AisMessage21;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisBsTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisBsTarget.java
@@ -45,9 +45,9 @@ public class AisBsTarget extends AisTarget {
 
     /**
      * Determine if message is BS report
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return boolean boolean
      */
     public static boolean isBsReport(AisMessage aisMessage) {
         return aisMessage instanceof AisMessage4;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassAPosition.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassAPosition.java
@@ -28,17 +28,25 @@ public class AisClassAPosition extends AisVesselPosition {
     private byte navStatus;
     private byte specialManIndicator;
 
+    /**
+     * Instantiates a new Ais class a position.
+     */
     public AisClassAPosition() {
     }
 
+    /**
+     * Instantiates a new Ais class a position.
+     *
+     * @param posMessage the pos message
+     */
     public AisClassAPosition(AisPositionMessage posMessage) {
         update(posMessage);
     }
 
     /**
      * Update data object with data from AIS message
-     * 
-     * @param posMessage
+     *
+     * @param posMessage the pos message
      */
     public void update(AisPositionMessage posMessage) {
         rot = posMessage.isRotValid() ? (double) posMessage.getRot() : null;
@@ -47,26 +55,56 @@ public class AisClassAPosition extends AisVesselPosition {
         super.update((IVesselPositionMessage) posMessage);
     }
 
+    /**
+     * Gets rot.
+     *
+     * @return the rot
+     */
     public Double getRot() {
         return rot;
     }
 
+    /**
+     * Sets rot.
+     *
+     * @param rot the rot
+     */
     public void setRot(Double rot) {
         this.rot = rot;
     }
 
+    /**
+     * Gets nav status.
+     *
+     * @return the nav status
+     */
     public byte getNavStatus() {
         return navStatus;
     }
 
+    /**
+     * Sets nav status.
+     *
+     * @param navStatus the nav status
+     */
     public void setNavStatus(byte navStatus) {
         this.navStatus = navStatus;
     }
 
+    /**
+     * Gets special man indicator.
+     *
+     * @return the special man indicator
+     */
     public byte getSpecialManIndicator() {
         return specialManIndicator;
     }
 
+    /**
+     * Sets special man indicator.
+     *
+     * @param specialManIndicator the special man indicator
+     */
     public void setSpecialManIndicator(byte specialManIndicator) {
         this.specialManIndicator = specialManIndicator;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassAStatic.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassAStatic.java
@@ -34,15 +34,28 @@ public class AisClassAStatic extends AisVesselStatic {
     private byte version;
     private byte dte;
 
+    /**
+     * Instantiates a new Ais class a static.
+     */
     public AisClassAStatic() {
         super();
     }
 
+    /**
+     * Instantiates a new Ais class a static.
+     *
+     * @param msg5 the msg 5
+     */
     public AisClassAStatic(AisMessage5 msg5) {
         super();
         update(msg5);
     }
 
+    /**
+     * Update.
+     *
+     * @param msg5 the msg 5
+     */
     public void update(AisMessage5 msg5) {
         this.destination = AisMessage.trimText(msg5.getDest());
         if (this.destination.length() == 0) {
@@ -59,58 +72,128 @@ public class AisClassAStatic extends AisVesselStatic {
         super.update(msg5);
     }
 
+    /**
+     * Gets imo no.
+     *
+     * @return the imo no
+     */
     public Integer getImoNo() {
         return imoNo;
     }
 
+    /**
+     * Sets imo no.
+     *
+     * @param imoNo the imo no
+     */
     public void setImoNo(Integer imoNo) {
         this.imoNo = imoNo;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public String getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(String destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets eta.
+     *
+     * @return the eta
+     */
     public Date getEta() {
         return eta;
     }
 
+    /**
+     * Sets eta.
+     *
+     * @param eta the eta
+     */
     public void setEta(Date eta) {
         this.eta = eta;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public byte getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(byte posType) {
         this.posType = posType;
     }
 
+    /**
+     * Gets draught.
+     *
+     * @return the draught
+     */
     public Double getDraught() {
         return draught;
     }
 
+    /**
+     * Sets draught.
+     *
+     * @param draught the draught
+     */
     public void setDraught(Double draught) {
         this.draught = draught;
     }
 
+    /**
+     * Gets version.
+     *
+     * @return the version
+     */
     public byte getVersion() {
         return version;
     }
 
+    /**
+     * Sets version.
+     *
+     * @param version the version
+     */
     public void setVersion(byte version) {
         this.version = version;
     }
 
+    /**
+     * Gets dte.
+     *
+     * @return the dte
+     */
     public byte getDte() {
         return dte;
     }
 
+    /**
+     * Sets dte.
+     *
+     * @param dte the dte
+     */
     public void setDte(byte dte) {
         this.dte = dte;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassATarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassATarget.java
@@ -27,6 +27,9 @@ public class AisClassATarget extends AisVesselTarget {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais class a target.
+     */
     public AisClassATarget() {
         super();
     }
@@ -44,11 +47,21 @@ public class AisClassATarget extends AisVesselTarget {
         super.update(aisMessage);
     }
 
+    /**
+     * Gets class a position.
+     *
+     * @return the class a position
+     */
     @JsonIgnore
     public AisClassAPosition getClassAPosition() {
         return (AisClassAPosition) this.vesselPosition;
     }
 
+    /**
+     * Gets class a static.
+     *
+     * @return the class a static
+     */
     @JsonIgnore
     public AisClassAStatic getClassAStatic() {
         return (AisClassAStatic) this.vesselStatic;
@@ -61,9 +74,9 @@ public class AisClassATarget extends AisVesselTarget {
 
     /**
      * Determine if AIS message is class A position report or static report
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return boolean boolean
      */
     public static boolean isClassAPosOrStatic(AisMessage aisMessage) {
         return aisMessage instanceof AisPositionMessage || aisMessage instanceof AisMessage5;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBPosition.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBPosition.java
@@ -25,15 +25,28 @@ public class AisClassBPosition extends AisVesselPosition {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais class b position.
+     */
     public AisClassBPosition() {
         super();
     }
 
+    /**
+     * Instantiates a new Ais class b position.
+     *
+     * @param msg18 the msg 18
+     */
     public AisClassBPosition(AisMessage18 msg18) {
         super();
         update(msg18);
     }
-    
+
+    /**
+     * Instantiates a new Ais class b position.
+     *
+     * @param msg19 the msg 19
+     */
     public AisClassBPosition(AisMessage19 msg19) {
         super();
         update(msg19);
@@ -41,17 +54,17 @@ public class AisClassBPosition extends AisVesselPosition {
 
     /**
      * Update data object with data from AIS message
-     * 
-     * @param msg18
+     *
+     * @param msg18 the msg 18
      */
     public void update(AisMessage18 msg18) {
         super.update((IVesselPositionMessage) msg18);
     }
-    
+
     /**
      * Update data object with data from AIS message
-     * 
-     * @param msg19
+     *
+     * @param msg19 the msg 19
      */
     public void update(AisMessage19 msg19) {
         super.update((IVesselPositionMessage) msg19);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBStatic.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBStatic.java
@@ -26,20 +26,38 @@ public class AisClassBStatic extends AisVesselStatic {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais class b static.
+     */
     public AisClassBStatic() {
         super();
     }
 
+    /**
+     * Instantiates a new Ais class b static.
+     *
+     * @param msg24 the msg 24
+     */
     public AisClassBStatic(AisMessage24 msg24) {
         super();
         update(msg24);
     }
-    
+
+    /**
+     * Instantiates a new Ais class b static.
+     *
+     * @param msg19 the msg 19
+     */
     public AisClassBStatic(AisMessage19 msg19) {
         super();
         update(msg19);
     }
 
+    /**
+     * Update.
+     *
+     * @param msg24 the msg 24
+     */
     public void update(AisMessage24 msg24) {
         if (msg24.getPartNumber() == 0) {
             this.name = AisMessage.trimText(msg24.getName());
@@ -51,7 +69,12 @@ public class AisClassBStatic extends AisVesselStatic {
         }
         super.update((AisMessage) msg24);
     }
-    
+
+    /**
+     * Update.
+     *
+     * @param msg19 the msg 19
+     */
     public void update(AisMessage19 msg19) {
         this.name = AisMessage.trimText(msg19.getName());
         this.callsign = AisMessage.trimText(msg19.getCallsign());

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisClassBTarget.java
@@ -28,6 +28,9 @@ public class AisClassBTarget extends AisVesselTarget {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais class b target.
+     */
     public AisClassBTarget() {
         super();
     }
@@ -45,11 +48,21 @@ public class AisClassBTarget extends AisVesselTarget {
         super.update(aisMessage);
     }
 
+    /**
+     * Gets class b position.
+     *
+     * @return the class b position
+     */
     @JsonIgnore
     public AisClassBPosition getClassBPosition() {
         return (AisClassBPosition) this.vesselPosition;
     }
 
+    /**
+     * Gets class b static.
+     *
+     * @return the class b static
+     */
     @JsonIgnore
     public AisClassBStatic getClassBStatic() {
         return (AisClassBStatic) this.vesselStatic;
@@ -62,9 +75,9 @@ public class AisClassBTarget extends AisVesselTarget {
 
     /**
      * Determine if AIS message is class B position report or static report
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return boolean boolean
      */
     public static boolean isClassBPosOrStatic(AisMessage aisMessage) {
         return aisMessage instanceof AisMessage18 || aisMessage instanceof AisMessage24 || aisMessage instanceof AisMessage19;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisReport.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisReport.java
@@ -26,49 +26,109 @@ public abstract class AisReport implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Mmsi.
+     */
     protected long mmsi;
+    /**
+     * The Received.
+     */
     protected Date received;
+    /**
+     * The Source timestamp.
+     */
     protected Date sourceTimestamp;
+    /**
+     * The Created.
+     */
     protected Date created;
 
+    /**
+     * Instantiates a new Ais report.
+     */
     public AisReport() {
         this.created = new Date();
     }
 
+    /**
+     * Update.
+     *
+     * @param aisMessage the ais message
+     */
     public void update(AisMessage aisMessage) {
         this.mmsi = aisMessage.getUserId();
         this.received = new Date();
         this.sourceTimestamp = aisMessage.getVdm().getTimestamp();
     }
 
+    /**
+     * Gets received.
+     *
+     * @return the received
+     */
     public Date getReceived() {
         return received;
     }
 
+    /**
+     * Sets received.
+     *
+     * @param received the received
+     */
     public void setReceived(Date received) {
         this.received = received;
     }
 
+    /**
+     * Gets source timestamp.
+     *
+     * @return the source timestamp
+     */
     public Date getSourceTimestamp() {
         return sourceTimestamp;
     }
 
+    /**
+     * Sets source timestamp.
+     *
+     * @param sourceTimestamp the source timestamp
+     */
     public void setSourceTimestamp(Date sourceTimestamp) {
         this.sourceTimestamp = sourceTimestamp;
     }
 
+    /**
+     * Gets created.
+     *
+     * @return the created
+     */
     public Date getCreated() {
         return created;
     }
 
+    /**
+     * Sets created.
+     *
+     * @param created the created
+     */
     public void setCreated(Date created) {
         this.created = created;
     }
 
+    /**
+     * Gets mmsi.
+     *
+     * @return the mmsi
+     */
     public long getMmsi() {
         return mmsi;
     }
 
+    /**
+     * Sets mmsi.
+     *
+     * @param mmsi the mmsi
+     */
     public void setMmsi(long mmsi) {
         this.mmsi = mmsi;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisTarget.java
@@ -37,20 +37,35 @@ public abstract class AisTarget implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Mmsi.
+     */
     protected int mmsi;
+    /**
+     * The Country.
+     */
     protected Country country;
+    /**
+     * The Last report.
+     */
     protected Date lastReport;
+    /**
+     * The Created.
+     */
     protected Date created;
 
+    /**
+     * Instantiates a new Ais target.
+     */
     public AisTarget() {
         this.created = new Date();
     }
 
     /**
      * Determine if target is alive based on ttl given in seconds
-     * 
-     * @param ttl
-     * @return
+     *
+     * @param ttl the ttl
+     * @return boolean boolean
      */
     public boolean isAlive(int ttl) {
         if (lastReport == null) {
@@ -59,13 +74,19 @@ public abstract class AisTarget implements Serializable {
         long elapsed = System.currentTimeMillis() - lastReport.getTime();
         return elapsed / 1000 < ttl;
     }
-    
+
+    /**
+     * Is message compatible boolean.
+     *
+     * @param msg the msg
+     * @return the boolean
+     */
     public abstract boolean isMessageCompatible(AisMessage msg);
 
     /**
      * Update target given AIS message
-     * 
-     * @param aisMessage
+     *
+     * @param aisMessage the ais message
      */
     public void update(AisMessage aisMessage) {
         // Set MMSI
@@ -80,45 +101,90 @@ public abstract class AisTarget implements Serializable {
         country = Country.getCountryForMmsi(aisMessage.getUserId());
     }
 
+    /**
+     * Gets mmsi.
+     *
+     * @return the mmsi
+     */
     public int getMmsi() {
         return mmsi;
     }
 
+    /**
+     * Sets mmsi.
+     *
+     * @param mmsi the mmsi
+     */
     public void setMmsi(int mmsi) {
         this.mmsi = mmsi;
     }
 
+    /**
+     * Gets country.
+     *
+     * @return the country
+     */
     public Country getCountry() {
         return country;
     }
 
+    /**
+     * Sets country.
+     *
+     * @param country the country
+     */
     public void setCountry(Country country) {
         this.country = country;
     }
 
+    /**
+     * Gets last report.
+     *
+     * @return the last report
+     */
     public Date getLastReport() {
         return lastReport;
     }
 
+    /**
+     * Sets last report.
+     *
+     * @param lastReport the last report
+     */
     public void setLastReport(Date lastReport) {
         this.lastReport = lastReport;
     }
 
+    /**
+     * Gets created.
+     *
+     * @return the created
+     */
     public Date getCreated() {
         return created;
     }
 
+    /**
+     * Sets created.
+     *
+     * @param created the created
+     */
     public void setCreated(Date created) {
         this.created = created;
     }
 
+    /**
+     * Gets target type.
+     *
+     * @return the target type
+     */
     public abstract AisTargetType getTargetType();
 
     /**
      * Create new AIS target instance based on AIS message
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return ais target
      */
     public static AisTarget createTarget(AisMessage aisMessage) {
         AisTarget target = null;
@@ -136,9 +202,9 @@ public abstract class AisTarget implements Serializable {
 
     /**
      * Determine if message is a message from target containing data about the target
-     * 
-     * @param aisMessage
-     * @return
+     *
+     * @param aisMessage the ais message
+     * @return boolean boolean
      */
     public static boolean isTargetDataMessage(AisMessage aisMessage) {
         if (aisMessage instanceof IVesselPositionMessage) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisTargetDimensions.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisTargetDimensions.java
@@ -20,10 +20,9 @@ import dk.dma.ais.message.AisStaticCommon;
 
 /**
  * Class to represent dimensions of an AIS target with dimensions
- * 
+ * <p>
  * TODO: Evaluate the parameters and set length and witdt accordingly. Make attributes to determine if dimensions is
  * available, and if reference point is available.
- * 
  */
 public class AisTargetDimensions implements Serializable {
 
@@ -34,6 +33,11 @@ public class AisTargetDimensions implements Serializable {
     private byte dimPort;
     private byte dimStarboard;
 
+    /**
+     * Instantiates a new Ais target dimensions.
+     *
+     * @param staticCommon the static common
+     */
     public AisTargetDimensions(AisStaticCommon staticCommon) {
         this.dimBow = (short) staticCommon.getDimBow();
         this.dimStern = (short) staticCommon.getDimStern();
@@ -43,34 +47,74 @@ public class AisTargetDimensions implements Serializable {
         // TODO
     }
 
+    /**
+     * Gets dim bow.
+     *
+     * @return the dim bow
+     */
     public short getDimBow() {
         return dimBow;
     }
 
+    /**
+     * Sets dim bow.
+     *
+     * @param dimBow the dim bow
+     */
     public void setDimBow(short dimBow) {
         this.dimBow = dimBow;
     }
 
+    /**
+     * Gets dim stern.
+     *
+     * @return the dim stern
+     */
     public short getDimStern() {
         return dimStern;
     }
 
+    /**
+     * Sets dim stern.
+     *
+     * @param dimStern the dim stern
+     */
     public void setDimStern(short dimStern) {
         this.dimStern = dimStern;
     }
 
+    /**
+     * Gets dim port.
+     *
+     * @return the dim port
+     */
     public byte getDimPort() {
         return dimPort;
     }
 
+    /**
+     * Sets dim port.
+     *
+     * @param dimPort the dim port
+     */
     public void setDimPort(byte dimPort) {
         this.dimPort = dimPort;
     }
 
+    /**
+     * Gets dim starboard.
+     *
+     * @return the dim starboard
+     */
     public byte getDimStarboard() {
         return dimStarboard;
     }
 
+    /**
+     * Sets dim starboard.
+     *
+     * @param dimStarboard the dim starboard
+     */
     public void setDimStarboard(byte dimStarboard) {
         this.dimStarboard = dimStarboard;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselPosition.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselPosition.java
@@ -25,18 +25,47 @@ public class AisVesselPosition extends AisReport {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Sog.
+     */
     protected Double sog;
+    /**
+     * The Cog.
+     */
     protected Double cog;
+    /**
+     * The Heading.
+     */
     protected Double heading;
+    /**
+     * The Pos.
+     */
     protected Position pos;
+    /**
+     * The Pos acc.
+     */
     protected byte posAcc;
+    /**
+     * The Utc sec.
+     */
     protected byte utcSec;
+    /**
+     * The Raim.
+     */
     protected byte raim;
 
+    /**
+     * Instantiates a new Ais vessel position.
+     */
     public AisVesselPosition() {
         super();
     }
 
+    /**
+     * Update.
+     *
+     * @param posMessage the pos message
+     */
     public void update(IVesselPositionMessage posMessage) {
         sog = posMessage.isSogValid() ? posMessage.getSog() / 10.0 : null;
         cog = posMessage.isCogValid() ? posMessage.getCog() / 10.0 : null;
@@ -52,58 +81,128 @@ public class AisVesselPosition extends AisReport {
         super.update((AisMessage) posMessage);
     }
 
+    /**
+     * Gets sog.
+     *
+     * @return the sog
+     */
     public Double getSog() {
         return sog;
     }
 
+    /**
+     * Sets sog.
+     *
+     * @param sog the sog
+     */
     public void setSog(Double sog) {
         this.sog = sog;
     }
 
+    /**
+     * Gets cog.
+     *
+     * @return the cog
+     */
     public Double getCog() {
         return cog;
     }
 
+    /**
+     * Sets cog.
+     *
+     * @param cog the cog
+     */
     public void setCog(Double cog) {
         this.cog = cog;
     }
 
+    /**
+     * Gets heading.
+     *
+     * @return the heading
+     */
     public Double getHeading() {
         return heading;
     }
 
+    /**
+     * Sets heading.
+     *
+     * @param heading the heading
+     */
     public void setHeading(Double heading) {
         this.heading = heading;
     }
 
+    /**
+     * Gets pos.
+     *
+     * @return the pos
+     */
     public Position getPos() {
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(Position pos) {
         this.pos = pos;
     }
 
+    /**
+     * Gets pos acc.
+     *
+     * @return the pos acc
+     */
     public byte getPosAcc() {
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(byte posAcc) {
         this.posAcc = posAcc;
     }
 
+    /**
+     * Gets utc sec.
+     *
+     * @return the utc sec
+     */
     public byte getUtcSec() {
         return utcSec;
     }
 
+    /**
+     * Sets utc sec.
+     *
+     * @param utcSec the utc sec
+     */
     public void setUtcSec(byte utcSec) {
         this.utcSec = utcSec;
     }
 
+    /**
+     * Gets raim.
+     *
+     * @return the raim
+     */
     public byte getRaim() {
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(byte raim) {
         this.raim = raim;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselStatic.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselStatic.java
@@ -25,16 +25,39 @@ public abstract class AisVesselStatic extends AisReport {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Name.
+     */
     protected String name;
+    /**
+     * The Callsign.
+     */
     protected String callsign;
+    /**
+     * The Ship type.
+     */
     protected byte shipType;
+    /**
+     * The Ship type cargo.
+     */
     protected ShipTypeCargo shipTypeCargo;
+    /**
+     * The Dimensions.
+     */
     protected AisTargetDimensions dimensions;
 
+    /**
+     * Instantiates a new Ais vessel static.
+     */
     public AisVesselStatic() {
         super();
     }
 
+    /**
+     * Update.
+     *
+     * @param staticMessage the static message
+     */
     public void update(AisStaticCommon staticMessage) {
         this.name = AisMessage.trimText(staticMessage.getName());
         this.callsign = AisMessage.trimText(staticMessage.getCallsign());
@@ -44,42 +67,92 @@ public abstract class AisVesselStatic extends AisReport {
         super.update(staticMessage);
     }
 
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets callsign.
+     *
+     * @return the callsign
+     */
     public String getCallsign() {
         return callsign;
     }
 
+    /**
+     * Sets callsign.
+     *
+     * @param callsign the callsign
+     */
     public void setCallsign(String callsign) {
         this.callsign = callsign;
     }
 
+    /**
+     * Gets ship type.
+     *
+     * @return the ship type
+     */
     public byte getShipType() {
         return shipType;
     }
 
+    /**
+     * Sets ship type.
+     *
+     * @param shipType the ship type
+     */
     public void setShipType(byte shipType) {
         this.shipType = shipType;
     }
 
+    /**
+     * Gets ship type cargo.
+     *
+     * @return the ship type cargo
+     */
     public ShipTypeCargo getShipTypeCargo() {
         return shipTypeCargo;
     }
 
+    /**
+     * Sets ship type cargo.
+     *
+     * @param shipTypeCargo the ship type cargo
+     */
     public void setShipTypeCargo(ShipTypeCargo shipTypeCargo) {
         this.shipTypeCargo = shipTypeCargo;
     }
 
+    /**
+     * Gets dimensions.
+     *
+     * @return the dimensions
+     */
     public AisTargetDimensions getDimensions() {
         return dimensions;
     }
 
+    /**
+     * Sets dimensions.
+     *
+     * @param dimensions the dimensions
+     */
     public void setDimensions(AisTargetDimensions dimensions) {
         this.dimensions = dimensions;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/AisVesselTarget.java
@@ -28,9 +28,18 @@ public abstract class AisVesselTarget extends AisTarget {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Vessel static.
+     */
     protected AisVesselStatic vesselStatic;
+    /**
+     * The Vessel position.
+     */
     protected AisVesselPosition vesselPosition;
 
+    /**
+     * Instantiates a new Ais vessel target.
+     */
     public AisVesselTarget() {
         super();
     }
@@ -77,18 +86,38 @@ public abstract class AisVesselTarget extends AisTarget {
         super.update(aisMessage);
     }
 
+    /**
+     * Gets vessel static.
+     *
+     * @return the vessel static
+     */
     public AisVesselStatic getVesselStatic() {
         return vesselStatic;
     }
 
+    /**
+     * Sets vessel static.
+     *
+     * @param vesselStatic the vessel static
+     */
     public void setVesselStatic(AisVesselStatic vesselStatic) {
         this.vesselStatic = vesselStatic;
     }
 
+    /**
+     * Gets vessel position.
+     *
+     * @return the vessel position
+     */
     public AisVesselPosition getVesselPosition() {
         return vesselPosition;
     }
 
+    /**
+     * Sets vessel position.
+     *
+     * @param vesselPosition the vessel position
+     */
     public void setVesselPosition(AisVesselPosition vesselPosition) {
         this.vesselPosition = vesselPosition;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/IPastTrack.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/IPastTrack.java
@@ -23,23 +23,23 @@ public interface IPastTrack {
 
     /**
      * Add position to past track if it is more than minimum distance from last position
-     * 
-     * @param vesselPosition
-     * @param minDist
+     *
+     * @param vesselPosition the vessel position
+     * @param minDist        the min dist
      */
     void addPosition(AisVesselPosition vesselPosition, int minDist);
 
     /**
      * Remove points in past track older than ttl
-     * 
-     * @param ttl
+     *
+     * @param ttl the ttl
      */
     void cleanup(int ttl);
 
     /**
      * Get past track points
-     * 
-     * @return
+     *
+     * @return points points
      */
     List<PastTrackPoint> getPoints();
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/data/PastTrackPoint.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/data/PastTrackPoint.java
@@ -32,6 +32,11 @@ public class PastTrackPoint implements Serializable, Comparable<PastTrackPoint> 
     private final double sog;
     private final long time;
 
+    /**
+     * Instantiates a new Past track point.
+     *
+     * @param vesselPosition the vessel position
+     */
     public PastTrackPoint(AisVesselPosition vesselPosition) {
         Position pos = vesselPosition.getPos();
         this.lat = pos.getLatitude();
@@ -46,31 +51,67 @@ public class PastTrackPoint implements Serializable, Comparable<PastTrackPoint> 
         }
     }
 
+    /**
+     * Is dead boolean.
+     *
+     * @param ttl the ttl
+     * @return the boolean
+     */
     public boolean isDead(int ttl) {
         int elapsed = (int) ((System.currentTimeMillis() - time) / 1000);
         return elapsed > ttl;
     }
 
+    /**
+     * Gets lat.
+     *
+     * @return the lat
+     */
     public double getLat() {
         return lat;
     }
 
+    /**
+     * Gets lon.
+     *
+     * @return the lon
+     */
     public double getLon() {
         return lon;
     }
 
+    /**
+     * Gets cog.
+     *
+     * @return the cog
+     */
     public double getCog() {
         return cog;
     }
 
+    /**
+     * Gets sog.
+     *
+     * @return the sog
+     */
     public double getSog() {
         return sog;
     }
 
+    /**
+     * Gets time.
+     *
+     * @return the time
+     */
     public long getTime() {
         return time;
     }
-    
+
+    /**
+     * Gets date.
+     *
+     * @return the date
+     */
     public Date getDate() {
         return new Date(time);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/DownSampleFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/DownSampleFilter.java
@@ -22,14 +22,13 @@ import dk.dma.ais.message.AisMessage;
 
 /**
  * A down sampling filter.
- * 
+ * <p>
  * For position reports 1,2,3,4 and 18, only one message will be forwarded within the give sampling rate. E.g. one message per
  * minute.
- * 
+ * <p>
  * For static reports 5 and 24 the same apply. But it is handled separately from the position reports.
- * 
+ * <p>
  * All remaining message types are passed through without down sampling.
- * 
  */
 @ThreadSafe
 public class DownSampleFilter extends MessageFilterBase {
@@ -57,8 +56,8 @@ public class DownSampleFilter extends MessageFilterBase {
 
     /**
      * Constructor given sampling rate in seconds
-     * 
-     * @param samplingRate
+     *
+     * @param samplingRate the sampling rate
      */
     public DownSampleFilter(long samplingRate) {
         this.samplingRate = samplingRate;
@@ -118,8 +117,8 @@ public class DownSampleFilter extends MessageFilterBase {
 
     /**
      * Get sampling rate in seconds
-     * 
-     * @return
+     *
+     * @return sampling rate
      */
     public long getSamplingRate() {
         return samplingRate;
@@ -127,10 +126,9 @@ public class DownSampleFilter extends MessageFilterBase {
 
     /**
      * Set sampling rate in seconds
-     * 
-     * @param samplingRate
+     *
+     * @param samplingRate the sampling rate
      */
-
     public void setSamplingRate(long samplingRate) {
         this.samplingRate = samplingRate;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/DuplicateFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/DuplicateFilter.java
@@ -25,10 +25,9 @@ import dk.dma.ais.message.AisMessage;
 
 /**
  * A doublet filter.
- * 
+ * <p>
  * The doublet filter works by only allowing the same message through once in a time window. The six bit string of the message is
  * used as unique identifier.
- * 
  */
 @ThreadSafe
 public class DuplicateFilter extends MessageFilterBase {
@@ -55,14 +54,16 @@ public class DuplicateFilter extends MessageFilterBase {
      */
     private volatile long cleanupAge;
 
+    /**
+     * Instantiates a new Duplicate filter.
+     */
     public DuplicateFilter() {
     }
 
     /**
      * Constructor given window size
-     * 
-     * @param window
-     *            size in milliseconds
+     *
+     * @param windowSize the window size
      */
     public DuplicateFilter(long windowSize) {
         this.windowSize = windowSize;
@@ -117,10 +118,20 @@ public class DuplicateFilter extends MessageFilterBase {
         return false;
     }
 
+    /**
+     * Gets window size.
+     *
+     * @return the window size
+     */
     public long getWindowSize() {
         return windowSize;
     }
 
+    /**
+     * Sets window size.
+     *
+     * @param windowSize the window size
+     */
     public void setWindowSize(long windowSize) {
         this.windowSize = windowSize;
     }
@@ -133,6 +144,12 @@ public class DuplicateFilter extends MessageFilterBase {
         private String sixbit;
         private long received;
 
+        /**
+         * Instantiates a new Doublet entry.
+         *
+         * @param sixbit   the sixbit
+         * @param received the received
+         */
         public DoubletEntry(String sixbit, long received) {
             this.sixbit = sixbit;
             this.received = received;
@@ -146,10 +163,20 @@ public class DuplicateFilter extends MessageFilterBase {
             return sixbit.compareTo(doubletEntry.sixbit);
         }
 
+        /**
+         * Gets received.
+         *
+         * @return the received
+         */
         public long getReceived() {
             return received;
         }
 
+        /**
+         * Gets sixbit.
+         *
+         * @return the sixbit
+         */
         public String getSixbit() {
             return sixbit;
         }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/ExpressionFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/ExpressionFilter.java
@@ -21,12 +21,21 @@ import java.util.function.Predicate;
 
 /**
  * Filtering using string expression
- * @see dk.dma.ais.packet.AisPacketFiltersParseHelper 
+ *
+ * see dk.dma.ais.packet.AisPacketFiltersParseHelper (broken link!?)
  */
 public class ExpressionFilter implements IPacketFilter {
-    
+
+    /**
+     * The Predicate.
+     */
     final Predicate<AisPacket> predicate;
-    
+
+    /**
+     * Instantiates a new Expression filter.
+     *
+     * @param filter the filter
+     */
     public ExpressionFilter(String filter) {
         this.predicate = AisPacketFilters.parseExpressionFilter(filter);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/FarFutureFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/FarFutureFilter.java
@@ -19,10 +19,9 @@ import java.util.Date;
 import dk.dma.ais.packet.AisPacket;
 
 /**
- * @author Jens Tuxen
+ * The type Far future filter.
  *
- * Reject packets with timestamp far into the future according to device clock
- * 
+ * @author Jens Tuxen Reject packets with timestamp far into the future according to device clock
  * @deprecated please use FutureFilter with argument new FutureFilter(86400000)
  */
 @Deprecated

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/FutureFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/FutureFilter.java
@@ -18,17 +18,25 @@ package dk.dma.ais.filter;
 import dk.dma.ais.packet.AisPacket;
 
 /**
- * @author Jens Tuxen
+ * The type Future filter.
  *
- * Reject packets with timestamp in the future according to device clock
+ * @author Jens Tuxen Reject packets with timestamp in the future according to device clock
  */
 public class FutureFilter implements IPacketFilter {
     private final long threshold;
-    
+
+    /**
+     * Instantiates a new Future filter.
+     */
     public FutureFilter() {
         threshold = 60000;
     }
-    
+
+    /**
+     * Instantiates a new Future filter.
+     *
+     * @param threshold the threshold
+     */
     public FutureFilter(long threshold) {
         this.threshold = threshold;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/GatehouseSourceFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/GatehouseSourceFilter.java
@@ -28,8 +28,8 @@ import dk.dma.enav.model.Country;
 
 /**
  * Filtering based on the source information attached to message.
- * 
- * @see dk.dma.ais.data.AisTargetSourceData
+ *
+ * see dk.dma.ais.data.AisTargetSourceData (broken link!?)
  */
 @ThreadSafe
 public class GatehouseSourceFilter extends MessageFilterBase {
@@ -51,6 +51,9 @@ public class GatehouseSourceFilter extends MessageFilterBase {
      */
     private final Map<String, HashSet<String>> filter = new ConcurrentHashMap<>();
 
+    /**
+     * Instantiates a new Gatehouse source filter.
+     */
     public GatehouseSourceFilter() {
 
     }
@@ -99,10 +102,21 @@ public class GatehouseSourceFilter extends MessageFilterBase {
         return false;
     }
 
+    /**
+     * Is empty boolean.
+     *
+     * @return the boolean
+     */
     public boolean isEmpty() {
         return filter.size() == 0;
     }
 
+    /**
+     * Add filter value.
+     *
+     * @param filterName the filter name
+     * @param value      the value
+     */
     public void addFilterValue(String filterName, String value) {
         if (!FILTER_NAMES.contains(filterName)) {
             throw new IllegalArgumentException("Unknown filter: " + filterName);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/GeoMaskFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/GeoMaskFilter.java
@@ -26,13 +26,24 @@ import java.util.List;
  * that if an AisPacket passed to the filter is positively known to origin from inside one of these bounding
  * boxes, then it is rejected.
  *
- * @author Thomas Borg Salling <tbsalling@tbsalling.dk>
+ * @author Thomas Borg Salling &lt;tbsalling@tbsalling.dk&gt;
  */
 public class GeoMaskFilter implements IPacketFilter {
 
+    /**
+     * The Blocked.
+     */
     final Predicate<AisPacket> blocked;
+    /**
+     * The Suppressed bounding boxes.
+     */
     final List<BoundingBox> suppressedBoundingBoxes;
 
+    /**
+     * Instantiates a new Geo mask filter.
+     *
+     * @param suppressedBoundingBoxes the suppressed bounding boxes
+     */
     public GeoMaskFilter(List<BoundingBox> suppressedBoundingBoxes) {
         this.suppressedBoundingBoxes = suppressedBoundingBoxes;
 
@@ -49,6 +60,11 @@ public class GeoMaskFilter implements IPacketFilter {
         this.blocked = oredPredicates;
     }
 
+    /**
+     * Gets suppressed bounding boxes.
+     *
+     * @return the suppressed bounding boxes
+     */
     public List<BoundingBox> getSuppressedBoundingBoxes() {
         return suppressedBoundingBoxes;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/IMessageFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/IMessageFilter.java
@@ -23,6 +23,12 @@ import dk.dma.ais.message.AisMessage;
 @ThreadSafe
 public interface IMessageFilter {
 
+    /**
+     * Rejected by filter boolean.
+     *
+     * @param message the message
+     * @return the boolean
+     */
     boolean rejectedByFilter(AisMessage message);
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/IPacketFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/IPacketFilter.java
@@ -23,6 +23,12 @@ import dk.dma.ais.packet.AisPacket;
 @ThreadSafe
 public interface IPacketFilter {
 
+    /**
+     * Rejected by filter boolean.
+     *
+     * @param packet the packet
+     * @return the boolean
+     */
     boolean rejectedByFilter(AisPacket packet);
 
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/LocationFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/LocationFilter.java
@@ -69,6 +69,11 @@ public class LocationFilter extends MessageFilterBase {
         return true;
     }
 
+    /**
+     * Add filter geometry.
+     *
+     * @param geometry the geometry
+     */
     public void addFilterGeometry(Predicate<? super Position> geometry) {
         geomtries.add(geometry);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/MessageHandlerFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/MessageHandlerFilter.java
@@ -23,12 +23,11 @@ import java.util.function.Consumer;
 
 /**
  * Message handler filter
- * 
+ * <p>
  * A filter receives AIS messages, do some manipulation, and delivers messages to a list of receivers. Hence filters can be put
  * between an AIS source and handlers.
- * 
+ * <p>
  * Thread safe by delegation
- * 
  */
 @ThreadSafe
 public class MessageHandlerFilter implements Consumer<AisMessage> {
@@ -45,8 +44,8 @@ public class MessageHandlerFilter implements Consumer<AisMessage> {
 
     /**
      * Constructor given message filter
-     * 
-     * @param messageFilter
+     *
+     * @param messageFilter the message filter
      */
     public MessageHandlerFilter(IMessageFilter messageFilter) {
         this.messageFilter = messageFilter;
@@ -54,8 +53,8 @@ public class MessageHandlerFilter implements Consumer<AisMessage> {
 
     /**
      * Register a receiver of filtered messages
-     * 
-     * @param receiver
+     *
+     * @param receiver the receiver
      */
     public void registerReceiver(Consumer<? super AisMessage> receiver) {
         receivers.add(receiver);
@@ -63,8 +62,8 @@ public class MessageHandlerFilter implements Consumer<AisMessage> {
 
     /**
      * Remove receiver
-     * 
-     * @param receiver
+     *
+     * @param receiver the receiver
      */
     public void removeReceiver(Consumer<? super AisMessage> receiver) {
         receivers.remove(receiver);
@@ -72,8 +71,8 @@ public class MessageHandlerFilter implements Consumer<AisMessage> {
 
     /**
      * Send message to receivers
-     * 
-     * @param aisMessage
+     *
+     * @param aisMessage the ais message
      */
     protected void sendMessage(AisMessage aisMessage) {
         for (Consumer<? super AisMessage> receiver : receivers) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/MessageTypeFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/MessageTypeFilter.java
@@ -33,7 +33,10 @@ public class MessageTypeFilter implements IPacketFilter {
      */
     private final Set<Integer> messageTypes = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
     private volatile boolean disallowed;
-    
+
+    /**
+     * Instantiates a new Message type filter.
+     */
     public MessageTypeFilter() {
         
     }
@@ -49,11 +52,21 @@ public class MessageTypeFilter implements IPacketFilter {
         }
         return !disallowed;
     }
-    
+
+    /**
+     * Gets message types.
+     *
+     * @return the message types
+     */
     public Set<Integer> getMessageTypes() {
         return messageTypes;
     }
-    
+
+    /**
+     * Sets disallowed.
+     *
+     * @param disallowed the disallowed
+     */
     public void setDisallowed(boolean disallowed) {
         this.disallowed = disallowed;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/PacketFilterCollection.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/PacketFilterCollection.java
@@ -21,24 +21,38 @@ import dk.dma.ais.packet.AisPacket;
 
 /**
  * Filter that holds a collection of packet filers and checks against all filters
- * 
+ * <p>
  * Thread safe by delegation
  */
 @ThreadSafe
 public class PacketFilterCollection implements IPacketFilter {
 
     private final CopyOnWriteArrayList<IPacketFilter> packetFilters = new CopyOnWriteArrayList<>();
+    /**
+     * The constant TYPE_AND.
+     */
     public static final int TYPE_AND = 0;
+    /**
+     * The constant TYPE_OR.
+     */
     public static final int TYPE_OR = 1;
     
     private int filterType = TYPE_AND;
-    
 
+
+    /**
+     * Gets filter type.
+     *
+     * @return the filter type
+     */
     public int getFilterType() {
         return filterType;
     }
 
 
+    /**
+     * Instantiates a new Packet filter collection.
+     */
     public PacketFilterCollection() {
 
     }
@@ -72,20 +86,28 @@ public class PacketFilterCollection implements IPacketFilter {
 
     /**
      * Add a filter
-     * 
-     * @param filter
+     *
+     * @param filter the filter
      */
     public void addFilter(IPacketFilter filter) {
            packetFilters.add(filter);
     }
-    
+
     /**
-     * 
+     * Is type boolean.
+     *
+     * @param t the t
+     * @return the boolean
      */
     public boolean isType(int t) {
         return filterType == t;
     }
 
+    /**
+     * Sets filter type.
+     *
+     * @param filterType the filter type
+     */
     public void setFilterType(int filterType) {
         this.filterType = filterType;
         

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/PastFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/PastFilter.java
@@ -18,18 +18,26 @@ package dk.dma.ais.filter;
 import dk.dma.ais.packet.AisPacket;
 
 /**
- * @author Jens Tuxen
+ * The type Past filter.
  *
- * Reject packets with timestamp in the future according to device clock
+ * @author Jens Tuxen Reject packets with timestamp in the future according to device clock
  */
 public class PastFilter implements IPacketFilter {
     private final long threshold;
-    
+
+    /**
+     * Instantiates a new Past filter.
+     */
     public PastFilter() {
         /* defaults to filtering packets older than 24 hours */
         threshold = 24*60*60*1000; 
     }
-    
+
+    /**
+     * Instantiates a new Past filter.
+     *
+     * @param threshold the threshold
+     */
     public PastFilter(long threshold) {
         this.threshold = threshold;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/ReplayDownSampleFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/ReplayDownSampleFilter.java
@@ -25,14 +25,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A down sampling filter.
- * <p/>
+ * <p>
  * For position reports 1,2,3,4 and 18, only one message will be forwarded within the give sampling rate. E.g. one message per
  * minute.
- * <p/>
+ * <p>
  * For static reports 5 and 24 the same apply. But it is handled separately from the position reports.
- * <p/>
+ * <p>
  * All remaining message types are passed through without down sampling.
- * <p/>
+ * <p>
  * As opposed to the DownSampleFilter (which operates on current system time), this filter uses the timestamp on
  * AisPackets as current time when filtering.
  */
@@ -63,12 +63,18 @@ public class ReplayDownSampleFilter implements IPacketFilter {
     /**
      * Constructor given sampling rate in seconds
      *
-     * @param samplingRate
+     * @param samplingRate the sampling rate
      */
     public ReplayDownSampleFilter(long samplingRate) {
         this.samplingRate = samplingRate;
     }
 
+    /**
+     * Gets message id.
+     *
+     * @param packet the packet
+     * @return the message id
+     */
     protected static int getMessageId(AisPacket packet) {
         int msgId = -1;
 
@@ -125,8 +131,8 @@ public class ReplayDownSampleFilter implements IPacketFilter {
 
     /**
      * Get sampling rate in seconds
-     * 
-     * @return
+     *
+     * @return sampling rate
      */
     public long getSamplingRate() {
         return samplingRate;
@@ -134,10 +140,9 @@ public class ReplayDownSampleFilter implements IPacketFilter {
 
     /**
      * Set sampling rate in seconds
-     * 
-     * @param samplingRate
+     *
+     * @param samplingRate the sampling rate
      */
-
     public void setSamplingRate(long samplingRate) {
         this.samplingRate = samplingRate;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/ReplayDuplicateFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/ReplayDuplicateFilter.java
@@ -26,10 +26,9 @@ import dk.dma.ais.packet.AisPacket;
 
 /**
  * A doublet filter for replayed streams
- * 
+ * <p>
  * The doublet filter works by only allowing the same message through once in a time window. The six bit string of the message is
  * used as unique identifier.
- * 
  */
 @ThreadSafe
 public class ReplayDuplicateFilter implements IPacketFilter {
@@ -56,14 +55,16 @@ public class ReplayDuplicateFilter implements IPacketFilter {
      */
     private volatile long cleanupAge;
 
+    /**
+     * Instantiates a new Replay duplicate filter.
+     */
     public ReplayDuplicateFilter() {
     }
 
     /**
      * Constructor given window size
-     * 
-     * @param window
-     *            size in milliseconds
+     *
+     * @param windowSize the window size
      */
     public ReplayDuplicateFilter(long windowSize) {
         this.windowSize = windowSize;
@@ -124,10 +125,20 @@ public class ReplayDuplicateFilter implements IPacketFilter {
         return false;
     }
 
+    /**
+     * Gets window size.
+     *
+     * @return the window size
+     */
     public long getWindowSize() {
         return windowSize;
     }
 
+    /**
+     * Sets window size.
+     *
+     * @param windowSize the window size
+     */
     public void setWindowSize(long windowSize) {
         this.windowSize = windowSize;
     }
@@ -140,6 +151,12 @@ public class ReplayDuplicateFilter implements IPacketFilter {
         private String sixbit;
         private long received;
 
+        /**
+         * Instantiates a new Doublet entry.
+         *
+         * @param sixbit   the sixbit
+         * @param received the received
+         */
         public DoubletEntry(String sixbit, long received) {
             this.sixbit = sixbit;
             this.received = received;
@@ -153,10 +170,20 @@ public class ReplayDuplicateFilter implements IPacketFilter {
             return sixbit.compareTo(doubletEntry.sixbit);
         }
 
+        /**
+         * Gets received.
+         *
+         * @return the received
+         */
         public long getReceived() {
             return received;
         }
 
+        /**
+         * Gets sixbit.
+         *
+         * @return the sixbit
+         */
         public String getSixbit() {
             return sixbit;
         }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/SanityFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/SanityFilter.java
@@ -42,6 +42,9 @@ public class SanityFilter extends MessageFilterBase {
      */
     private final Cache<Integer, Boolean> hasStaticMap;
 
+    /**
+     * Instantiates a new Sanity filter.
+     */
     public SanityFilter() {
         hasStaticMap = CacheBuilder.newBuilder().maximumSize(STATIC_CACHE_SIZE).expireAfterWrite(24, TimeUnit.HOURS).build();
     }
@@ -105,10 +108,20 @@ public class SanityFilter extends MessageFilterBase {
         return false;
     }
 
+    /**
+     * Gets count.
+     *
+     * @return the count
+     */
     public long getCount() {
         return count;
     }
 
+    /**
+     * Gets reject count.
+     *
+     * @return the reject count
+     */
     public long getRejectCount() {
         return rejectCount;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/TaggingFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/TaggingFilter.java
@@ -27,6 +27,11 @@ public class TaggingFilter implements IPacketFilter {
 
     private final AisPacketTags filterTagging;
 
+    /**
+     * Instantiates a new Tagging filter.
+     *
+     * @param filterTagging the filter tagging
+     */
     public TaggingFilter(AisPacketTags filterTagging) {
         this.filterTagging = filterTagging;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/filter/TargetCountryFilter.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/filter/TargetCountryFilter.java
@@ -32,7 +32,10 @@ public class TargetCountryFilter extends MessageFilterBase {
      * Set of allowed countries by their ISO 3166 three letter code
      */
     private final Set<String> allowedCountries = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
-    
+
+    /**
+     * Instantiates a new Target country filter.
+     */
     public TargetCountryFilter() {
         
     }
@@ -47,11 +50,21 @@ public class TargetCountryFilter extends MessageFilterBase {
         }
         return !allowedCountries.contains(country.getThreeLetter());
     }
-    
+
+    /**
+     * Add country.
+     *
+     * @param country the country
+     */
     public void addCountry(Country country) {
         allowedCountries.add(country.getThreeLetter());
     }
-    
+
+    /**
+     * Remove country.
+     *
+     * @param country the country
+     */
     public void removeCountry(Country country) {
         allowedCountries.remove(country.getThreeLetter());
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacket.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacket.java
@@ -35,7 +35,7 @@ import dk.dma.enav.model.geometry.PositionTime;
 /**
  * Encapsulation of the VDM lines containing a single AIS message including leading proprietary tags and comment/tag
  * blocks.
- * 
+ *
  * @author Kasper Nielsen
  */
 @NotThreadSafe
@@ -51,11 +51,23 @@ public class AisPacket implements Comparable<AisPacket> {
         this.rawMessage = requireNonNull(stringMessage);
     }
 
+    /**
+     * Instantiates a new Ais packet.
+     *
+     * @param vdm           the vdm
+     * @param stringMessage the string message
+     */
     AisPacket(Vdm vdm, String stringMessage) {
         this(stringMessage);
         this.vdm = vdm;
     }
 
+    /**
+     * From byte buffer ais packet.
+     *
+     * @param buffer the buffer
+     * @return the ais packet
+     */
     public static AisPacket fromByteBuffer(ByteBuffer buffer) {
         int cap = buffer.remaining();
         byte[] buf = new byte[cap];
@@ -63,17 +75,28 @@ public class AisPacket implements Comparable<AisPacket> {
         return fromByteArray(buf);
     }
 
+    /**
+     * From byte array ais packet.
+     *
+     * @param array the array
+     * @return the ais packet
+     */
     public static AisPacket fromByteArray(byte[] array) {
         return from(new String(array, StandardCharsets.US_ASCII));
     }
 
+    /**
+     * To byte array byte [ ].
+     *
+     * @return the byte [ ]
+     */
     public byte[] toByteArray() {
         return rawMessage.getBytes(StandardCharsets.US_ASCII);
     }
 
     /**
      * Returns the timestamp of the packet, or -1 if no timestamp is available.
-     * 
+     *
      * @return the timestamp of the packet, or -1 if no timestamp is available
      */
     public long getBestTimestamp() {
@@ -85,18 +108,28 @@ public class AisPacket implements Comparable<AisPacket> {
         return timestamp;
     }
 
+    /**
+     * Gets string message.
+     *
+     * @return the string message
+     */
     public String getStringMessage() {
         return rawMessage;
     }
 
+    /**
+     * Gets string message lines.
+     *
+     * @return the string message lines
+     */
     public List<String> getStringMessageLines() {
         return Arrays.asList(rawMessage.split("\\r?\\n"));
     }
 
     /**
      * Get existing VDM or parse one from message string
-     * 
-     * @return Vdm
+     *
+     * @return Vdm vdm
      */
     public Vdm getVdm() {
         if (vdm == null) {
@@ -116,7 +149,7 @@ public class AisPacket implements Comparable<AisPacket> {
 
     /**
      * Returns the tags of the packet.
-     * 
+     *
      * @return the tags of the packet
      */
     public AisPacketTags getTags() {
@@ -127,7 +160,12 @@ public class AisPacket implements Comparable<AisPacket> {
         return tags;
     }
 
-    // TODO fizx
+    /**
+     * Try get ais message ais message.
+     *
+     * @return the ais message
+     */
+// TODO fizx
     public AisMessage tryGetAisMessage() {
         try {
             return getAisMessage();
@@ -138,10 +176,10 @@ public class AisPacket implements Comparable<AisPacket> {
 
     /**
      * Try to get AIS message from packet
-     * 
-     * @return
-     * @throws SixbitException
-     * @throws AisMessageException
+     *
+     * @return ais message
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
      */
     public AisMessage getAisMessage() throws AisMessageException, SixbitException {
         if (message != null || getVdm() == null) {
@@ -152,8 +190,8 @@ public class AisPacket implements Comparable<AisPacket> {
 
     /**
      * Check if VDM contains a valid AIS message
-     * 
-     * @return
+     *
+     * @return boolean boolean
      */
     public boolean isValidMessage() {
         return tryGetAisMessage() != null;
@@ -161,8 +199,8 @@ public class AisPacket implements Comparable<AisPacket> {
 
     /**
      * Try to get timestamp for packet.
-     * 
-     * @return
+     *
+     * @return timestamp timestamp
      */
     public Date getTimestamp() {
         if (getVdm() == null) {
@@ -171,6 +209,11 @@ public class AisPacket implements Comparable<AisPacket> {
         return vdm.getTimestamp();
     }
 
+    /**
+     * Try get position time position time.
+     *
+     * @return the position time
+     */
     public PositionTime tryGetPositionTime() {
         AisMessage m = tryGetAisMessage();
         if (m instanceof IPositionMessage) {
@@ -181,18 +224,22 @@ public class AisPacket implements Comparable<AisPacket> {
 
     }
 
+    /**
+     * From ais packet.
+     *
+     * @param stringMessage the string message
+     * @return the ais packet
+     */
     public static AisPacket from(String stringMessage) {
         return new AisPacket(stringMessage);
     }
 
     /**
      * Construct AisPacket from raw packet string
-     * 
-     * @param messageString
-     * @param optional
-     *            factory
-     * @return
-     * @throws SentenceException
+     *
+     * @param messageString the message string
+     * @return ais packet
+     * @throws SentenceException the sentence exception
      */
     public static AisPacket readFromString(String messageString) throws SentenceException {
         AisPacket packet = null;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketCSVOutputSink.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketCSVOutputSink.java
@@ -51,8 +51,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Transform AisPackets into csv objects with only specific columns
- * @author Thomas Borg Salling
  *
+ * @author Thomas Borg Salling
  */
 public class AisPacketCSVOutputSink extends OutputStreamSink<AisPacket> {
 
@@ -67,16 +67,33 @@ public class AisPacketCSVOutputSink extends OutputStreamSink<AisPacket> {
 
     private Lock csvLock = new ReentrantLock();
 
+    /**
+     * The constant NULL_INDICATOR.
+     */
     protected static final String NULL_INDICATOR = "null";
-    
+
+    /**
+     * Instantiates a new Ais packet csv output sink.
+     */
     public AisPacketCSVOutputSink() {
         this("timestamp_pretty;timestamp;targetType;mmsi;msgid;posacc;lat;lon;sog;cog;draught;name;dimBow;dimPort;dimStarboard;dimStern;shipTypeCargoTypeCode;shipType;shipCargo;destination;eta;imo;callsign", ";");
     }
 
+    /**
+     * Instantiates a new Ais packet csv output sink.
+     *
+     * @param format the format
+     */
     public AisPacketCSVOutputSink(String format) {
         this(format, ";");
     }
 
+    /**
+     * Instantiates a new Ais packet csv output sink.
+     *
+     * @param format    the format
+     * @param separator the separator
+     */
     public AisPacketCSVOutputSink(String format, String separator) {
         LOG.info("Exporting CSV columns: " + format);
         columns = format.split(separator);
@@ -404,6 +421,12 @@ public class AisPacketCSVOutputSink extends OutputStreamSink<AisPacket> {
 
     // ---
 
+    /**
+     * Format eta string.
+     *
+     * @param eta the eta
+     * @return the string
+     */
     protected String formatEta(long eta) {
         /*
         Estimated time of arrival; MMDDHHMM UTC
@@ -421,88 +444,199 @@ public class AisPacketCSVOutputSink extends OutputStreamSink<AisPacket> {
         return formatEta(day, month, hour, minute);
     }
 
+    /**
+     * Format eta string.
+     *
+     * @param eta the eta
+     * @return the string
+     */
     protected String formatEta(Date eta) {
         LocalDateTime time = LocalDateTime.ofInstant(Instant.ofEpochMilli(eta.getTime()), ZoneId.systemDefault());
         return formatEta(time.getDayOfMonth(), time.getMonthValue(), time.getHour(), time.getMinute());
     }
 
+    /**
+     * Format eta string.
+     *
+     * @param day    the day
+     * @param month  the month
+     * @param hour   the hour
+     * @param minute the minute
+     * @return the string
+     */
     protected String formatEta(int day, int month, int hour, int minute) {
         return String.format("%02d/%02d %02d:%02d UTC", day, month, hour, minute);
     }
 
     // ---
 
+    /**
+     * Sets null value for position accuracy.
+     *
+     * @param nullValueForPositionAccuracy the null value for position accuracy
+     */
     protected void setNullValueForPositionAccuracy(Function<AisMessage, Object> nullValueForPositionAccuracy) {
         this.nullValueForPositionAccuracy = nullValueForPositionAccuracy;
     }
 
+    /**
+     * Sets null value for latitude.
+     *
+     * @param nullValueForLatitude the null value for latitude
+     */
     protected void setNullValueForLatitude(Function<AisMessage, Object> nullValueForLatitude) {
         this.nullValueForLatitude = nullValueForLatitude;
     }
 
+    /**
+     * Sets null value for longitude.
+     *
+     * @param nullValueForLongitude the null value for longitude
+     */
     protected void setNullValueForLongitude(Function<AisMessage, Object> nullValueForLongitude) {
         this.nullValueForLongitude = nullValueForLongitude;
     }
 
+    /**
+     * Sets null value for sog.
+     *
+     * @param nullValueForSog the null value for sog
+     */
     protected void setNullValueForSog(Function<AisMessage, Object> nullValueForSog) {
         this.nullValueForSog = nullValueForSog;
     }
 
+    /**
+     * Sets null value for cog.
+     *
+     * @param nullValueForCog the null value for cog
+     */
     protected void setNullValueForCog(Function<AisMessage, Object> nullValueForCog) {
         this.nullValueForCog = nullValueForCog;
     }
 
+    /**
+     * Sets null value for true heading.
+     *
+     * @param nullValueForTrueHeading the null value for true heading
+     */
     protected void setNullValueForTrueHeading(Function<AisMessage, Object> nullValueForTrueHeading) {
         this.nullValueForTrueHeading = nullValueForTrueHeading;
     }
 
+    /**
+     * Sets null value for draught.
+     *
+     * @param nullValueForDraught the null value for draught
+     */
     protected void setNullValueForDraught(Function<AisMessage, Object> nullValueForDraught) {
         this.nullValueForDraught = nullValueForDraught;
     }
 
+    /**
+     * Sets null value for name.
+     *
+     * @param nullValueForName the null value for name
+     */
     protected void setNullValueForName(Function<AisMessage, Object> nullValueForName) {
         this.nullValueForName = nullValueForName;
     }
 
+    /**
+     * Sets null value for dim bow.
+     *
+     * @param nullValueForDimBow the null value for dim bow
+     */
     protected void setNullValueForDimBow(Function<AisMessage, Object> nullValueForDimBow) {
         this.nullValueForDimBow = nullValueForDimBow;
     }
 
+    /**
+     * Sets null value for dim port.
+     *
+     * @param nullValueForDimPort the null value for dim port
+     */
     protected void setNullValueForDimPort(Function<AisMessage, Object> nullValueForDimPort) {
         this.nullValueForDimPort = nullValueForDimPort;
     }
 
+    /**
+     * Sets null value for dim starboard.
+     *
+     * @param nullValueForDimStarboard the null value for dim starboard
+     */
     protected void setNullValueForDimStarboard(Function<AisMessage, Object> nullValueForDimStarboard) {
         this.nullValueForDimStarboard = nullValueForDimStarboard;
     }
 
+    /**
+     * Sets null value for dim stern.
+     *
+     * @param nullValueForDimStern the null value for dim stern
+     */
     protected void setNullValueForDimStern(Function<AisMessage, Object> nullValueForDimStern) {
         this.nullValueForDimStern = nullValueForDimStern;
     }
 
+    /**
+     * Sets null value for ship type cargo type code.
+     *
+     * @param nullValueForShipTypeCargoTypeCode the null value for ship type cargo type code
+     */
     protected void setNullValueForShipTypeCargoTypeCode(Function<AisMessage, Object> nullValueForShipTypeCargoTypeCode) {
         this.nullValueForShipTypeCargoTypeCode = nullValueForShipTypeCargoTypeCode;
     }
+
+    /**
+     * Sets null value for ship type.
+     *
+     * @param nullValueForShipType the null value for ship type
+     */
     protected void setNullValueForShipType(Function<AisMessage, Object> nullValueForShipType) {
         this.nullValueForShipType = nullValueForShipType;
     }
 
+    /**
+     * Sets null value for ship cargo.
+     *
+     * @param nullValueForShipCargo the null value for ship cargo
+     */
     protected void setNullValueForShipCargo(Function<AisMessage, Object> nullValueForShipCargo) {
         this.nullValueForShipCargo = nullValueForShipCargo;
     }
 
+    /**
+     * Sets null value for callsign.
+     *
+     * @param nullValueForCallsign the null value for callsign
+     */
     protected void setNullValueForCallsign(Function<AisMessage, Object> nullValueForCallsign) {
         this.nullValueForCallsign = nullValueForCallsign;
     }
 
+    /**
+     * Sets null value for imo.
+     *
+     * @param nullValueForImo the null value for imo
+     */
     protected void setNullValueForImo(Function<AisMessage, Object> nullValueForImo) {
         this.nullValueForImo = nullValueForImo;
     }
 
+    /**
+     * Sets null value for destination.
+     *
+     * @param nullValueForDestination the null value for destination
+     */
     protected void setNullValueForDestination(Function<AisMessage, Object> nullValueForDestination) {
         this.nullValueForDestination = nullValueForDestination;
     }
 
+    /**
+     * Sets null value for eta.
+     *
+     * @param nullValueForEta the null value for eta
+     */
     protected void setNullValueForEta(Function<AisMessage, Object> nullValueForEta) {
         this.nullValueForEta = nullValueForEta;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketCSVStatefulOutputSink.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketCSVStatefulOutputSink.java
@@ -51,14 +51,28 @@ public class AisPacketCSVStatefulOutputSink extends AisPacketCSVOutputSink {
 
     private TargetTracker tracker = new TargetTracker();
 
+    /**
+     * Instantiates a new Ais packet csv stateful output sink.
+     */
     public AisPacketCSVStatefulOutputSink() {
         this("timestamp_pretty;timestamp;targetType;mmsi;msgid;posacc;lat;lon;sog;cog;draught;name;dimBow;dimPort;dimStarboard;dimStern;shipTypeCargoTypeCode;shipType;shipCargo;destination;eta;imo;callsign", ";");
     }
 
+    /**
+     * Instantiates a new Ais packet csv stateful output sink.
+     *
+     * @param format the format
+     */
     public AisPacketCSVStatefulOutputSink(String format) {
         this(format, ";");
     }
 
+    /**
+     * Instantiates a new Ais packet csv stateful output sink.
+     *
+     * @param format    the format
+     * @param separator the separator
+     */
     public AisPacketCSVStatefulOutputSink(String format, String separator) {
         super(format, separator);
         setNullValueForPositionAccuracy(cachedPositionAccuracy);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFilters.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFilters.java
@@ -42,10 +42,20 @@ import java.util.function.Predicate;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * The type Ais packet filters.
+ *
  * @author Kasper Nielsen
  */
 public class AisPacketFilters extends AisPacketFiltersBase {
 
+    /**
+     * Filter on message type predicate.
+     *
+     * @param <T>         the type parameter
+     * @param messageType the message type
+     * @param predicate   the predicate
+     * @return the predicate
+     */
     public static <T> Predicate<AisPacket> filterOnMessageType(final Class<T> messageType, final Predicate<T> predicate) {
         requireNonNull(messageType);
         requireNonNull(predicate);
@@ -70,6 +80,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message type predicate.
+     *
+     * @param <T>         the type parameter
+     * @param messageType the message type
+     * @return the predicate
+     */
     public static <T> Predicate<AisPacket> filterOnMessageType(final Class<T> messageType) {
         requireNonNull(messageType);
         return new AbstractMessagePredicate() {
@@ -79,6 +96,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on source basestation predicate.
+     *
+     * @param ids the ids
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnSourceBasestation(Integer... ids) {
         final Integer[] copy = ids.clone();
         Arrays.sort(copy);
@@ -97,8 +120,7 @@ public class AisPacketFilters extends AisPacketFiltersBase {
     /**
      * Returns a predicate that will filter packets based on the base station source tag.
      *
-     * @param ids
-     *            the id of the base stations for which packets should be accepted
+     * @param ids the id of the base stations for which packets should be accepted
      * @return the predicate
      */
     public static Predicate<AisPacket> filterOnSourceBasestation(String... ids) {
@@ -112,8 +134,7 @@ public class AisPacketFilters extends AisPacketFiltersBase {
     /**
      * Returns a predicate that will filter packets based on the country of the source tag.
      *
-     * @param countries
-     *            the countries for which packets should be accepted
+     * @param countries the countries for which packets should be accepted
      * @return the predicate
      */
     public static Predicate<AisPacket> filterOnSourceCountry(final Country... countries) {
@@ -130,6 +151,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on source id predicate.
+     *
+     * @param ids the ids
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnSourceId(final String... ids) {
         final String[] s = check(ids);
         return new Predicate<AisPacket>() {
@@ -144,6 +171,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on source region predicate.
+     *
+     * @param regions the regions
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnSourceRegion(final String... regions) {
         final String[] s = check(regions);
         requireNonNull(regions, "regions is null");
@@ -160,6 +193,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on source type predicate.
+     *
+     * @param sourceType the source type
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnSourceType(final SourceType... sourceType) {
         final SourceType[] sourceTypes = sourceType.clone();
         requireNonNull(sourceType, "sourceType is null");
@@ -184,11 +223,9 @@ public class AisPacketFilters extends AisPacketFiltersBase {
     /**
      * Filter on message to have known position inside given area.
      *
-     * @param area
-     *            The area that the position must reside inside.
-     * @return
+     * @param area The area that the position must reside inside.
+     * @return predicate predicate
      */
-
     public static Predicate<AisPacket> filterOnMessagePositionWithin(final Area area) {
         requireNonNull(area);
         return filterOnMessageType(IPositionMessage.class, new Predicate<IPositionMessage>() {
@@ -210,11 +247,9 @@ public class AisPacketFilters extends AisPacketFiltersBase {
     /**
      * Block position messages outside of given area; let all other messages pass.
      *
-     * @param area
-     *            The area that the position messages must reside inside.
-     * @return
+     * @param area The area that the position messages must reside inside.
+     * @return predicate predicate
      */
-
     public static Predicate<AisPacket> filterRelaxedOnMessagePositionWithin(final Area area) {
         requireNonNull(area);
         return new Predicate<AisPacket>() {
@@ -233,6 +268,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on source basestation predicate.
+     *
+     * @param operator the operator
+     * @param bs       the bs
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnSourceBasestation(final CompareToOperator operator, final Integer bs) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -250,12 +292,11 @@ public class AisPacketFilters extends AisPacketFiltersBase {
     /**
      * Filter on a comparison to a value of the indicated calendarField (see java.util.Calendar).
      *
-     * @param operator
-     * @param calendarField
-     * @param value
-     * @return
+     * @param operator      the operator
+     * @param calendarField the calendar field
+     * @param value         the value
+     * @return predicate predicate
      */
-
     protected static Predicate<AisPacket> filterOnMessageReceiveTime(final CompareToOperator operator, final int calendarField,
             final int value) {
         return new Predicate<AisPacket>() {
@@ -276,14 +317,35 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time month predicate.
+     *
+     * @param operator the operator
+     * @param rhs      the rhs
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeMonth(final CompareToOperator operator, Integer rhs) {
         return filterOnMessageReceiveTime(operator, Calendar.MONTH, rhs);
     }
 
+    /**
+     * Filter on message receive time day of week predicate.
+     *
+     * @param operator the operator
+     * @param rhs      the rhs
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeDayOfWeek(final CompareToOperator operator, Integer rhs) {
         return filterOnMessageReceiveTime(operator, Calendar.DAY_OF_WEEK, rhs);
     }
 
+    /**
+     * Filter on message receive time year predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeYear(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -296,6 +358,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time year predicate.
+     *
+     * @param years the years
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeYear(Integer... years) {
         final Integer[] copy = years.clone();
         Arrays.sort(copy);
@@ -310,6 +378,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time month predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeMonth(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -322,6 +397,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time month predicate.
+     *
+     * @param months the months
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeMonth(Integer... months) {
         final Integer[] copy = months.clone();
         Arrays.sort(copy);
@@ -336,6 +417,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time day of month predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeDayOfMonth(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -348,6 +436,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time day of month predicate.
+     *
+     * @param days the days
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeDayOfMonth(Integer... days) {
         final Integer[] copy = days.clone();
         Arrays.sort(copy);
@@ -362,6 +456,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time day of week predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeDayOfWeek(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -374,6 +475,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time day of week predicate.
+     *
+     * @param days the days
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeDayOfWeek(Integer... days) {
         final Integer[] copy = days.clone();
         Arrays.sort(copy);
@@ -388,6 +495,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time hour predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeHour(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -400,6 +514,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time hour predicate.
+     *
+     * @param hours the hours
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeHour(Integer... hours) {
         final Integer[] copy = hours.clone();
         Arrays.sort(copy);
@@ -414,6 +534,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time minute predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeMinute(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -426,6 +553,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message receive time minute predicate.
+     *
+     * @param minutes the minutes
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageReceiveTimeMinute(Integer... minutes) {
         final Integer[] copy = minutes.clone();
         Arrays.sort(copy);
@@ -481,6 +614,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
 
     // ---
 
+    /**
+     * Filter on message id predicate.
+     *
+     * @param operator the operator
+     * @param id       the id
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageId(final CompareToOperator operator, final Integer id) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -494,6 +634,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message mmsi predicate.
+     *
+     * @param operator the operator
+     * @param mmsi     the mmsi
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageMmsi(final CompareToOperator operator, final Integer mmsi) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -507,6 +654,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message imo predicate.
+     *
+     * @param operator the operator
+     * @param imo      the imo
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageImo(final CompareToOperator operator, final Integer imo) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -524,6 +678,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message shiptype predicate.
+     *
+     * @param operator the operator
+     * @param shiptype the shiptype
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageShiptype(final CompareToOperator operator, final Integer shiptype) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -541,6 +702,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message navigational status predicate.
+     *
+     * @param operator  the operator
+     * @param navstatus the navstatus
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageNavigationalStatus(final CompareToOperator operator, final Integer navstatus) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -558,14 +726,35 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message name predicate.
+     *
+     * @param operator the operator
+     * @param name     the name
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageName(final CompareToOperator operator, final Float name) {
         return filterOnMessageName(operator, name.toString());
     }
 
+    /**
+     * Filter on message name predicate.
+     *
+     * @param operator the operator
+     * @param name     the name
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageName(final CompareToOperator operator, final Integer name) {
         return filterOnMessageName(operator, name.toString());
     }
 
+    /**
+     * Filter on message name predicate.
+     *
+     * @param operator the operator
+     * @param name     the name
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageName(final CompareToOperator operator, String name) {
         final String n = preprocessExpressionString(name);
         return new Predicate<AisPacket>() {
@@ -584,6 +773,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message name match predicate.
+     *
+     * @param pattern the pattern
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageNameMatch(String pattern) {
         final String glob = preprocessExpressionString(pattern);
         return new Predicate<AisPacket>() {
@@ -602,6 +797,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message callsign predicate.
+     *
+     * @param operator the operator
+     * @param callsign the callsign
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageCallsign(final CompareToOperator operator, String callsign) {
         final String n = preprocessExpressionString(callsign);
         return new Predicate<AisPacket>() {
@@ -620,6 +822,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message callsign match predicate.
+     *
+     * @param pattern the pattern
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageCallsignMatch(String pattern) {
         final String glob = preprocessExpressionString(pattern);
         return new Predicate<AisPacket>() {
@@ -638,6 +846,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message speed over ground predicate.
+     *
+     * @param operator the operator
+     * @param sog      the sog
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageSpeedOverGround(final CompareToOperator operator, final Float sog) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -655,6 +870,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message course over ground predicate.
+     *
+     * @param operator the operator
+     * @param cog      the cog
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageCourseOverGround(final CompareToOperator operator, final Float cog) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -672,6 +894,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message true heading predicate.
+     *
+     * @param operator the operator
+     * @param hdg      the hdg
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageTrueHeading(final CompareToOperator operator, final Integer hdg) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -689,6 +918,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message longitude predicate.
+     *
+     * @param operator the operator
+     * @param lon      the lon
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageLongitude(final CompareToOperator operator, final Float lon) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -706,6 +942,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message latitude predicate.
+     *
+     * @param operator the operator
+     * @param lat      the lat
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageLatitude(final CompareToOperator operator, final Float lat) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -723,6 +966,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message draught predicate.
+     *
+     * @param operator the operator
+     * @param draught  the draught
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageDraught(final CompareToOperator operator, final Float draught) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -740,6 +990,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message id predicate.
+     *
+     * @param ids the ids
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageId(Integer... ids) {
         final Integer[] m = ids.clone();
         Arrays.sort(m);
@@ -759,6 +1015,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message mmsi predicate.
+     *
+     * @param mmsis the mmsis
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageMmsi(Integer... mmsis) {
         final Integer[] m = mmsis.clone();
         Arrays.sort(m);
@@ -778,6 +1040,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message imo predicate.
+     *
+     * @param imos the imos
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageImo(Integer... imos) {
         final Integer[] m = imos.clone();
         Arrays.sort(m);
@@ -798,6 +1066,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message shiptype predicate.
+     *
+     * @param shiptypes the shiptypes
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageShiptype(Integer... shiptypes) {
         final Integer[] m = shiptypes.clone();
         Arrays.sort(m);
@@ -818,6 +1092,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message navigational status predicate.
+     *
+     * @param navstats the navstats
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageNavigationalStatus(Integer... navstats) {
         final Integer[] m = navstats.clone();
         Arrays.sort(m);
@@ -838,6 +1118,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message name predicate.
+     *
+     * @param names the names
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageName(String... names) {
         final String[] m = preprocessExpressionStrings(names);
         Arrays.sort(m);
@@ -858,6 +1144,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message callsign predicate.
+     *
+     * @param callsigns the callsigns
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageCallsign(String... callsigns) {
         final String[] m = preprocessExpressionStrings(callsigns);
         Arrays.sort(m);
@@ -878,6 +1170,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message true heading predicate.
+     *
+     * @param hdgs the hdgs
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageTrueHeading(Integer... hdgs) {
         final Integer[] m = hdgs.clone();
         Arrays.sort(m);
@@ -898,6 +1196,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message id predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageId(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -915,6 +1220,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message mmsi predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageMmsi(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -932,6 +1244,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message imo predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageImo(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -949,6 +1268,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message shiptype predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageShiptype(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -966,6 +1292,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message navigational status predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageNavigationalStatus(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -983,6 +1316,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message true heading predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageTrueHeading(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -1000,6 +1340,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message latitude predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageLatitude(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -1017,6 +1364,13 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message longitude predicate.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageLongitude(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -1034,6 +1388,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Filter on message type predicate.
+     *
+     * @param types the types
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageType(final int... types) {
         final int[] t = types.clone();
         Arrays.sort(t);
@@ -1053,11 +1413,23 @@ public class AisPacketFilters extends AisPacketFiltersBase {
             }
         };
     }
-    
+
+    /**
+     * Filter on message country predicate.
+     *
+     * @param countries the countries
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnMessageCountry(final Country... countries) {
         return filterOnTargetCountry(countries);
     }
 
+    /**
+     * Filter on target country predicate.
+     *
+     * @param countries the countries
+     * @return the predicate
+     */
     public static Predicate<AisPacket> filterOnTargetCountry(final Country... countries) {
         final Country[] c = AisPacketFilters.check(countries);
         return new AbstractMessagePredicate() {
@@ -1072,30 +1444,52 @@ public class AisPacketFilters extends AisPacketFiltersBase {
         };
     }
 
+    /**
+     * Sampling filter predicate.
+     *
+     * @param minDistanceInMeters the min distance in meters
+     * @param minDurationInMS     the min duration in ms
+     * @return the predicate
+     */
     public static Predicate<AisPacket> samplingFilter(Integer minDistanceInMeters, Long minDurationInMS) {
         return new SamplerFilter(minDistanceInMeters, minDurationInMS);
     }
 
     /**
-     * Replaced by Predicate<AisPacket> parseExpressionFilter(String filter)
+     * Replaced by Predicate&lt;AisPacket&gt; parseExpressionFilter(String filter)
      *
+     * @param filter the filter
+     * @return predicate predicate
      * @deprecated
-     * @param filter
-     * @return
      */
     @Deprecated
     public static Predicate<AisPacket> parseSourceFilter(String filter) {
         return AisPacketFiltersExpressionFilterParser.parseExpressionFilter(filter);
     }
 
+    /**
+     * Parse expression filter predicate.
+     *
+     * @param filter the filter
+     * @return the predicate
+     */
     public static Predicate<AisPacket> parseExpressionFilter(String filter) {
         return AisPacketFiltersExpressionFilterParser.parseExpressionFilter(filter);
     }
 
     // ---
 
+    /**
+     * The type Abstract message predicate.
+     */
     abstract static class AbstractMessagePredicate implements Predicate<AisPacket> {
 
+        /**
+         * Test boolean.
+         *
+         * @param message the message
+         * @return the boolean
+         */
         abstract boolean test(AisMessage message);
 
         /**
@@ -1133,6 +1527,12 @@ public class AisPacketFilters extends AisPacketFiltersBase {
          */
         final Long minDurationInMS;
 
+        /**
+         * Instantiates a new Sampler filter.
+         *
+         * @param minDistanceInMeters the min distance in meters
+         * @param minDurationInMS     the min duration in ms
+         */
         SamplerFilter(Integer minDistanceInMeters, Long minDurationInMS) {
             if (minDistanceInMeters == null && minDurationInMS == null) {
                 throw new IllegalArgumentException("minDistanceInMeters and minDurationInMS cannot both be null");
@@ -1167,6 +1567,7 @@ public class AisPacketFilters extends AisPacketFiltersBase {
 
     /**
      * Similar to the {@code SamplingFilter} except that it applies the sampling per MMSI target
+     *
      * @param minDistance the minimum distance between two packets per target
      * @param minDuration the minimum time in ms between two packets per target
      * @return the target sampling filter predicate
@@ -1228,6 +1629,7 @@ public class AisPacketFilters extends AisPacketFiltersBase {
 
     /**
      * Removes duplicates within the given time window
+     *
      * @param windowSize the sampling rate in ms
      * @return the target sampling filter predicate
      */

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersBase.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersBase.java
@@ -22,6 +22,13 @@ import java.util.Arrays;
  */
 public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
+    /**
+     * Check t [ ].
+     *
+     * @param <T>      the type parameter
+     * @param elements the elements
+     * @return the t [ ]
+     */
     @SafeVarargs
     static <T> T[] check(T... elements) {
         T[] s = elements.clone();
@@ -35,12 +42,19 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
         return s;
     }
 
+    /**
+     * Skip brackets string.
+     *
+     * @param s the s
+     * @return the string
+     */
     static String skipBrackets(String s) {
         return s.length() < 2 ? "" : s.substring(1, s.length() - 1);
     }
 
     /**
      * Convert an AIS string to a Java string. I.e. convert '@' to space and remove leading and trailing spaces.
+     *
      * @param aisString the AIS string
      * @return the Java string
      */
@@ -50,8 +64,9 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Remove an optional pair of apostrophes around the string.
-     * @param string
-     * @return
+     *
+     * @param string the string
+     * @return string string
      */
     protected static final String preprocessExpressionString(String string) {
         String preprocessedString = string;
@@ -63,8 +78,9 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Remove an optional pair of apostrophes around each string in an array of strings.
-     * @param strings
-     * @return
+     *
+     * @param strings the strings
+     * @return string [ ]
      */
     protected static final String[] preprocessExpressionStrings(String[] strings) {
         String[] preprocessedStrings = new String[strings.length];
@@ -76,8 +92,9 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Lexically compare the left-hand side value to the right-hand side value using the specified operator.
-     * @param lhs the value of the left-hand side.
-     * @param rhs the value of the right-hand side.
+     *
+     * @param lhs      the value of the left-hand side.
+     * @param rhs      the value of the right-hand side.
      * @param operator the binary operator to apply for the comparison.
      * @return true if the left-hand side compares true to the right-hand side. False otherwise.
      */
@@ -105,8 +122,9 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Compare the left-hand side value to the right-hand side value using the specified operator.
-     * @param lhs the value of the left-hand side.
-     * @param rhs the value of the right-hand side.
+     *
+     * @param lhs      the value of the left-hand side.
+     * @param rhs      the value of the right-hand side.
      * @param operator the binary operator to apply for the comparison.
      * @return true if the left-hand side compares true to the right-hand side. False otherwise.
      */
@@ -131,8 +149,9 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Compare the left-hand side value to the right-hand side value using the specified operator.
-     * @param lhs the value of the left-hand side.
-     * @param rhs the value of the right-hand side.
+     *
+     * @param lhs      the value of the left-hand side.
+     * @param rhs      the value of the right-hand side.
      * @param operator the binary operator to apply for the comparison.
      * @return true if the left-hand side compares true to the right-hand side. False otherwise.
      */
@@ -157,10 +176,11 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Test if the integer value is in the closed range between min and max.
-     * @param min
-     * @param max
-     * @param value
-     * @return
+     *
+     * @param min   the min
+     * @param max   the max
+     * @param value the value
+     * @return boolean boolean
      */
     protected static final boolean inRange(int min, int max, int value) {
         return value >= min && value <= max;
@@ -168,10 +188,11 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Test if the floating point value is in the closed range between min and max.
-     * @param min
-     * @param max
-     * @param value
-     * @return
+     *
+     * @param min   the min
+     * @param max   the max
+     * @param value the value
+     * @return boolean boolean
      */
     protected static final boolean inRange(float min, float max, float value) {
         return value >= min && value <= max;
@@ -179,11 +200,12 @@ public abstract class AisPacketFiltersBase implements FilterPredicateFactory {
 
     /**
      * Test of the string representation of the supplied value matches the given glob expression.
-     * @see <a href="https://en.wikipedia.org/wiki/Glob_(programming)">Wikipedia on Glob expressions.</a>
-     * @param value
-     * @param glob
-     * @param <T>
+     *
+     * @param <T>   the type parameter
+     * @param value the value
+     * @param glob  the glob
      * @return true if the value matches the glob.
+     * @see <a href="https://en.wikipedia.org/wiki/Glob_(programming)">Wikipedia on Glob expressions.</a>
      */
     protected static final <T> boolean matchesGlob(T value, String glob) {
         return value.toString().matches(convertGlobToRegex(glob));

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersExpressionFilterParser.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersExpressionFilterParser.java
@@ -25,14 +25,25 @@ import org.antlr.v4.runtime.misc.NotNull;
 import java.util.Calendar;
 
 /**
+ * The type Ais packet filters expression filter parser.
+ *
  * @author Kasper Nielsen
  */
 class AisPacketFiltersExpressionFilterParser extends ExpressionFilterParserBase {
 
+    /**
+     * Parse expression filter predicate.
+     *
+     * @param filter the filter
+     * @return the predicate
+     */
     static Predicate<AisPacket> parseExpressionFilter(String filter) {
         return createFilterContext(filter).filterExpression().accept(new ExpressionFilterToPredicateVisitor());
     }
 
+    /**
+     * The type Expression filter to predicate visitor.
+     */
     static class ExpressionFilterToPredicateVisitor extends ExpressionFilterBaseVisitor<Predicate<AisPacket>> {
 
         @Override

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersStateful.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketFiltersStateful.java
@@ -30,16 +30,16 @@ import java.util.function.Predicate;
 import static java.util.Objects.requireNonNull;
 
 /**
- * This class provides factory methods to create Predicate<AisPacket> functions which can be used to filter AisPackets.
- *
+ * This class provides factory methods to create Predicate&lt;AisPacket&gt; functions which can be used to filter AisPackets.
+ * <p>
  * As opposed to the AisPacketFilters class, this class is designed to create predicates which "remember" some state of AisPackets
  * that have previously been served. This implies, that it is possible to establish more advanced filtering, than just inspecting
  * the current AisPacket.
- *
+ * <p>
  * Instead, with this stateful filter, it is possible to generate Predicates which can e.g. filter away AisStaticCommon packages for
  * targets whose position is outside some defined area.
  *
- * @author Thomas Borg Salling <tbsalling@tbsalling.dk>
+ * @author Thomas Borg Salling &lt;tbsalling@tbsalling.dk&gt;
  * @since v2.1
  */
 public class AisPacketFiltersStateful extends AisPacketFiltersBase {
@@ -47,6 +47,9 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
     private AisPacketStream aisPacketStream = new AisPacketStreamImpl();
     private TargetTracker targetTracker = new TargetTracker();
 
+    /**
+     * Instantiates a new Ais packet filters stateful.
+     */
     public AisPacketFiltersStateful() {
         targetTracker.subscribeToPacketStream(aisPacketStream);
     }
@@ -55,12 +58,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an IMO no. different to 'imo'.
-     * 
-     * @param operator
-     * @param rhsImo
-     * @return
+     *
+     * @param operator the operator
+     * @param rhsImo   the rhs imo
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetImo(final CompareToOperator operator, Integer rhsImo) {
         final int imo = rhsImo;
         return new Predicate<AisPacket>() {
@@ -79,8 +81,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an IMO outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetImo(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -98,8 +103,10 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an IMO outside the given list.
+     *
+     * @param imos the imos
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetImo(Integer[] imos) {
         final int[] list = ArrayUtils.toPrimitive(imos);
         Arrays.sort(list);
@@ -121,12 +128,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an IMO no. different to 'imo'.
-     * 
-     * @param operator
-     * @param rhsShiptype
-     * @return
+     *
+     * @param operator    the operator
+     * @param rhsShiptype the rhs shiptype
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetShiptype(final CompareToOperator operator, Integer rhsShiptype) {
         final int shiptype = rhsShiptype;
         return new Predicate<AisPacket>() {
@@ -145,8 +151,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an shiptype outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetShiptype(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -164,8 +173,10 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a ship type outside the given list.
+     *
+     * @param shiptypes the shiptypes
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetShiptype(Integer[] shiptypes) {
         final int[] list = ArrayUtils.toPrimitive(shiptypes);
         Arrays.sort(list);
@@ -187,12 +198,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with an navstat different to the rhs parameter.
-     * 
-     * @param operator
-     * @param rhsNavstat
-     * @return
+     *
+     * @param operator   the operator
+     * @param rhsNavstat the rhs navstat
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetNavigationalStatus(final CompareToOperator operator, Integer rhsNavstat) {
         final int navstat = rhsNavstat;
         return new Predicate<AisPacket>() {
@@ -211,8 +221,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a navstat outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetNavigationalStatus(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -230,8 +243,10 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a navstat outside the given list.
+     *
+     * @param navstats the navstats
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetNavigationalStatus(Integer[] navstats) {
         final int[] list = ArrayUtils.toPrimitive(navstats);
         Arrays.sort(list);
@@ -253,12 +268,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a SOG comparing false to 'sog'.
-     * 
-     * @param operator
-     * @param sog
-     * @return
+     *
+     * @param operator the operator
+     * @param sog      the sog
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetSpeedOverGround(final CompareToOperator operator, Float sog) {
         final float rhsSog = sog;
         return new Predicate<AisPacket>() {
@@ -277,8 +291,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a SOG outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetSpeedOverGround(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -298,12 +315,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a COG comparing false to 'cog'.
-     * 
-     * @param operator
-     * @param cog
-     * @return
+     *
+     * @param operator the operator
+     * @param cog      the cog
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetCourseOverGround(final CompareToOperator operator, Float cog) {
         final float rhsCog = cog;
         return new Predicate<AisPacket>() {
@@ -322,8 +338,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a COG outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetCourseOverGround(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -343,12 +362,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a COG comparing false to 'hdg'.
-     * 
-     * @param operator
-     * @param hdg
-     * @return
+     *
+     * @param operator the operator
+     * @param hdg      the hdg
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetTrueHeading(final CompareToOperator operator, Integer hdg) {
         final int rhsHdg = hdg;
         return new Predicate<AisPacket>() {
@@ -367,8 +385,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a COG outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetTrueHeading(final int min, final int max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -388,12 +409,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a draught comparing false to 'draught'.
-     * 
-     * @param operator
-     * @param draught
-     * @return
+     *
+     * @param operator the operator
+     * @param draught  the draught
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetDraught(final CompareToOperator operator, Float draught) {
         final float rhsDraught = draught;
         return new Predicate<AisPacket>() {
@@ -412,8 +432,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a draught outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetDraught(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -433,12 +456,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a latitude comparing false to 'lat'.
-     * 
-     * @param operator
-     * @param lat
-     * @return
+     *
+     * @param operator the operator
+     * @param lat      the lat
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetLatitude(final CompareToOperator operator, Float lat) {
         final float rhsLat = lat;
         return new Predicate<AisPacket>() {
@@ -457,8 +479,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a latitude outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetLatitude(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -478,12 +503,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a longitude comparing false to 'lon'.
-     * 
-     * @param operator
-     * @param lon
-     * @return
+     *
+     * @param operator the operator
+     * @param lon      the lon
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetLongitude(final CompareToOperator operator, Float lon) {
         final float rhsLon = lon;
         return new Predicate<AisPacket>() {
@@ -502,8 +526,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a longitude outside the given range.
+     *
+     * @param min the min
+     * @param max the max
+     * @return the predicate
      */
-
     public Predicate<AisPacket> filterOnTargetLongitude(final float min, final float max) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -523,10 +550,11 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a name not comparing to rhs parameter.
-     * 
-     * @return
+     *
+     * @param operator the operator
+     * @param rhsName  the rhs name
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetName(final CompareToOperator operator, final String rhsName) {
         return new Predicate<AisPacket>() {
             public boolean test(AisPacket p) {
@@ -544,10 +572,10 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a name not comparing to rhs parameter.
-     * 
-     * @return
+     *
+     * @param pattern the pattern
+     * @return predicate predicate
      */
-
     public Predicate<AisPacket> filterOnTargetNameMatch(final String pattern) {
         final String glob = preprocessExpressionString(pattern);
         return p -> {
@@ -562,8 +590,10 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a callsign not comparing to rhs parameter.
-     * 
-     * @return
+     *
+     * @param operator    the operator
+     * @param rhsCallsign the rhs callsign
+     * @return predicate predicate
      */
     public Predicate<AisPacket> filterOnTargetCallsign(final CompareToOperator operator, final String rhsCallsign) {
         return new Predicate<AisPacket>() {
@@ -582,8 +612,9 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
 
     /**
      * Return false if this message is known to be related to a target with a callsign not comparing to rhs parameter.
-     * 
-     * @return
+     *
+     * @param pattern the pattern
+     * @return predicate predicate
      */
     public Predicate<AisPacket> filterOnTargetCallsignMatch(final String pattern) {
         final String glob = preprocessExpressionString(pattern);
@@ -604,9 +635,8 @@ public class AisPacketFiltersStateful extends AisPacketFiltersBase {
     /**
      * Filter on message to have known position inside given area.
      *
-     * @param area
-     *            The area that the position must reside inside.
-     * @return
+     * @param area The area that the position must reside inside.
+     * @return predicate predicate
      */
     public Predicate<AisPacket> filterOnTargetPositionWithin(final Area area) {
         requireNonNull(area);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketKMLOutputSink.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketKMLOutputSink.java
@@ -61,9 +61,9 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * This class receives AisPacket and use them to build a scenario
- *
+ * <p>
  * When the sink is closed it dumps the entire target state to the output stream in KML format.
- *
+ * <p>
  * TODO Even though the triggerSnapshot predicate encourages generation of multiple snapshots, only one is currently
  * supported.
  *
@@ -92,13 +92,19 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
      */
     private final Predicate<? super AisPacket> filter;
 
-    /** Include the 'situation' folder in the generated KML */
+    /**
+     * Include the 'situation' folder in the generated KML
+     */
     final boolean createSituationFolder;
 
-    /** Include the 'movements' folder in the generated KML */
+    /**
+     * Include the 'movements' folder in the generated KML
+     */
     final boolean createMovementsFolder;
 
-    /** Include the 'tracks' folder in the generated KML */
+    /**
+     * Include the 'tracks' folder in the generated KML
+     */
     final boolean createTracksFolder;
 
     private final Predicate<? super AisPacket> isPrimaryTarget;
@@ -174,6 +180,9 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
      */
     private static final int KML_POSITION_TIMESPAN_SECS = 1;
 
+    /**
+     * Instantiates a new Ais packet kml output sink.
+     */
     public AisPacketKMLOutputSink() {
         this.filter = e -> true;
         this.createSituationFolder = true;
@@ -193,8 +202,7 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
      * Create a sink that writes KML contents to outputStream - but build the scenario only from AisPackets which comply
      * with the filter predicate.
      *
-     * @param filter
-     *            a filter predicate for pre-filtering of AisPackets.
+     * @param filter a filter predicate for pre-filtering of AisPackets.
      */
     public AisPacketKMLOutputSink(Predicate<? super AisPacket> filter) {
         this.filter = filter;
@@ -215,18 +223,16 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
      * Create a sink that writes KML contents to outputStream - but build the scenario only from AisPackets which comply
      * with the filter predicate.
      *
-     * @param filter
-     *            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
-     * @param createSituationFolder
-     *            create and populate the 'situation' folder in the generated KML
-     * @param createMovementsFolder
-     *            create and populate the 'movements' folder in the generated KML
-     * @param createTracksFolder
-     *            create and populate the 'tracks' folder in the generated KML
-     * @param isPrimaryTarget
-     *            Apply primary KML styling to targets which are updated by packets that pass this predicate.
-     * @param isSecondaryTarget
-     *            Apply secondary KML styling to targets which are updated by packets that pass this predicate.
+     * @param filter                            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
+     * @param createSituationFolder             create and populate the 'situation' folder in the generated KML
+     * @param createMovementsFolder             create and populate the 'movements' folder in the generated KML
+     * @param createTracksFolder                create and populate the 'tracks' folder in the generated KML
+     * @param isPrimaryTarget                   Apply primary KML styling to targets which are updated by packets that pass this predicate.
+     * @param isSecondaryTarget                 Apply secondary KML styling to targets which are updated by packets that pass this predicate.
+     * @param triggerSnapshot                   the trigger snapshot
+     * @param snapshotDescriptionSupplier       the snapshot description supplier
+     * @param movementInterpolationStepSupplier the movement interpolation step supplier
+     * @param iconHrefSupplier                  the icon href supplier
      */
     public AisPacketKMLOutputSink(Predicate<? super AisPacket> filter, boolean createSituationFolder,
             boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget,
@@ -254,22 +260,18 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
      * Create a sink that writes KML contents to outputStream - but build the scenario only from AisPackets which comply
      * with the filter predicate.
      *
-     * @param filter
-     *            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
-     * @param createSituationFolder
-     *            create and populate the 'situation' folder in the generated KML
-     * @param createMovementsFolder
-     *            create and populate the 'movements' folder in the generated KML
-     * @param createTracksFolder
-     *            create and populate the 'tracks' folder in the generated KML
-     * @param isPrimaryTarget
-     *            Apply primary KML styling to targets which are updated by packets that pass this predicate.
-     * @param isSecondaryTarget
-     *            Apply secondary KML styling to targets which are updated by packets that pass this predicate.
-     * @param supplyTitle
-     *            Supplier of KML folder title
-     * @param supplyDescription
-     *            Supplier of KML folder description
+     * @param filter                            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
+     * @param createSituationFolder             create and populate the 'situation' folder in the generated KML
+     * @param createMovementsFolder             create and populate the 'movements' folder in the generated KML
+     * @param createTracksFolder                create and populate the 'tracks' folder in the generated KML
+     * @param isPrimaryTarget                   Apply primary KML styling to targets which are updated by packets that pass this predicate.
+     * @param isSecondaryTarget                 Apply secondary KML styling to targets which are updated by packets that pass this predicate.
+     * @param triggerSnapshot                   the trigger snapshot
+     * @param snapshotDescriptionSupplier       the snapshot description supplier
+     * @param movementInterpolationStepSupplier the movement interpolation step supplier
+     * @param supplyTitle                       Supplier of KML folder title
+     * @param supplyDescription                 Supplier of KML folder description
+     * @param iconHrefSupplier                  the icon href supplier
      */
     public AisPacketKMLOutputSink(Predicate<? super AisPacket> filter, boolean createSituationFolder,
             boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget,
@@ -320,6 +322,12 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
         kml.marshal(outputStream);
     }
 
+    /**
+     * The entry point of application.
+     *
+     * @param args the input arguments
+     * @throws IOException the io exception
+     */
     public static void main(String[] args) throws IOException {
         Predicate<AisPacket> filter = new Predicate<AisPacket>() {
             @Override
@@ -377,6 +385,12 @@ class AisPacketKMLOutputSink extends OutputStreamSink<AisPacket> {
         }
     };
 
+    /**
+     * Create kml kml.
+     *
+     * @return the kml
+     * @throws IOException the io exception
+     */
     protected Kml createKml() throws IOException {
         Kml kml = new Kml();
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketKMZOutputSink.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketKMZOutputSink.java
@@ -32,12 +32,15 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * This class receives AisPacket and use them to build a scenario for replay in Google Earth.
- *
+ * <p>
  * When the sink is closed it dumps the entire target state to the output stream in KMZ format.
  */
 @NotThreadSafe
 class AisPacketKMZOutputSink extends AisPacketKMLOutputSink {
 
+    /**
+     * Instantiates a new Ais packet kmz output sink.
+     */
     public AisPacketKMZOutputSink() {
         super();
     }
@@ -56,12 +59,16 @@ class AisPacketKMZOutputSink extends AisPacketKMLOutputSink {
      * Create a sink that writes KMZ contents to outputStream - but build the scenario only from
      * AisPackets which comply with the filter predicate.
      *
-     * @param filter a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
-     * @param createSituationFolder create and populate the 'situation' folder in the generated KML
-     * @param createMovementsFolder create and populate the 'movements' folder in the generated KML
-     * @param createTracksFolder create and populate the 'tracks' folder in the generated KML
-     * @param isPrimaryTarget Apply primary KMZ styling to targets which are updated by packets that pass this predicate.
-     * @param isSecondaryTarget Apply secondary KMZ styling to targets which are updated by packets that pass this predicate.
+     * @param filter                            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
+     * @param createSituationFolder             create and populate the 'situation' folder in the generated KML
+     * @param createMovementsFolder             create and populate the 'movements' folder in the generated KML
+     * @param createTracksFolder                create and populate the 'tracks' folder in the generated KML
+     * @param isPrimaryTarget                   Apply primary KMZ styling to targets which are updated by packets that pass this predicate.
+     * @param isSecondaryTarget                 Apply secondary KMZ styling to targets which are updated by packets that pass this predicate.
+     * @param triggerSnapshot                   the trigger snapshot
+     * @param snapshotDescriptionSupplier       the snapshot description supplier
+     * @param movementInterpolationStepSupplier the movement interpolation step supplier
+     * @param iconHrefSupplier                  the icon href supplier
      */
     public AisPacketKMZOutputSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStepSupplier, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         super(filter,
@@ -81,14 +88,18 @@ class AisPacketKMZOutputSink extends AisPacketKMLOutputSink {
      * Create a sink that writes KMZ contents to outputStream - but build the scenario only from
      * AisPackets which comply with the filter predicate.
      *
-     * @param filter a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
-     * @param createSituationFolder create and populate the 'situation' folder in the generated KML
-     * @param createMovementsFolder create and populate the 'movements' folder in the generated KML
-     * @param createTracksFolder create and populate the 'tracks' folder in the generated KML
-     * @param isPrimaryTarget Apply primary KMZ styling to targets which are updated by packets that pass this predicate.
-     * @param isSecondaryTarget Apply secondary KMZ styling to targets which are updated by packets that pass this predicate.
-     * @param supplyTitle Supplier of KMZ folder title
-     * @param supplyDescription Supplier of KMZ folder description
+     * @param filter                            a filter predicate for pre-filtering of AisPackets before they are passed to the tracker.
+     * @param createSituationFolder             create and populate the 'situation' folder in the generated KML
+     * @param createMovementsFolder             create and populate the 'movements' folder in the generated KML
+     * @param createTracksFolder                create and populate the 'tracks' folder in the generated KML
+     * @param isPrimaryTarget                   Apply primary KMZ styling to targets which are updated by packets that pass this predicate.
+     * @param isSecondaryTarget                 Apply secondary KMZ styling to targets which are updated by packets that pass this predicate.
+     * @param triggerSnapshot                   the trigger snapshot
+     * @param snapshotDescriptionSupplier       the snapshot description supplier
+     * @param movementInterpolationStepSupplier the movement interpolation step supplier
+     * @param supplyTitle                       Supplier of KMZ folder title
+     * @param supplyDescription                 Supplier of KMZ folder description
+     * @param iconHrefSupplier                  the icon href supplier
      */
     public AisPacketKMZOutputSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStepSupplier, Supplier<? extends String> supplyTitle, Supplier<? extends String> supplyDescription, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         super(filter,
@@ -148,6 +159,12 @@ class AisPacketKMZOutputSink extends AisPacketKMLOutputSink {
         }
     }
 
+    /**
+     * The entry point of application.
+     *
+     * @param args the input arguments
+     * @throws IOException the io exception
+     */
     public static void main(String[] args) throws IOException {
         byte[] bytes = Files.toByteArray(new File("/Users/tbsalling/tmp/img/vessel_blue.png"));
         //byte[] bytes = Files.toByteArray(new File("/Users/tbsalling/tmp/img/vessel_blue_moored.png"));

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinkJsonObject.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinkJsonObject.java
@@ -33,28 +33,46 @@ import dk.dma.enav.model.geometry.Position;
 
 /**
  * Transform AisPackets into json objects with only specific columns
- * @author Jens Tuxen
  *
+ * @author Jens Tuxen
  */
 public class AisPacketOutputSinkJsonObject extends OutputStreamSink<AisPacket> {
     
     /** The column we are writing. */
     private final String[] columns;
-    
+
+    /**
+     * The Separator.
+     */
     final byte[] separator;
     
     private DecimalFormat df = new DecimalFormat("###.#####");
     
     private boolean first = true;
-    
+
+    /**
+     * The constant ALLCOLUMNS.
+     */
     public static final String ALLCOLUMNS = "mmsi;timestamp;lat;lon;sog;cog;name;dimBow;dimPort;dimStarboard;dimStern;shipType;shipCargo;callsign;targetType";
 
     private String objectName;
-    
+
+    /**
+     * Instantiates a new Ais packet output sink json object.
+     *
+     * @param format the format
+     */
     public AisPacketOutputSinkJsonObject(String format) {
         this(format,";","data");
     }
-    
+
+    /**
+     * Instantiates a new Ais packet output sink json object.
+     *
+     * @param format     the format
+     * @param separator  the separator
+     * @param objectName the object name
+     */
     public AisPacketOutputSinkJsonObject(String format, String separator, String objectName) {
        columns = format.split(separator);
        this.objectName = objectName;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinkTable.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinkTable.java
@@ -42,7 +42,8 @@ import dk.dma.ais.message.IPositionMessage;
 import dk.dma.commons.util.io.OutputStreamSink;
 
 /**
- * 
+ * The type Ais packet output sink table.
+ *
  * @author Kasper Nielsen
  */
 class AisPacketOutputSinkTable extends OutputStreamSink<AisPacket> {
@@ -64,14 +65,33 @@ class AisPacketOutputSinkTable extends OutputStreamSink<AisPacket> {
             .appendMonthOfYear(2).appendLiteral('-').appendYear(2, 2).appendLiteral(' ').appendHourOfDay(2)
             .appendLiteral(':').appendMinuteOfHour(2).appendLiteral(':').appendSecondOfMinute(2).toFormatter();
 
+    /**
+     * The Separator.
+     */
     final byte[] separator;
 
+    /**
+     * The Write header.
+     */
     final boolean writeHeader;
 
+    /**
+     * Instantiates a new Ais packet output sink table.
+     *
+     * @param format      the format
+     * @param writeHeader the write header
+     */
     public AisPacketOutputSinkTable(String format, boolean writeHeader) {
         this(format, writeHeader, ";");
     }
 
+    /**
+     * Instantiates a new Ais packet output sink table.
+     *
+     * @param format      the format
+     * @param writeHeader the write header
+     * @param separator   the separator
+     */
     public AisPacketOutputSinkTable(String format, boolean writeHeader, String separator) {
         columns = format.split(";");
         this.writeHeader = writeHeader;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinks.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketOutputSinks.java
@@ -47,20 +47,27 @@ import static dk.dma.commons.util.io.IoUtil.writeAscii;
  */
 public class AisPacketOutputSinks {
 
-    /** A thread local with a default text format. */
+    /**
+     * A thread local with a default text format.
+     */
     static final ThreadLocal<SimpleDateFormat> DEFAULT_DATE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
         protected SimpleDateFormat initialValue() {
             return new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
         }
     };
 
+    /**
+     * The Position formatter.
+     */
     static final ThreadLocal<DecimalFormat> POSITION_FORMATTER = new ThreadLocal<DecimalFormat>() {
         protected DecimalFormat initialValue() {
             return new DecimalFormat("###.#####");
         }
     };
 
-    /** A sink that writes an ais packet to an output stream. Using the default multi-line format. */
+    /**
+     * A sink that writes an ais packet to an output stream. Using the default multi-line format.
+     */
     public static final OutputStreamSink<AisPacket> OUTPUT_TO_TEXT = new OutputStreamSink<AisPacket>() {
         @Override
         public void process(OutputStream stream, AisPacket message, long count) throws IOException {
@@ -114,9 +121,11 @@ public class AisPacketOutputSinks {
             stream.write("{\"track\": {".getBytes(StandardCharsets.US_ASCII));
         }
     };
-    
+
     /**
      * A sink that writes ais messages as JSON to an output stream. Each Line is a valid json object.
+     *
+     * @return the output stream sink
      */
     public static OutputStreamSink<AisPacket> jsonMessageSink() {
         return new OutputStreamSink<AisPacket>() {
@@ -189,20 +198,38 @@ public class AisPacketOutputSinks {
             }
         };
     }
-    
+
+    /**
+     * Json object sink output stream sink.
+     *
+     * @param format the format
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> jsonObjectSink(String format) {
         return new AisPacketOutputSinkJsonObject(format);
     }
-        
+
+    /**
+     * Json pos list sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> jsonPosListSink() {
         return new AisPacketOutputSinkJsonObject("mmsi;timestamp;lat;lon;sog;cog",";","dynamic");
     }
-    
+
+    /**
+     * Json static list sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> jsonStaticListSink() {
         return new AisPacketOutputSinkJsonObject("mmsi;name;dimBow;dimPort;dimStarboard;dimStern;shipType;shipCargo;callsign;timestamp;targetType",";","static");
     }
 
-    /** A sink that writes an AIS packet to an output stream. Printing only the actual sentence . */
+    /**
+     * A sink that writes an AIS packet to an output stream. Printing only the actual sentence .
+     */
     public static final OutputStreamSink<AisPacket> OUTPUT_PREFIXED_SENTENCES = new OutputStreamSink<AisPacket>() {
 
         @Override
@@ -219,7 +246,9 @@ public class AisPacketOutputSinks {
         }
     };
 
-    /** A sink that writes an AIS packet to an output stream. Using the default multi-line format. */
+    /**
+     * A sink that writes an AIS packet to an output stream. Using the default multi-line format.
+     */
     public static final OutputStreamSink<AisPacket> OUTPUT_TO_HTML = new OutputStreamSink<AisPacket>() {
         @Override
         public void process(OutputStream stream, AisPacket message, long count) throws IOException {
@@ -234,24 +263,24 @@ public class AisPacketOutputSinks {
             }
         }
     };
-    
-    /** A sink that transforms ais stream into kml. */
+
+    /**
+     * A sink that transforms ais stream into kml.  @return the output stream sink
+     *
+     * @return the output stream sink
+     */
     public static final OutputStreamSink<AisPacket> OUTPUT_TO_KML() {
         return new AisPacketKMLOutputSink();
     };
-    
-    
+
 
     /**
      * Filters a list of packets according to their timestamp.
      *
-     * @param packets
-     *            a list of packets
-     * @param start
-     *            inclusive start
-     * @param end
-     *            exclusive end
-     * @return
+     * @param packets a list of packets
+     * @param start   inclusive start
+     * @param end     exclusive end
+     * @return list list
      */
     static List<AisPacket> filterPacketsByTime(Iterable<AisPacket> packets, long start, long end) {
         ArrayList<AisPacket> result = new ArrayList<>();
@@ -263,7 +292,14 @@ public class AisPacketOutputSinks {
         return result;
     }
 
-    // currently unused
+    /**
+     * Read from file list.
+     *
+     * @param p the p
+     * @return the list
+     * @throws IOException the io exception
+     */
+// currently unused
     static List<AisPacket> readFromFile(Path p) throws IOException {
         final ConcurrentLinkedQueue<AisPacket> list = new ConcurrentLinkedQueue<>();
         AisPacket packet;
@@ -275,63 +311,196 @@ public class AisPacketOutputSinks {
         return new ArrayList<>(list);
     }
 
+    /**
+     * New table sink output stream sink.
+     *
+     * @param columns     the columns
+     * @param writeHeader the write header
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newTableSink(String columns, boolean writeHeader) {
         return new AisPacketOutputSinkTable(columns, writeHeader);
     }
 
+    /**
+     * New table sink output stream sink.
+     *
+     * @param columns     the columns
+     * @param writeHeader the write header
+     * @param seperator   the seperator
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newTableSink(String columns, boolean writeHeader, String seperator) {
         return new AisPacketOutputSinkTable(columns, writeHeader, seperator);
     }
 
+    /**
+     * New csv sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newCsvSink() {
         return new AisPacketCSVOutputSink();
     }
 
+    /**
+     * New csv sink output stream sink.
+     *
+     * @param format the format
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newCsvSink(String format) {
         return new AisPacketCSVOutputSink(format);
     }
 
+    /**
+     * New csv stateful sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newCsvStatefulSink() {
         return new AisPacketCSVStatefulOutputSink();
     }
 
+    /**
+     * New csv stateful sink output stream sink.
+     *
+     * @param format the format
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newCsvStatefulSink(String format) {
         return new AisPacketCSVStatefulOutputSink(format);
     }
 
+    /**
+     * New kml sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmlSink() {
         return new AisPacketKMLOutputSink();
     }
 
+    /**
+     * New kml sink output stream sink.
+     *
+     * @param filter the filter
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmlSink(Predicate<? super AisPacket> filter) {
         return new AisPacketKMLOutputSink(filter);
     }
 
+    /**
+     * New kml sink output stream sink.
+     *
+     * @param filter                      the filter
+     * @param createSituationFolder       the create situation folder
+     * @param createMovementsFolder       the create movements folder
+     * @param createTracksFolder          the create tracks folder
+     * @param isPrimaryTarget             the is primary target
+     * @param isSecondaryTarget           the is secondary target
+     * @param triggerSnapshot             the trigger snapshot
+     * @param snapshotDescriptionSupplier the snapshot description supplier
+     * @param movementInterpolationStep   the movement interpolation step
+     * @param iconHrefSupplier            the icon href supplier
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmlSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStep, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         return new AisPacketKMLOutputSink(filter, createSituationFolder, createMovementsFolder, createTracksFolder, isPrimaryTarget, isSecondaryTarget, triggerSnapshot, snapshotDescriptionSupplier, movementInterpolationStep, iconHrefSupplier);
     }
 
+    /**
+     * New kml sink output stream sink.
+     *
+     * @param filter                      the filter
+     * @param createSituationFolder       the create situation folder
+     * @param createMovementsFolder       the create movements folder
+     * @param createTracksFolder          the create tracks folder
+     * @param isPrimaryTarget             the is primary target
+     * @param isSecondaryTarget           the is secondary target
+     * @param triggerSnapshot             the trigger snapshot
+     * @param snapshotDescriptionSupplier the snapshot description supplier
+     * @param movementInterpolationStep   the movement interpolation step
+     * @param supplyTitle                 the supply title
+     * @param supplyDescription           the supply description
+     * @param iconHrefSupplier            the icon href supplier
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmlSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStep, Supplier<? extends String> supplyTitle, Supplier<? extends String> supplyDescription, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         return new AisPacketKMLOutputSink(filter, createSituationFolder, createMovementsFolder, createTracksFolder, isPrimaryTarget, isSecondaryTarget, triggerSnapshot, snapshotDescriptionSupplier, movementInterpolationStep, supplyTitle, supplyDescription, iconHrefSupplier);
     }
 
+    /**
+     * New kmz sink output stream sink.
+     *
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmzSink() {
         return new AisPacketKMZOutputSink();
     }
 
+    /**
+     * New kmz sink output stream sink.
+     *
+     * @param filter the filter
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmzSink(Predicate<? super AisPacket> filter) {
         return new AisPacketKMZOutputSink(filter);
     }
 
+    /**
+     * New kmz sink output stream sink.
+     *
+     * @param filter                      the filter
+     * @param createSituationFolder       the create situation folder
+     * @param createMovementsFolder       the create movements folder
+     * @param createTracksFolder          the create tracks folder
+     * @param isPrimaryTarget             the is primary target
+     * @param isSecondaryTarget           the is secondary target
+     * @param triggerSnapshot             the trigger snapshot
+     * @param snapshotDescriptionSupplier the snapshot description supplier
+     * @param movementInterpolationStep   the movement interpolation step
+     * @param iconHrefSupplier            the icon href supplier
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmzSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStep, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         return new AisPacketKMZOutputSink(filter, createSituationFolder, createMovementsFolder, createTracksFolder, isPrimaryTarget, isSecondaryTarget, triggerSnapshot, snapshotDescriptionSupplier, movementInterpolationStep, iconHrefSupplier);
     }
 
+    /**
+     * New kmz sink output stream sink.
+     *
+     * @param filter                      the filter
+     * @param createSituationFolder       the create situation folder
+     * @param createMovementsFolder       the create movements folder
+     * @param createTracksFolder          the create tracks folder
+     * @param isPrimaryTarget             the is primary target
+     * @param isSecondaryTarget           the is secondary target
+     * @param triggerSnapshot             the trigger snapshot
+     * @param snapshotDescriptionSupplier the snapshot description supplier
+     * @param movementInterpolationStep   the movement interpolation step
+     * @param supplyTitle                 the supply title
+     * @param supplyDescription           the supply description
+     * @param iconHrefSupplier            the icon href supplier
+     * @return the output stream sink
+     */
     public static OutputStreamSink<AisPacket> newKmzSink(Predicate<? super AisPacket> filter, boolean createSituationFolder, boolean createMovementsFolder, boolean createTracksFolder, Predicate<? super AisPacket> isPrimaryTarget, Predicate<? super AisPacket> isSecondaryTarget, Predicate<? super AisPacket> triggerSnapshot, Supplier<? extends String> snapshotDescriptionSupplier, Supplier<? extends Integer> movementInterpolationStep, Supplier<? extends String> supplyTitle, Supplier<? extends String> supplyDescription, BiFunction<? super ShipTypeCargo, ? super NavigationalStatus, ? extends String> iconHrefSupplier) {
         return new AisPacketKMZOutputSink(filter, createSituationFolder, createMovementsFolder, createTracksFolder, isPrimaryTarget, isSecondaryTarget, triggerSnapshot, snapshotDescriptionSupplier, movementInterpolationStep, supplyTitle, supplyDescription, iconHrefSupplier);
     }
-    
 
+
+    /**
+     * Gets output sink.
+     *
+     * @param params the params
+     * @return the output sink
+     * @throws IllegalArgumentException the illegal argument exception
+     * @throws IllegalAccessException   the illegal access exception
+     * @throws NoSuchFieldException     the no such field exception
+     * @throws SecurityException        the security exception
+     */
     @SuppressWarnings("unchecked")
     public static OutputStreamSink<AisPacket> getOutputSink(String...params) throws IllegalArgumentException, IllegalAccessException,
             NoSuchFieldException, SecurityException {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketParser.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketParser.java
@@ -57,6 +57,9 @@ public class AisPacketParser {
      */
     private SentenceLine sentenceLine = new SentenceLine();
 
+    /**
+     * New vdm.
+     */
     void newVdm() {
         vdm = new Vdm();
         tags.clear();
@@ -65,10 +68,10 @@ public class AisPacketParser {
 
     /**
      * Handle a single line. If a complete packet is assembled the package will be returned. Otherwise null is returned.
-     * 
-     * @param line
-     * @return
-     * @throws SentenceException
+     *
+     * @param line the line
+     * @return ais packet
+     * @throws SentenceException the sentence exception
      */
     public AisPacket readLine(String line) throws SentenceException {
         return readLine(line, false);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketReader.java
@@ -51,28 +51,38 @@ import static java.util.Objects.requireNonNull;
  */
 public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
 
-    /** The logger */
+    /**
+     * The logger
+     */
     static final Logger LOG = LoggerFactory.getLogger(AisPacketReader.class);
 
     /** The number of bytes read by this instance. */
     private final AtomicLong bytesRead = new AtomicLong();
 
-    /** Whether or not this reader has been closed. */
+    /**
+     * Whether or not this reader has been closed.
+     */
     volatile boolean closed;
 
     /** The number of lines read by this instance. */
     private final AtomicLong linesRead = new AtomicLong();
 
-    /** Reader to parse lines and deliver complete AIS packets. */
+    /**
+     * Reader to parse lines and deliver complete AIS packets.
+     */
     protected final AisPacketParser packetReader = new AisPacketParser();
 
     /** The number of packets read by this instance. */
     private final AtomicLong packetsRead = new AtomicLong();
 
-    /** The wrapped reader. */
+    /**
+     * The wrapped reader.
+     */
     final BufferedReader reader;
 
-    /** The wrapped input stream. */
+    /**
+     * The wrapped input stream.
+     */
     final InputStream stream;
 
     /**
@@ -84,13 +94,18 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
     /**
      * Create
      *
-     * @param stream
-     *            the input stream to read data from
+     * @param stream the input stream to read data from
      */
     public AisPacketReader(InputStream stream) {
         this(stream, false);
     }
 
+    /**
+     * Instantiates a new Ais packet reader.
+     *
+     * @param stream    the stream
+     * @param errorFree the error free
+     */
     AisPacketReader(InputStream stream, boolean errorFree) {
         this.stream = requireNonNull(stream);
         this.reader = new BufferedReader(new InputStreamReader(new CountingInputStream(stream, bytesRead),
@@ -133,8 +148,7 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
     /**
      * Override this method to handle {@link Abk} sentences.
      *
-     * @param abk
-     *            the sentence to handle
+     * @param abk the sentence to handle
      */
     protected void handleAbk(Abk abk) {}
 
@@ -184,6 +198,12 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
         }
     }
 
+    /**
+     * For each remaining.
+     *
+     * @param consumers the consumers
+     * @throws IOException the io exception
+     */
     @SafeVarargs
     public final void forEachRemaining(Consumer<? super AisPacket>... consumers) throws IOException {
         requireNonNull(consumers);
@@ -195,6 +215,12 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
         }
     }
 
+    /**
+     * For each remaining message.
+     *
+     * @param consumers the consumers
+     * @throws IOException the io exception
+     */
     @SafeVarargs
     public final void forEachRemainingMessage(Consumer<? super AisMessage>... consumers) throws IOException {
         requireNonNull(consumers);
@@ -210,9 +236,10 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
     }
 
     /**
+     * Read packet ais packet.
+     *
      * @return the next packet or null if the end of the stream has been reached
-     * @throws IOException
-     *             if an exception occurred while reading the packet
+     * @throws IOException if an exception occurred while reading the packet
      */
     public AisPacket readPacket() throws IOException {
         return readPacket0();
@@ -220,6 +247,9 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
 
     /**
      * Reads the next AisPacket
+     *
+     * @return the ais packet
+     * @throws IOException the io exception
      */
     AisPacket readPacket0() throws IOException {
         for (String line = reader.readLine(); line != null; line = reader.readLine()) {
@@ -247,6 +277,7 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
     /**
      * Returns a AIS packet stream using the specified executor.
      *
+     * @param e the e
      * @return a AIS packet stream using the specified executor
      */
     public AisPacketStream stream(Executor e) {
@@ -265,6 +296,14 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
         return s.immutableStream();
     }
 
+    /**
+     * Create from system resource ais packet reader.
+     *
+     * @param resourceName    the resource name
+     * @param throwExceptions the throw exceptions
+     * @return the ais packet reader
+     * @throws IOException the io exception
+     */
     public static AisPacketReader createFromSystemResource(String resourceName, boolean throwExceptions)
             throws IOException {
         URL url = ClassLoader.getSystemResource(resourceName);
@@ -280,13 +319,10 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
      * Creates a new AIS packet reader from the specified file. If the specified file has a '.zip' suffix. The file is
      * automatically treated as a zip file.
      *
-     * @param p
-     *            the path of the file
-     * @param throwExceptions
-     *            whether to throw exceptions or just log them
+     * @param p               the path of the file
+     * @param throwExceptions whether to throw exceptions or just log them
      * @return a new reader
-     * @throws IOException
-     *             if the reader failed to be constructed, for example, if the specified file does not exist
+     * @throws IOException if the reader failed to be constructed, for example, if the specified file does not exist
      */
     public static AisPacketReader createFromFile(Path p, boolean throwExceptions) throws IOException {
         InputStream is = Files.newInputStream(p);
@@ -324,12 +360,9 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
     /**
      * Writes the reminder of packets to the output stream using the specified sink
      *
-     * @param os
-     *            the output stream to write to
-     * @param sink
-     *            the sink to write to
-     * @throws IOException
-     *             if the a packet could not be written
+     * @param os   the output stream to write to
+     * @param sink the sink to write to
+     * @throws IOException if the a packet could not be written
      */
     public void writeTo(OutputStream os, OutputStreamSink<AisPacket> sink) throws IOException {
         sink.header(os);
@@ -349,6 +382,9 @@ public class AisPacketReader implements AutoCloseable, Iterable<AisPacket> {
         return new IteratorImpl();
     }
 
+    /**
+     * The type Iterator.
+     */
     class IteratorImpl extends AbstractIterator<AisPacket> {
 
         /** {@inheritDoc} */

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSource.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSource.java
@@ -22,7 +22,8 @@ import java.io.Serializable;
 import java.util.function.Predicate;
 
 /**
- * 
+ * The type Ais packet source.
+ *
  * @author Kasper Nielsen
  */
 public class AisPacketSource implements Serializable {
@@ -48,6 +49,15 @@ public class AisPacketSource implements Serializable {
     /** Source type (comment block key: 'st', value: SAT | LIVE) */
     private final SourceType sourceType;
 
+    /**
+     * Instantiates a new Ais packet source.
+     *
+     * @param sourceId          the source id
+     * @param sourceBaseStation the source base station
+     * @param sourceCountry     the source country
+     * @param sourceType        the source type
+     * @param sourceRegion      the source region
+     */
     AisPacketSource(String sourceId, Integer sourceBaseStation, Country sourceCountry, SourceType sourceType,
             String sourceRegion) {
         if (sourceBaseStation != null && sourceBaseStation.intValue() < 0) {
@@ -61,7 +71,11 @@ public class AisPacketSource implements Serializable {
         this.hash = calcHash();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc} @return the int
+     *
+     * @return the int
+     */
     int calcHash() {
         final int prime = 31;
         int result = 1;
@@ -120,12 +134,18 @@ public class AisPacketSource implements Serializable {
         return true;
     }
 
-    /** Returns the base station source. */
+    /**
+     * Returns the base station source.  @return the source base station
+     *
+     * @return the source base station
+     */
     public Integer getSourceBaseStation() {
         return sourceBaseStation;
     }
 
     /**
+     * Gets source country.
+     *
      * @return the sourceCountry
      */
     public Country getSourceCountry() {
@@ -133,6 +153,8 @@ public class AisPacketSource implements Serializable {
     }
 
     /**
+     * Gets source id.
+     *
      * @return the sourceId
      */
     public String getSourceId() {
@@ -140,6 +162,8 @@ public class AisPacketSource implements Serializable {
     }
 
     /**
+     * Gets source region.
+     *
      * @return the sourceRegion
      */
     public String getSourceRegion() {
@@ -147,6 +171,8 @@ public class AisPacketSource implements Serializable {
     }
 
     /**
+     * Gets source type.
+     *
      * @return the sourceType
      */
     public SourceType getSourceType() {
@@ -168,6 +194,12 @@ public class AisPacketSource implements Serializable {
                 + ", sourceRegion=" + sourceRegion + ", sourceType=" + sourceType + "]";
     }
 
+    /**
+     * Create ais packet source.
+     *
+     * @param packet the packet
+     * @return the ais packet source
+     */
     public static AisPacketSource create(AisPacket packet) {
         AisPacketTags tags = packet.getTags();
         Integer sourceBaseStation = tags.getSourceBs();
@@ -181,6 +213,12 @@ public class AisPacketSource implements Serializable {
         return new AisPacketSource(sourceId, sourceBaseStation, sourceCountry, sourceType, region);
     }
 
+    /**
+     * Create predicate predicate.
+     *
+     * @param expression the expression
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> createPredicate(String expression) {
         return AisPacketSourceFilters.parseSourceFilter(expression);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSourceFilters.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSourceFilters.java
@@ -24,10 +24,19 @@ import java.util.function.Predicate;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * The type Ais packet source filters.
+ *
  * @author Kasper Nielsen
  */
 public class AisPacketSourceFilters implements FilterPredicateFactory {
 
+    /**
+     * Check t [ ].
+     *
+     * @param <T>      the type parameter
+     * @param elements the elements
+     * @return the t [ ]
+     */
     @SafeVarargs
     static <T> T[] check(T... elements) {
         T[] s = elements.clone();
@@ -41,6 +50,13 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         return s;
     }
 
+    /**
+     * Filter on source basestation predicate.
+     *
+     * @param operator the operator
+     * @param bs       the bs
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> filterOnSourceBasestation(final CompareToOperator operator, final Integer bs) {
         return new Predicate<AisPacketSource>() {
             public boolean test(AisPacketSource p) {
@@ -53,6 +69,12 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         };
     }
 
+    /**
+     * Filter on source basestation predicate.
+     *
+     * @param ids the ids
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> filterOnSourceBasestation(Integer... ids) {
         final Integer[] copy = ids.clone();
         Arrays.sort(copy);
@@ -70,12 +92,10 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
 
     /**
      * Returns a predicate that will filter packets based on the country of the source tag.
-     * 
-     * @param countries
-     *            the countries for which packets should be accepted
+     *
+     * @param countries the countries for which packets should be accepted
      * @return the predicate
      */
-
     public static Predicate<AisPacketSource> filterOnSourceCountry(final Country... countries) {
         final Country[] c = check(countries);
         return new Predicate<AisPacketSource>() {
@@ -90,6 +110,12 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         };
     }
 
+    /**
+     * Filter on source id predicate.
+     *
+     * @param ids the ids
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> filterOnSourceId(final String... ids) {
         final String[] s = check(ids);
         return new Predicate<AisPacketSource>() {
@@ -104,6 +130,12 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         };
     }
 
+    /**
+     * Filter on source region predicate.
+     *
+     * @param regions the regions
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> filterOnSourceRegion(final String... regions) {
         final String[] s = check(regions);
         requireNonNull(regions, "regions is null");
@@ -119,6 +151,12 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         };
     }
 
+    /**
+     * Filter on source type predicate.
+     *
+     * @param sourceType the source type
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> filterOnSourceType(final SourceType... sourceType) {
         requireNonNull(sourceType, "sourceType is null");
         final ImmutableSet<SourceType> sourceTypes = ImmutableSet.copyOf(sourceType);
@@ -133,10 +171,22 @@ public class AisPacketSourceFilters implements FilterPredicateFactory {
         };
     }
 
+    /**
+     * Parse source filter predicate.
+     *
+     * @param filter the filter
+     * @return the predicate
+     */
     public static Predicate<AisPacketSource> parseSourceFilter(String filter) {
         return AisPacketSourceFiltersParser.parseSourceFilter(filter);
     }
 
+    /**
+     * Skip brackets string.
+     *
+     * @param s the s
+     * @return the string
+     */
     static String skipBrackets(String s) {
         return s.length() < 2 ? "" : s.substring(1, s.length() - 1);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSourceFiltersParser.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketSourceFiltersParser.java
@@ -22,13 +22,24 @@ import dk.dma.internal.ais.generated.parser.expressionfilter.ExpressionFilterPar
 import org.antlr.v4.runtime.misc.NotNull;
 
 /**
+ * The type Ais packet source filters parser.
+ *
  * @author Kasper Nielsen
  */
 class AisPacketSourceFiltersParser extends ExpressionFilterParserBase {
+    /**
+     * Parse source filter predicate.
+     *
+     * @param filter the filter
+     * @return the predicate
+     */
     static Predicate<AisPacketSource> parseSourceFilter(String filter) {
         return createFilterContext(filter).filterExpression().accept(new SourceFilterToPredicateVisitor());
     }
 
+    /**
+     * The type Source filter to predicate visitor.
+     */
     static class SourceFilterToPredicateVisitor extends ExpressionFilterBaseVisitor<Predicate<AisPacketSource>> {
 
         @Override

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketStream.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketStream.java
@@ -28,21 +28,21 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A stream of packets.
- * 
+ *
  * @author Kasper Nielsen
  */
 public abstract class AisPacketStream {
 
-    /** Thrown by a subscriber to indicate that the subscription should be cancelled. */
+    /**
+     * Thrown by a subscriber to indicate that the subscription should be cancelled.
+     */
     public static final RuntimeException CANCEL = new RuntimeException();
 
     /**
      * Adds the specified packet to the stream
-     * 
-     * @param packet
-     *            the packet to add
-     * @throws UnsupportedOperationException
-     *             if the stream is immutable
+     *
+     * @param p the p
+     * @throws UnsupportedOperationException if the stream is immutable
      */
     public void add(AisPacket p) {
         throw new UnsupportedOperationException("Stream is immutable");// default stream is immutable.
@@ -50,25 +50,47 @@ public abstract class AisPacketStream {
 
     /**
      * Returns a new stream that only streams packets accepted by the specified predicate.
-     * 
-     * @param predicate
-     *            the predicate to test against each element
+     *
+     * @param predicate the predicate to test against each element
      * @return the new stream
      */
     public abstract AisPacketStream filter(Predicate<? super AisPacket> predicate);
 
+    /**
+     * Filter ais packet stream.
+     *
+     * @param expression the expression
+     * @return the ais packet stream
+     */
     public AisPacketStream filter(String expression) {
         return filter(AisPacketFilters.parseExpressionFilter(expression));
     }
 
+    /**
+     * Filter on message type ais packet stream.
+     *
+     * @param messageTypes the message types
+     * @return the ais packet stream
+     */
     public AisPacketStream filterOnMessageType(int... messageTypes) {
         return filter(AisPacketFilters.filterOnMessageType(messageTypes));
     }
 
+    /**
+     * Immutable stream ais packet stream.
+     *
+     * @return the ais packet stream
+     */
     public final AisPacketStream immutableStream() {
         return this instanceof ImmutableAisPacketStream ? this : new ImmutableAisPacketStream(this);
     }
 
+    /**
+     * Limit ais packet stream.
+     *
+     * @param limit the limit
+     * @return the ais packet stream
+     */
     public AisPacketStream limit(long limit) {
         if (limit < 1) {
             throw new IllegalArgumentException("Limit must be at least 1, was: " + limit);
@@ -84,8 +106,20 @@ public abstract class AisPacketStream {
         });
     }
 
+    /**
+     * Subscribe subscription.
+     *
+     * @param c the c
+     * @return the subscription
+     */
     public abstract Subscription subscribe(Consumer<AisPacket> c);
 
+    /**
+     * Subscribe messages subscription.
+     *
+     * @param c the c
+     * @return the subscription
+     */
     public Subscription subscribeMessages(final Consumer<AisMessage> c) {
         requireNonNull(c);
         if (c instanceof AisPacketStream.StreamConsumer) {
@@ -118,6 +152,13 @@ public abstract class AisPacketStream {
         }
     }
 
+    /**
+     * Subscribe sink subscription.
+     *
+     * @param sink the sink
+     * @param os   the os
+     * @return the subscription
+     */
     public Subscription subscribeSink(final OutputStreamSink<AisPacket> sink, final OutputStream os) {
         requireNonNull(sink);
         requireNonNull(os);
@@ -154,30 +195,51 @@ public abstract class AisPacketStream {
 
     /**
      * Returns a new stream.
-     * 
+     *
      * @return the new stream
      */
     public static AisPacketStream newStream() {
         return new AisPacketStreamImpl();
     }
 
+    /**
+     * The type Stream consumer.
+     *
+     * @param <T> the type parameter
+     */
     public abstract static class StreamConsumer<T> implements Consumer<T> {
-        /** Invoked immediately before the first message is delivered. */
+        /**
+         * Invoked immediately before the first message is delivered.
+         */
         public void begin() {}
 
         /**
          * Invoked immediately after the last message has been delivered.
-         * 
-         * @param cause
-         *            if an exception caused the consumer to be unsubscribed
+         *
+         * @param cause if an exception caused the consumer to be unsubscribed
          */
         public void end(Throwable cause) {}
     }
 
-    /** A subcription is created each time a new consumer is added to the stream. */
+    /**
+     * A subcription is created each time a new consumer is added to the stream.
+     */
     public interface Subscription {
+        /**
+         * Await cancelled.
+         *
+         * @throws InterruptedException the interrupted exception
+         */
         void awaitCancelled() throws InterruptedException;
 
+        /**
+         * Await cancelled boolean.
+         *
+         * @param timeout the timeout
+         * @param unit    the unit
+         * @return the boolean
+         * @throws InterruptedException the interrupted exception
+         */
         boolean awaitCancelled(long timeout, TimeUnit unit) throws InterruptedException;
 
         /**
@@ -186,15 +248,27 @@ public abstract class AisPacketStream {
          */
         void cancel();
 
-        /** Returns whether or not the subscription has been cancelled. */
+        /**
+         * Returns whether or not the subscription has been cancelled.  @return the boolean
+         *
+         * @return the boolean
+         */
         boolean isCancelled();
     }
 
+    /**
+     * The type Delegating ais packet stream.
+     */
     static class DelegatingAisPacketStream extends AisPacketStream {
+        /**
+         * The Stream.
+         */
         final AisPacketStream stream;
 
         /**
-         * @param stream
+         * Instantiates a new Delegating ais packet stream.
+         *
+         * @param stream the stream
          */
         public DelegatingAisPacketStream(AisPacketStream stream) {
             this.stream = requireNonNull(stream);
@@ -235,10 +309,15 @@ public abstract class AisPacketStream {
         }
     }
 
+    /**
+     * The type Immutable ais packet stream.
+     */
     static class ImmutableAisPacketStream extends DelegatingAisPacketStream {
 
         /**
-         * @param stream
+         * Instantiates a new Immutable ais packet stream.
+         *
+         * @param stream the stream
          */
         public ImmutableAisPacketStream(AisPacketStream stream) {
             super(stream);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketTags.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/AisPacketTags.java
@@ -32,9 +32,21 @@ public class AisPacketTags implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The constant SOURCE_ID_KEY.
+     */
     public static final String SOURCE_ID_KEY = "si";
+    /**
+     * The constant SOURCE_BS_KEY.
+     */
     public static final String SOURCE_BS_KEY = "sb";
+    /**
+     * The constant SOURCE_COUNTRY_KEY.
+     */
     public static final String SOURCE_COUNTRY_KEY = "sc";
+    /**
+     * The constant SOURCE_TYPE_KEY.
+     */
     public static final String SOURCE_TYPE_KEY = "st";
 
     /**
@@ -58,14 +70,17 @@ public class AisPacketTags implements Serializable {
      */
     private SourceType sourceType;
 
+    /**
+     * Instantiates a new Ais packet tags.
+     */
     public AisPacketTags() {
 
     }
 
     /**
      * Copy constructor
-     * 
-     * @param t
+     *
+     * @param t the t
      */
     public AisPacketTags(AisPacketTags t) {
         if (t.timestamp != null) {
@@ -78,57 +93,107 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Determine if any tag is non null
-     * 
-     * @return
+     *
+     * @return boolean boolean
      */
     public boolean isEmpty() {
         return timestamp == null && sourceId == null && sourceBs == null && sourceCountry == null && sourceType == null;
     }
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     public Date getTimestamp() {
         return timestamp;
     }
 
+    /**
+     * Sets timestamp.
+     *
+     * @param timestamp the timestamp
+     */
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
     }
 
+    /**
+     * Gets source id.
+     *
+     * @return the source id
+     */
     public String getSourceId() {
         return sourceId;
     }
 
+    /**
+     * Sets source id.
+     *
+     * @param sourceId the source id
+     */
     public void setSourceId(String sourceId) {
         this.sourceId = sourceId;
     }
 
+    /**
+     * Gets source bs.
+     *
+     * @return the source bs
+     */
     public Integer getSourceBs() {
         return sourceBs;
     }
 
+    /**
+     * Sets source bs.
+     *
+     * @param sourceBs the source bs
+     */
     public void setSourceBs(Integer sourceBs) {
         this.sourceBs = sourceBs;
     }
 
+    /**
+     * Gets source country.
+     *
+     * @return the source country
+     */
     public Country getSourceCountry() {
         return sourceCountry;
     }
 
+    /**
+     * Sets source country.
+     *
+     * @param sourceCountry the source country
+     */
     public void setSourceCountry(Country sourceCountry) {
         this.sourceCountry = sourceCountry;
     }
 
+    /**
+     * Sets source type.
+     *
+     * @param sourceType the source type
+     */
     public void setSourceType(SourceType sourceType) {
         this.sourceType = sourceType;
     }
 
+    /**
+     * Gets source type.
+     *
+     * @return the source type
+     */
     public SourceType getSourceType() {
         return sourceType;
     }
 
     /**
      * Make comment block with tags
-     * 
-     * @return
+     *
+     * @return comment block
      */
     public CommentBlock getCommentBlock() {
         return getCommentBlock(new CommentBlock());
@@ -136,9 +201,9 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Supplement given comment block with tags (overriding)
-     * 
-     * @param cb
-     * @return
+     *
+     * @param cb the cb
+     * @return comment block
      */
     public CommentBlock getCommentBlock(CommentBlock cb) {
         if (timestamp != null) {
@@ -161,9 +226,9 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Supplement given comment block with tags (not overriding)
-     * 
-     * @param cb
-     * @return
+     *
+     * @param cb the cb
+     * @return comment block preserve
      */
     public CommentBlock getCommentBlockPreserve(CommentBlock cb) {
         if (timestamp != null && !cb.contains("c")) {
@@ -186,9 +251,9 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Get new tagging with tags in proposed tagging not already in the current tag
-     * 
-     * @param tagging
-     * @return
+     *
+     * @param proposed the proposed
+     * @return ais packet tags
      */
     public AisPacketTags mergeMissing(AisPacketTags proposed) {
         AisPacketTags addedTagging = new AisPacketTags();
@@ -209,9 +274,9 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Determine if given tagging match this tagging
-     * 
-     * @param parse
-     * @return
+     *
+     * @param tagging the tagging
+     * @return boolean boolean
      */
     public boolean filterMatch(AisPacketTags tagging) {
         if (sourceId != null && (tagging.getSourceId() == null || !tagging.getSourceId().equals(sourceId))) {
@@ -235,8 +300,8 @@ public class AisPacketTags implements Serializable {
 
     /**
      * Parse tags from Vdm. Uses comment block with first priority and fall back to proprietary tags.
-     * 
-     * @param packet
+     *
+     * @param vdm the vdm
      * @return tagging instance
      */
     static AisPacketTags parse(Vdm vdm) {
@@ -293,8 +358,25 @@ public class AisPacketTags implements Serializable {
     }
 
 
+    /**
+     * The enum Source type.
+     */
     public enum SourceType {
-        TERRESTRIAL, SATELLITE;
+        /**
+         * Terrestrial source type.
+         */
+        TERRESTRIAL,
+        /**
+         * Satellite source type.
+         */
+        SATELLITE;
+
+        /**
+         * From string source type.
+         *
+         * @param st the st
+         * @return the source type
+         */
         public static SourceType fromString(String st) {
             if (st == null) {
                 return null;
@@ -307,6 +389,11 @@ public class AisPacketTags implements Serializable {
             throw new IllegalArgumentException("Unknow source type: " + st);
         }
 
+        /**
+         * Encode string.
+         *
+         * @return the string
+         */
         public String encode() {
             return this == TERRESTRIAL ? "LIVE" : "SAT";
         }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/CompareToOperator.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/CompareToOperator.java
@@ -14,12 +14,33 @@
  */
 package dk.dma.ais.packet;
 
+/**
+ * The enum Compare to operator.
+ */
 public enum CompareToOperator {
+    /**
+     * Equals compare to operator.
+     */
     EQUALS("="),
+    /**
+     * Not equals compare to operator.
+     */
     NOT_EQUALS("!="),
+    /**
+     * Less than compare to operator.
+     */
     LESS_THAN("<"),
+    /**
+     * Less than or equals compare to operator.
+     */
     LESS_THAN_OR_EQUALS("<="),
+    /**
+     * Greater than compare to operator.
+     */
     GREATER_THAN(">"),
+    /**
+     * Greater than or equals compare to operator.
+     */
     GREATER_THAN_OR_EQUALS(">=");
 
     private final String operator;
@@ -28,6 +49,12 @@ public enum CompareToOperator {
         this.operator = operator;
     }
 
+    /**
+     * From string compare to operator.
+     *
+     * @param operator the operator
+     * @return the compare to operator
+     */
     static CompareToOperator fromString(String operator) {
         if ("=".equals(operator)) {
             return EQUALS;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/ExpressionFilterParserBase.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/ExpressionFilterParserBase.java
@@ -59,11 +59,11 @@ abstract class ExpressionFilterParserBase {
      * Create a filter predicate with will compare the left-hand side to the right-hand side both assumed to be present
      * in the supplied ANTLR context.
      *
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForComparison(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -101,11 +101,11 @@ abstract class ExpressionFilterParserBase {
      * Create a filter predicate with will test the left-side value assumed to be present
      * in the supplied ANTLR context against the list or range supplied on the right-hand side.
      *
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForRangeOrList(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -132,10 +132,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for comparisons of strings, including the LIKE operator.
-     * @param filterPredicateFactoryClass
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForStringComparison(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -155,11 +157,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for comparison of ship types (as numbers or named in strings).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForComparisonOfShipType(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasCompareTo(ctx) && hasString(ctx)) {
@@ -183,11 +186,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for testing against lists of ship types (as numbers or named in strings).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForListOfShipType(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasStringList(ctx)) {
@@ -201,11 +205,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create a predicate for comparing navigational statuses (as numbers or named in strings).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForComparisonOfNavigationalStatus(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasCompareTo(ctx) && hasString(ctx)) {
@@ -228,11 +233,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for testing against lists of navigational statuses (as numbers or named in strings).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForListOfNavigationalStatus(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasStringList(ctx)) {
@@ -246,11 +252,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for testing against lists of countries.
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForListOfCountry(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasStringList(ctx)) {
@@ -264,11 +271,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for testing against lists of source types.
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForListOfSourceType(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasStringList(ctx)) {
@@ -282,11 +290,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for comparing months (as numbers or named in strings).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForComparisonOfMonth(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasCompareTo(ctx)) {
@@ -307,11 +316,11 @@ abstract class ExpressionFilterParserBase {
      * Create predicate for testing against lists of navigational statuses (as numbers or named in strings) or
      * ranges of months (as numbers).
      *
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForRangeOrListOfMonth(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -333,11 +342,12 @@ abstract class ExpressionFilterParserBase {
 
     /**
      * Create predicate for comparing weekdays (as numbers (monday = 1) or named in strings (in English)).
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForComparisonOfWeekday(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         if (hasCompareTo(ctx)) {
@@ -358,11 +368,11 @@ abstract class ExpressionFilterParserBase {
      * Create predicate for testing against lists of weekdays (as numbers (monday = 1) or named in strings (in
      * English))) or ranges of months (as numbers).
      *
-     * @param filterPredicateFactoryClass
-     * @param filterPredicateFactory
-     * @param ctx
-     * @param <T>
-     * @return
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return predicate predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForRangeOrListOfWeekday(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -382,6 +392,16 @@ abstract class ExpressionFilterParserBase {
         return filter;
     }
 
+    /**
+     * Create filter predicate for comparison of message receive time predicate.
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @param calendarField               the calendar field
+     * @return the predicate
+     */
     protected static <T> Predicate<T> createFilterPredicateForComparisonOfMessageReceiveTime(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx, int calendarField) {
         Predicate<T> filter = null;
         String filterPredicateFactoryMethodName = "filterOnMessageReceiveTime";
@@ -399,6 +419,15 @@ abstract class ExpressionFilterParserBase {
         return filter;
     }
 
+    /**
+     * Create filter predicate for range or list of message receive time predicate.
+     *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return the predicate
+     */
     protected static <T> Predicate<T> createFilterPredicateForRangeOrListOfMessageReceiveTime(Class<? extends FilterPredicateFactory> filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
         String filterPredicateFactoryMethodName = mapFieldTokenToFilterPredicateFactoryMethodName(ctx.getStart().getText());
@@ -424,7 +453,13 @@ abstract class ExpressionFilterParserBase {
     }
 
     /**
+     * Create filter predicate for position within predicate.
      *
+     * @param <T>                         the type parameter
+     * @param filterPredicateFactoryClass the filter predicate factory class
+     * @param filterPredicateFactory      the filter predicate factory
+     * @param ctx                         the ctx
+     * @return the predicate
      */
     protected static <T> Predicate<T> createFilterPredicateForPositionWithin(Class filterPredicateFactoryClass, FilterPredicateFactory filterPredicateFactory, ParserRuleContext ctx) {
         Predicate<T> filter = null;
@@ -1148,6 +1183,12 @@ abstract class ExpressionFilterParserBase {
         return month + 1; // 1 = jan
     }
 
+    /**
+     * Create filter context expression filter parser . filter context.
+     *
+     * @param filter the filter
+     * @return the expression filter parser . filter context
+     */
     static ExpressionFilterParser.FilterContext createFilterContext(String filter) {
         ANTLRInputStream input = new ANTLRInputStream(requireNonNull(filter));
         ExpressionFilterLexer lexer = new ExpressionFilterLexer(input);
@@ -1163,6 +1204,9 @@ abstract class ExpressionFilterParserBase {
         return parser.filter();
     }
 
+    /**
+     * The type Verbose listener.
+     */
     static class VerboseListener extends BaseErrorListener {
         @Override
         public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/packet/FilterPredicateFactory.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/packet/FilterPredicateFactory.java
@@ -15,5 +15,8 @@
 
 package dk.dma.ais.packet;
 
+/**
+ * The interface Filter predicate factory.
+ */
 public interface FilterPredicateFactory {
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/queue/BlockingMessageQueue.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/queue/BlockingMessageQueue.java
@@ -22,6 +22,8 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Implementation of a IMessageQueue using a Java ArrayBlockingQueue
+ *
+ * @param <T> the type parameter
  */
 @ThreadSafe
 public class BlockingMessageQueue<T> implements IMessageQueue<T> {
@@ -31,10 +33,18 @@ public class BlockingMessageQueue<T> implements IMessageQueue<T> {
     private final int limit;
     private final BlockingQueue<T> queue;
 
+    /**
+     * Instantiates a new Blocking message queue.
+     */
     public BlockingMessageQueue() {
         this(DEFAULT_MAX_SIZE);
     }
 
+    /**
+     * Instantiates a new Blocking message queue.
+     *
+     * @param limit the limit
+     */
     public BlockingMessageQueue(int limit) {
         this.limit = limit;
         this.queue = new ArrayBlockingQueue<>(limit);
@@ -77,6 +87,11 @@ public class BlockingMessageQueue<T> implements IMessageQueue<T> {
         return pull(l, Integer.MAX_VALUE);
     }
 
+    /**
+     * Gets limit.
+     *
+     * @return the limit
+     */
     public int getLimit() {
         return limit;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/queue/IMessageQueue.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/queue/IMessageQueue.java
@@ -20,49 +20,54 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Queue for transporting various data. Suited for AIS use.
+ *
+ * @param <T> the type parameter
  */
 @ThreadSafe
 public interface IMessageQueue<T> {
 
     /**
      * Push AisMessage onto the queue
-     * 
-     * @param aisMessage
+     *
+     * @param content the content
      * @return the number of elements on the queue after the insertion
-     * @throws MessageQueueOverflowException
-     *             when capacity limit has been reached
+     * @throws MessageQueueOverflowException when capacity limit has been reached
      */
     int push(T content) throws MessageQueueOverflowException;
-    
+
     /**
      * Push the specified element on the queue, waiting if necessary for space to become availably
-     * @param content
-     * @return
-     * @throws InterruptedException
+     *
+     * @param content the content
+     * @return int int
+     * @throws InterruptedException the interrupted exception
      */
     int put(T content) throws InterruptedException;
 
     /**
      * Pull message from the queue. This must be implemented as a blocking call.
-     * 
-     * @return AisMessageQueueEntry
+     *
+     * @return AisMessageQueueEntry t
+     * @throws InterruptedException the interrupted exception
      */
     T pull() throws InterruptedException;
 
     /**
      * Pull up to maxElements from queue. This must be a blocking call.
-     * 
-     * @param l list to add elements to 
-     * @param maxElements
+     *
+     * @param l           list to add elements to
+     * @param maxElements the max elements
      * @return list with added elements
+     * @throws InterruptedException the interrupted exception
      */
     List<T> pull(List<T> l, int maxElements) throws InterruptedException;
 
     /**
      * Pull all current message on the queue. This must be a blocking call.
-     * 
-     * @param l list to add elements to 
+     *
+     * @param c the c
      * @return list with added elements
+     * @throws InterruptedException the interrupted exception
      */
     List<T> pullAll(List<T> c) throws InterruptedException;
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/queue/IQueueEntryHandler.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/queue/IQueueEntryHandler.java
@@ -18,14 +18,16 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Interface to implement for classes wanting to handle messages from a MessageQueue
+ *
+ * @param <T> the type parameter
  */
 @ThreadSafe
 public interface IQueueEntryHandler<T> {
 
     /**
      * Method which to be called when delivering queue entry
-     * 
-     * @param queueEntry
+     *
+     * @param queueEntry the queue entry
      */
     void receive(T queueEntry);
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/queue/MessageQueueOverflowException.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/queue/MessageQueueOverflowException.java
@@ -21,6 +21,9 @@ public class MessageQueueOverflowException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Message queue overflow exception.
+     */
     public MessageQueueOverflowException() {
         super();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/queue/MessageQueueReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/queue/MessageQueueReader.java
@@ -21,6 +21,8 @@ import net.jcip.annotations.ThreadSafe;
 
 /**
  * Thread class to read from a message queue and delegating to a handler
+ *
+ * @param <T> the type parameter
  */
 @ThreadSafe
 public class MessageQueueReader<T> extends Thread {
@@ -29,10 +31,23 @@ public class MessageQueueReader<T> extends Thread {
     private final IMessageQueue<T> queue;
     private final int pullMaxElements;
 
+    /**
+     * Instantiates a new Message queue reader.
+     *
+     * @param handler the handler
+     * @param queue   the queue
+     */
     public MessageQueueReader(IQueueEntryHandler<T> handler, IMessageQueue<T> queue) {
         this(handler, queue, 1);
     }
 
+    /**
+     * Instantiates a new Message queue reader.
+     *
+     * @param handler         the handler
+     * @param queue           the queue
+     * @param pullMaxElements the pull max elements
+     */
     public MessageQueueReader(IQueueEntryHandler<T> handler, IMessageQueue<T> queue, int pullMaxElements) {
         this.handler = handler;
         this.queue = queue;
@@ -57,14 +72,27 @@ public class MessageQueueReader<T> extends Thread {
         
     }
 
+    /**
+     * Gets queue.
+     *
+     * @return the queue
+     */
     public IMessageQueue<T> getQueue() {
         return queue;
     }
-    
+
+    /**
+     * Gets handler.
+     *
+     * @return the handler
+     */
     public IQueueEntryHandler<T> getHandler() {
         return handler;
     }
-    
+
+    /**
+     * Cancel.
+     */
     public void cancel() {
         this.interrupt();
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisDirectoryReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisDirectoryReader.java
@@ -42,11 +42,10 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * AIS reader that iterates over every file from a given base directory. If a file matches a given pattern it will be read.
- * 
+ * <p>
  * If recursive used all sub directories will also be scanned using depth first.
- * 
- * Default ordering is by full path names. A Comparator<Path> can be provided for alternative ordering. 
- * 
+ * <p>
+ * Default ordering is by full path names. A Comparator&lt;Path&gt; can be provided for alternative ordering.
  */
 public class AisDirectoryReader extends AisReader {
 
@@ -59,11 +58,28 @@ public class AisDirectoryReader extends AisReader {
     private final Comparator<Path> comparator;
 
     private Long totalNumberOfPacketsToRead;
-    
+
+    /**
+     * Instantiates a new Ais directory reader.
+     *
+     * @param dir       the dir
+     * @param pattern   the pattern
+     * @param recursive the recursive
+     * @throws IOException the io exception
+     */
     AisDirectoryReader(String dir, String pattern, boolean recursive) throws IOException {
         this(dir, pattern, recursive, null);
     }
 
+    /**
+     * Instantiates a new Ais directory reader.
+     *
+     * @param dir        the dir
+     * @param pattern    the pattern
+     * @param recursive  the recursive
+     * @param comparator the comparator
+     * @throws IOException the io exception
+     */
     AisDirectoryReader(String dir, String pattern, boolean recursive, Comparator<Path> comparator) throws IOException {
         requireNonNull(dir);
         requireNonNull(pattern);
@@ -109,7 +125,7 @@ public class AisDirectoryReader extends AisReader {
      * Compute an estimate of the fraction of AIS packets which have been read, out of the total no. of AIS packets to read in the
      * matching files. The first call to this method may be long-running as it will scan all the matching files to count AIS
      * packets.
-     * 
+     *
      * @return Estimated fraction of AIS packets read as a floating point number between 0 and 1.
      */
     public float getEstimatedFractionOfPacketsRead() {
@@ -160,12 +176,23 @@ public class AisDirectoryReader extends AisReader {
      */
     private abstract class MatchingFileIterator {
         
-        private final Comparator<Path> comparator;      
-        
+        private final Comparator<Path> comparator;
+
+        /**
+         * Instantiates a new Matching file iterator.
+         *
+         * @param comparator the comparator
+         */
         public MatchingFileIterator(Comparator<Path> comparator) {
             this.comparator = comparator;
         }
-        
+
+        /**
+         * Do with matching file.
+         *
+         * @param matchingFile the matching file
+         * @throws IOException the io exception
+         */
         protected abstract void doWithMatchingFile(Path matchingFile) throws IOException;
 
         private void handleFile(Path file) {
@@ -178,6 +205,9 @@ public class AisDirectoryReader extends AisReader {
             }
         }
 
+        /**
+         * Iterate.
+         */
         public void iterate() {
             final List<Path> files = new ArrayList<>();
             final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReader.java
@@ -51,6 +51,9 @@ import static java.util.Objects.requireNonNull;
 @ManagedResource
 public abstract class AisReader extends Thread {
 
+    /**
+     * The Log.
+     */
     static final Logger LOG = LoggerFactory.getLogger(AisReader.class);
 
     /** The number of bytes read by this reader. */
@@ -59,19 +62,27 @@ public abstract class AisReader extends Thread {
     /** The number of bytes written by this reader. */
     private final AtomicLong bytesWritten = new AtomicLong();
 
-    /** List receivers for the AIS messages. */
+    /**
+     * List receivers for the AIS messages.
+     */
     protected final CopyOnWriteArrayList<Consumer<AisMessage>> handlers = new CopyOnWriteArrayList<>();
 
     /** The number of lines read by this reader. */
     private final AtomicLong linesRead = new AtomicLong();
 
-    /** List of packet handlers. */
+    /**
+     * List of packet handlers.
+     */
     protected final CopyOnWriteArrayList<Consumer<? super AisPacket>> packetHandlers = new CopyOnWriteArrayList<>();
 
-    /** A pool of sending threads. A sending thread handles the sending and reception of ABK message. */
+    /**
+     * A pool of sending threads. A sending thread handles the sending and reception of ABK message.
+     */
     protected final SendThreadPool sendThreadPool = new SendThreadPool();
 
-    /** Flag that indicates the reader should shutdown */
+    /**
+     * Flag that indicates the reader should shutdown
+     */
     final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
     /** The source id. */
@@ -82,11 +93,11 @@ public abstract class AisReader extends Thread {
 
     /**
      * The method to do the actual sending
-     * 
-     * @param sendRequest
-     * @param resultListener
-     * @param out
-     * @throws SendException
+     *
+     * @param sendRequest    the send request
+     * @param resultListener the result listener
+     * @param out            the out
+     * @throws SendException the send exception
      */
     protected void doSend(SendRequest sendRequest, Consumer<Abk> resultListener, OutputStream out) throws SendException {
         if (out == null) {
@@ -114,21 +125,41 @@ public abstract class AisReader extends Thread {
         sendThread.start();
     }
 
+    /**
+     * Gets number of bytes read.
+     *
+     * @return the number of bytes read
+     */
     @ManagedAttribute
     public long getNumberOfBytesRead() {
         return bytesRead.get();
     }
 
+    /**
+     * Gets number of bytes written.
+     *
+     * @return the number of bytes written
+     */
     @ManagedAttribute
     public long getNumberOfBytesWritten() {
         return bytesWritten.get();
     }
 
+    /**
+     * Gets number of lines read.
+     *
+     * @return the number of lines read
+     */
     @ManagedAttribute
     public long getNumberOfLinesRead() {
         return linesRead.get();
     }
 
+    /**
+     * Gets source id.
+     *
+     * @return the source id
+     */
     @ManagedAttribute
     public String getSourceId() {
         return sourceId;
@@ -136,22 +167,26 @@ public abstract class AisReader extends Thread {
 
     /**
      * Get the status of the connection, either connected or disconnected
-     * 
-     * @return status
+     *
+     * @return status status
      */
     @ManagedAttribute
     public abstract Status getStatus();
 
+    /**
+     * Is shutdown boolean.
+     *
+     * @return the boolean
+     */
     protected boolean isShutdown() {
         return shutdownLatch.getCount() == 0;
     }
 
     /**
      * The main read loop to use if sentences in stream
-     * 
-     * @param stream
-     *            the generic input stream to read from
-     * @throws IOException
+     *
+     * @param stream the generic input stream to read from
+     * @throws IOException the io exception
      */
     protected void readLoop(InputStream stream) throws IOException {
         try (AisPacketReader s = new AisPacketReader(stream) {
@@ -166,7 +201,12 @@ public abstract class AisReader extends Thread {
             }
         }
     }
-    
+
+    /**
+     * Distribute.
+     *
+     * @param packet the packet
+     */
     protected void distribute(AisPacket packet) {
         linesRead.incrementAndGet();
         
@@ -200,8 +240,8 @@ public abstract class AisReader extends Thread {
 
     /**
      * Add an AIS handler
-     * 
-     * @param aisHandler
+     *
+     * @param aisHandler the ais handler
      */
     public void registerHandler(Consumer<AisMessage> aisHandler) {
         handlers.add(aisHandler);
@@ -209,8 +249,8 @@ public abstract class AisReader extends Thread {
 
     /**
      * Add a packet handler
-     * 
-     * @param packetHandler
+     *
+     * @param packetConsumer the packet consumer
      */
     public void registerPacketHandler(Consumer<? super AisPacket> packetConsumer) {
         packetHandlers.add(packetConsumer);
@@ -218,8 +258,8 @@ public abstract class AisReader extends Thread {
 
     /**
      * Add a queue for receiving messages
-     * 
-     * @param queue
+     *
+     * @param queue the queue
      */
     public void registerQueue(final IMessageQueue<AisMessage> queue) {
         requireNonNull(queue);
@@ -237,8 +277,8 @@ public abstract class AisReader extends Thread {
 
     /**
      * Make a new queue and reader for the queue. Start and attach to to given handler.
-     * 
-     * @param handler
+     *
+     * @param handler the handler
      */
     public void registerQueueHandler(IQueueEntryHandler<AisMessage> handler) {
         MessageQueueReader<AisMessage> queueReader = new MessageQueueReader<>(handler,
@@ -249,13 +289,13 @@ public abstract class AisReader extends Thread {
 
     /**
      * Sending with 60 sec default timeout
-     * 
-     * @param aisMessage
-     * @param sequence
-     * @param destination
-     * @return
-     * @throws SendException
-     * @throws InterruptedException
+     *
+     * @param aisMessage  the ais message
+     * @param sequence    the sequence
+     * @param destination the destination
+     * @return abk abk
+     * @throws SendException        the send exception
+     * @throws InterruptedException the interrupted exception
      */
     public Abk send(AisMessage aisMessage, int sequence, int destination) throws SendException, InterruptedException {
         return send(aisMessage, sequence, destination, 60000);
@@ -263,14 +303,14 @@ public abstract class AisReader extends Thread {
 
     /**
      * Blocking method to send message in an easy way
-     * 
-     * @param aisMessage
-     * @param sequence
-     * @param destination
-     * @param timeout
-     * @return
-     * @throws InterruptedException
-     * @throws SendException
+     *
+     * @param aisMessage  the ais message
+     * @param sequence    the sequence
+     * @param destination the destination
+     * @param timeout     the timeout
+     * @return abk abk
+     * @throws SendException        the send exception
+     * @throws InterruptedException the interrupted exception
      */
     public Abk send(AisMessage aisMessage, int sequence, int destination, int timeout) throws SendException,
             InterruptedException {
@@ -281,13 +321,18 @@ public abstract class AisReader extends Thread {
 
     /**
      * Method to send addressed or broadcast AIS messages (ABM or BBM).
-     * 
-     * @param sendRequest
-     * @param resultListener
-     *            A class to handle the result when it is ready.
+     *
+     * @param sendRequest    the send request
+     * @param resultListener A class to handle the result when it is ready.
+     * @throws SendException the send exception
      */
     public abstract void send(SendRequest sendRequest, Consumer<Abk> resultListener) throws SendException;
 
+    /**
+     * Sets source id.
+     *
+     * @param sourceId the source id
+     */
     public void setSourceId(String sourceId) {
         this.sourceId = sourceId;
         if (sourceId != null) {
@@ -309,7 +354,7 @@ public abstract class AisReader extends Thread {
 
     /**
      * Returns a ais packet stream.
-     * 
+     *
      * @return the stream
      */
     public AisPacketStream stream() {
@@ -322,7 +367,17 @@ public abstract class AisReader extends Thread {
         return s.immutableStream();// Only adds from reader
     }
 
+    /**
+     * The enum Status.
+     */
     public enum Status {
-        CONNECTED, DISCONNECTED
+        /**
+         * Connected status.
+         */
+        CONNECTED,
+        /**
+         * Disconnected status.
+         */
+        DISCONNECTED
     }
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderGroup.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderGroup.java
@@ -33,32 +33,55 @@ import dk.dma.ais.packet.AisPacketStream;
 
 /**
  * A reader group organizes a group of readers.
- * 
+ *
  * @author Kasper Nielsen
  */
 public class AisReaderGroup implements Iterable<AisReader> {
 
-    /** The logger. */
+    /**
+     * The logger.
+     */
     static final Logger LOG = LoggerFactory.getLogger(AisReaderGroup.class);
 
-    /** A stream of all incoming packets. */
+    /**
+     * A stream of all incoming packets.
+     */
     final AisPacketStream stream = AisPacketStream.newStream();
 
+    /**
+     * The Lock.
+     */
     final ReentrantLock lock = new ReentrantLock();
 
-    /** All readers configured for this group. */
+    /**
+     * All readers configured for this group.
+     */
     final ConcurrentHashMap<String, AisTcpReader> readers = new ConcurrentHashMap<>();
 
-    /** All current subscriptions. */
+    /**
+     * All current subscriptions.
+     */
     final ConcurrentHashMap<AisReader, AisPacketStream.Subscription> subscriptions = new ConcurrentHashMap<>();
 
-    /** The name of the group. */
+    /**
+     * The name of the group.
+     */
     final String name;
 
+    /**
+     * Instantiates a new Ais reader group.
+     *
+     * @param name the name
+     */
     AisReaderGroup(String name) {
         this.name = requireNonNull(name);
     }
 
+    /**
+     * Add.
+     *
+     * @param reader the reader
+     */
     void add(AisTcpReader reader) {
         lock.lock();
         try {
@@ -77,6 +100,11 @@ public class AisReaderGroup implements Iterable<AisReader> {
         }
     }
 
+    /**
+     * As service service.
+     *
+     * @return the service
+     */
     public Service asService() {
         return new AbstractIdleService() {
             @Override
@@ -121,6 +149,12 @@ public class AisReaderGroup implements Iterable<AisReader> {
         return (Iterator) Collections.unmodifiableCollection(readers.values()).iterator();
     }
 
+    /**
+     * Remove boolean.
+     *
+     * @param name the name
+     * @return the boolean
+     */
     boolean remove(String name) {
         lock.lock();
         try {
@@ -137,7 +171,7 @@ public class AisReaderGroup implements Iterable<AisReader> {
 
     /**
      * Returns a stream of incoming packets for all the readers this group is managing.
-     * 
+     *
      * @return a stream of incoming packets for all the readers this group is managing
      */
     public AisPacketStream stream() {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderGroupMXBean.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderGroupMXBean.java
@@ -18,57 +18,64 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * An MXBean interface to {@link AisReaderGroup}.
- * 
+ *
  * @author Kasper Nielsen
  */
 public interface AisReaderGroupMXBean {
 
     /**
      * Adds the specified reader to the group.
-     * 
-     * @param sourceId
-     *            the source id of the reader
-     * @param oneOrMorHosts
-     *            one or more hosts
+     *
+     * @param sourceId      the source id of the reader
+     * @param oneOrMorHosts one or more hosts
      */
     void addReader(String sourceId, String oneOrMorHosts);
 
     /**
      * Returns the number of bytes received.
-     * 
+     *
      * @return the number of bytes received
      */
     long getBytesReceived();
 
     /**
      * Returns the number of bytes received.
-     * 
+     *
      * @return the number of bytes received
      */
     long getPacketsReceived();
 
     /**
      * Returns the number of readers.
-     * 
+     *
      * @return the number of readers
      */
     int getReaderCount();
 
     /**
      * Removes a reader from the group.
-     * 
-     * @param sourceId
-     *            the source id of the group
+     *
+     * @param sourceId the source id of the group
      * @return true if a reader with the specified id was removed, false otherwise
      */
     boolean removeReader(String sourceId);
 }
 
-/** The default implementation */
+/**
+ * The default implementation
+ */
 class AisReaderGroupMXBeanImpl implements AisReaderGroupMXBean {
 
+    /**
+     * The Group.
+     */
     final AisReaderGroup group;
 
+    /**
+     * Instantiates a new Ais reader group mx bean.
+     *
+     * @param group the group
+     */
     AisReaderGroupMXBeanImpl(AisReaderGroup group) {
         this.group = requireNonNull(group);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderMXBean.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderMXBean.java
@@ -23,25 +23,63 @@ import com.google.common.base.Joiner;
 import com.google.common.net.HostAndPort;
 
 /**
- * 
+ * The interface Ais reader mx bean.
+ *
  * @author Kasper Nielsen
  */
 public interface AisReaderMXBean {
 
+    /**
+     * Gets hosts.
+     *
+     * @return the hosts
+     */
     String getHosts();
 
+    /**
+     * Add host.
+     *
+     * @param hostname the hostname
+     * @param port     the port
+     */
     void addHost(String hostname, int port);
 
+    /**
+     * Gets bytes read.
+     *
+     * @return the bytes read
+     */
     long getBytesRead();
 
+    /**
+     * Gets packets read.
+     *
+     * @return the packets read
+     */
     long getPacketsRead();
 
+    /**
+     * Gets source.
+     *
+     * @return the source
+     */
     String getSource();
 }
 
+/**
+ * The type Ais reader mx bean.
+ */
 class AisReaderMXBeanImpl implements AisReaderMXBean {
+    /**
+     * The Reader.
+     */
     final AisTcpReader reader;
 
+    /**
+     * Instantiates a new Ais reader mx bean.
+     *
+     * @param reader the reader
+     */
     AisReaderMXBeanImpl(AisTcpReader reader) {
         this.reader = requireNonNull(reader);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaders.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaders.java
@@ -35,9 +35,9 @@ import java.util.zip.ZipInputStream;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Factory and utility methods for {@link AisReader}, {@link AisTcpReader}, {@link AisUdpReader}, 
+ * Factory and utility methods for {@link AisReader}, {@link AisTcpReader}, {@link AisUdpReader},
  * and {@link AisReaderGroup} classes defined in this package.
- * 
+ *
  * @author Kasper Nielsen
  */
 public class AisReaders {
@@ -45,6 +45,10 @@ public class AisReaders {
     /**
      * Equivalent to {@link #parseSource(String)} except that it will parse an array of sources. Returning a map making
      * sure there all source names are unique
+     *
+     * @param name    the name
+     * @param sources the sources
+     * @return the ais reader group
      */
     public static AisReaderGroup createGroup(String name, List<String> sources) {
         Map<String, AisTcpReader> readers = new HashMap<>();
@@ -65,9 +69,9 @@ public class AisReaders {
 
     /**
      * Creates a default group from reader available in the system property ais.default.sources
-     * 
+     *
      * @return a new reader group
-     * @see #getDefaultSources()
+     * @see #getDefaultSources() #getDefaultSources()#getDefaultSources()
      */
     public static AisReaderGroup createGroupFromDefaultsSource() {
         return createGroup("defaults", Arrays.asList(getDefaultSources()));
@@ -75,8 +79,9 @@ public class AisReaders {
 
     /**
      * Creates a {@link AisTcpReader} from a list of one or more hosts. On the form: host1:port1,...,hostN:portN
-     * 
-     * @param commaHostPort
+     *
+     * @param commaHostPort the comma host port
+     * @return the ais tcp reader
      */
     public static AisTcpReader createReader(String commaHostPort) {
         AisTcpReader r = new AisTcpReader();
@@ -87,17 +92,24 @@ public class AisReaders {
         return r;
     }
 
+    /**
+     * Create reader ais tcp reader.
+     *
+     * @param hostname the hostname
+     * @param port     the port
+     * @return the ais tcp reader
+     */
     public static AisTcpReader createReader(String hostname, int port) {
         AisTcpReader r = new AisTcpReader();
         r.addHostPort(HostAndPort.fromParts(hostname, port));
         return r;
     }
-    
+
     /**
      * Creates a {@link AisUdpReader} listening on port for any interface
-     * 
-     * @param port
-     * @return
+     *
+     * @param port the port
+     * @return ais udp reader
      */
     public static AisUdpReader createUdpReader(int port) {
         return createUdpReader(null, port);
@@ -105,37 +117,45 @@ public class AisReaders {
 
     /**
      * Creates a {@link AisUdpReader} listening on ip and port
-     * 
-     * @param address
-     * @param port
-     * @return
+     *
+     * @param address the address
+     * @param port    the port
+     * @return ais udp reader
      */
     public static AisUdpReader createUdpReader(String address, int port) {
         return new AisUdpReader(address, port);
     }
 
+    /**
+     * Create reader from input stream ais reader.
+     *
+     * @param inputStream the input stream
+     * @return the ais reader
+     */
     public static AisReader createReaderFromInputStream(InputStream inputStream) {
         return new AisStreamReader(inputStream);
     }
-    
+
     /**
-     * Creates a {@link AisReader} from a file. If the file has '.zip' or '.gz' suffix the file will treated as a zip file or 
-     * gzip file respectively. 
-     * @param filename
-     * @return
-     * @throws IOException
+     * Creates a {@link AisReader} from a file. If the file has '.zip' or '.gz' suffix the file will treated as a zip file or
+     * gzip file respectively.
+     *
+     * @param filename the filename
+     * @return ais reader
+     * @throws IOException the io exception
      */
     public static AisReader createReaderFromFile(String filename) throws IOException {
         return new AisStreamReader(createFileInputStream(requireNonNull(filename)));
     }
-    
+
     /**
-     * Reader that recursively reads files matching pattern in directories with root dir  
-     * @param dir
-     * @param pattern E.g. *.txt or *.gz
+     * Reader that recursively reads files matching pattern in directories with root dir
+     *
+     * @param dir       the dir
+     * @param pattern   E.g. *.txt or *.gz
      * @param recursive Apply to all sub directories depth first
-     * @return
-     * @throws IOException 
+     * @return ais directory reader
+     * @throws IOException the io exception
      */
     public static AisDirectoryReader createDirectoryReader(String dir, String pattern, boolean recursive) throws IOException {
         return new AisDirectoryReader(dir, pattern, recursive);
@@ -144,7 +164,7 @@ public class AisReaders {
     /**
      * Returns the default sources configured for the system. The default sources can be set using enviroment variable
      * AIS_DEFAULT_SOURCES.
-     * 
+     *
      * @return the default sources configured for the system
      */
     public static String[] getDefaultSources() {
@@ -158,6 +178,12 @@ public class AisReaders {
         return p.split(";");
     }
 
+    /**
+     * Manage group.
+     *
+     * @param group the group
+     * @throws JMException the jm exception
+     */
     public static void manageGroup(AisReaderGroup group) throws JMException {
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         ObjectName mxbeanName = new ObjectName("dk.dma.ais.readers.group." + group.name + ":name=Group");
@@ -174,9 +200,8 @@ public class AisReaders {
      * {@link RoundRobinAisTcpReader} if more than 1 host name is found. Example
      * "mySource=ais163.sealan.dk:65262,ais167.sealan.dk:65261" will return a RoundRobinAisTcpReader alternating between
      * the two sources if one is down.
-     * 
-     * @param fullSource
-     *            the full source
+     *
+     * @param fullSource the full source
      * @return a ais reader
      */
     static AisTcpReader parseSource(String fullSource) {
@@ -208,7 +233,14 @@ public class AisReaders {
             return r;
         }
     }
-    
+
+    /**
+     * Create file input stream input stream.
+     *
+     * @param filename the filename
+     * @return the input stream
+     * @throws IOException the io exception
+     */
     static InputStream createFileInputStream(String filename) throws IOException {
         InputStream in = new FileInputStream(filename);
         if (filename.endsWith(".gz")) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisStreamReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisStreamReader.java
@@ -27,9 +27,8 @@ import java.util.function.Consumer;
 
 /**
  * Thread class for reading any InputStream for AIS messages
- * 
+ * <p>
  * For fail tolerant TCP reading use AisTcpReader
- * 
  */
 public class AisStreamReader extends AisReader {
 
@@ -38,6 +37,11 @@ public class AisStreamReader extends AisReader {
     private final InputStream stream;
     private volatile boolean done;
 
+    /**
+     * Instantiates a new Ais stream reader.
+     *
+     * @param stream the stream
+     */
     AisStreamReader(InputStream stream) {
         this.stream = requireNonNull(stream);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
@@ -36,31 +36,48 @@ import java.util.function.Consumer;
 
 /**
  * Thread class for reading AIS messages from a TCP stream.
- * 
+ * <p>
  * Connection handling is fail tolerant. Connection error is handled by waiting a specified amount of time before doing
  * a re-connect (default 5 sec).
- * 
+ * <p>
  * Handlers for the parsed AIS messages must be registered with registerHanlder() method.
- * 
+ * <p>
  * Example of use:
- * 
+ * <p>
  * IAisHandler handler = new SomeHandler();
- * 
+ * <p>
  * AisTcpReader aisReader = new AisTcpReader("localhost", 4001); aisReader.registerHandler(handler);
  * aisReader.addProprietaryFactory(new GatehouseFactory()); aisReader.start(); aisReader.join();
- * 
  */
 public class AisTcpReader extends AisReader {
 
     private static final Logger LOG = LoggerFactory.getLogger(AisTcpReader.class);
 
+    /**
+     * The Reconnect interval.
+     */
     protected volatile long reconnectInterval = 5000; // Default 5 sec
+    /**
+     * The Output stream.
+     */
     protected OutputStream outputStream;
+    /**
+     * The Client socket.
+     */
     protected final AtomicReference<Socket> clientSocket = new AtomicReference<>(new Socket());
 
+    /**
+     * The Timeout.
+     */
     protected volatile int timeout = 10;
 
+    /**
+     * The Hosts.
+     */
     List<HostAndPort> hosts = new ArrayList<>();
+    /**
+     * The Current host index.
+     */
     int currentHostIndex = -1;
 
     // /**
@@ -75,8 +92,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Add another host/port on the form host:port
-     * 
-     * @param hostPort
+     *
+     * @param hostAndPort the host and port
      */
     void addHostPort(HostAndPort hostAndPort) {
         requireNonNull(hostAndPort);
@@ -124,6 +141,11 @@ public class AisTcpReader extends AisReader {
         } catch (IOException ignored) {}
     }
 
+    /**
+     * Connect.
+     *
+     * @throws IOException the io exception
+     */
     protected void connect() throws IOException {
         try {
             LOG.info("Connecting to source " + currentHost());
@@ -147,6 +169,9 @@ public class AisTcpReader extends AisReader {
         }
     }
 
+    /**
+     * Disconnect.
+     */
     protected void disconnect() {
         if (getStatus() == Status.CONNECTED) {
             try {
@@ -159,9 +184,9 @@ public class AisTcpReader extends AisReader {
     /**
      * Send sendRequest to the socket output stream and get result sent to resultListener.
      * 
-     * @param sendRequest
-     * @param resultListener
-     * @throws SendException
+     * @param sendRequest sendRequest
+     * @param resultListener Consumer resultListener
+     * @throws SendException a SendException
      */
     @Override
     public void send(SendRequest sendRequest, Consumer<Abk> resultListener) throws SendException {
@@ -174,8 +199,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Get the interval in milliseconds between re-connect attempts
-     * 
-     * @return reconnectInterval
+     *
+     * @return reconnectInterval reconnect interval
      */
     public long getReconnectInterval() {
         return reconnectInterval;
@@ -183,8 +208,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Set the interval in milliseconds between re-connect attempts
-     * 
-     * @param reconnectInterval
+     *
+     * @param reconnectInterval the reconnect interval
      */
     public void setReconnectInterval(long reconnectInterval) {
         this.reconnectInterval = reconnectInterval;
@@ -192,8 +217,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Get the number of hosts
-     * 
-     * @return
+     *
+     * @return host count
      */
     public int getHostCount() {
         return hosts.size();
@@ -201,8 +226,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Get socket read timeout
-     * 
-     * @return
+     *
+     * @return timeout timeout
      */
     public int getTimeout() {
         return timeout;
@@ -210,8 +235,8 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Set socket read timeout
-     * 
-     * @param timeout
+     *
+     * @param timeout the timeout
      */
     public void setTimeout(int timeout) {
         this.timeout = timeout;
@@ -219,21 +244,26 @@ public class AisTcpReader extends AisReader {
 
     /**
      * Returns the current hostname
-     * 
-     * @return
+     *
+     * @return hostname hostname
      */
     public String getHostname() {
         return currentHost().getHostText();
     }
 
+    /**
+     * Current host host and port.
+     *
+     * @return the host and port
+     */
     HostAndPort currentHost() {
         return hosts.get(currentHostIndex);
     }
 
     /**
      * Get port
-     * 
-     * @return
+     *
+     * @return port port
      */
     public int getPort() {
         return currentHost().getPort();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisUdpReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisUdpReader.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 
 /**
  * Thread class for reading AIS messages from UDP
- * 
  */
 public class AisUdpReader extends AisReader {
 
@@ -42,10 +41,21 @@ public class AisUdpReader extends AisReader {
     private volatile DatagramSocket socket;
     private volatile Thread reader;
 
+    /**
+     * Instantiates a new Ais udp reader.
+     *
+     * @param port the port
+     */
     AisUdpReader(int port) {
         this(null, port);
     }
 
+    /**
+     * Instantiates a new Ais udp reader.
+     *
+     * @param address the address
+     * @param port    the port
+     */
     AisUdpReader(String address, int port) {
         addr = (address == null) ? new InetSocketAddress(port) : new InetSocketAddress(address, port);
     }
@@ -112,14 +122,28 @@ public class AisUdpReader extends AisReader {
 
         private final ArrayBlockingQueue<byte[]> queue;
 
+        /**
+         * Instantiates a new Udp sentence input stream.
+         */
         public UdpSentenceInputStream() {
             this(1024);
         }
 
+        /**
+         * Instantiates a new Udp sentence input stream.
+         *
+         * @param maxLines the max lines
+         */
         public UdpSentenceInputStream(int maxLines) {
             queue = new ArrayBlockingQueue<>(maxLines);
         }
-        
+
+        /**
+         * Push.
+         *
+         * @param packet the packet
+         * @throws InterruptedException the interrupted exception
+         */
         public void push(byte[] packet) throws InterruptedException {
             queue.put(packet);
         }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/ClientSendThread.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/ClientSendThread.java
@@ -19,29 +19,56 @@ import java.util.function.Consumer;
 
 /**
  * Thread for clients to use for sending. E.g.
- * 
+ * <p>
  * AisReader aisReader = new AisReader(...); aisReader.start();
- * 
+ * <p>
  * SendRequest sendRequest = new SendRequest(...);
- * 
+ * <p>
  * ClientSendThread client = new ClientSendThread(aisReader, sendRequest); client.send();
- * 
+ * <p>
  * client.isSuccess();
- * 
  */
 class ClientSendThread extends Thread implements Consumer<Abk> {
 
+    /**
+     * The Ais reader.
+     */
     protected AisReader aisReader;
+    /**
+     * The Send request.
+     */
     protected SendRequest sendRequest;
+    /**
+     * The Abk.
+     */
     protected Abk abk;
+    /**
+     * The Abk received.
+     */
     protected boolean abkReceived;
+    /**
+     * The Timeout.
+     */
     protected long timeout = 60000; // 60 sec default
 
+    /**
+     * Instantiates a new Client send thread.
+     *
+     * @param aisReader   the ais reader
+     * @param sendRequest the send request
+     */
     public ClientSendThread(AisReader aisReader, SendRequest sendRequest) {
         this.aisReader = aisReader;
         this.sendRequest = sendRequest;
     }
 
+    /**
+     * Send abk.
+     *
+     * @return the abk
+     * @throws SendException        the send exception
+     * @throws InterruptedException the interrupted exception
+     */
     public Abk send() throws SendException, InterruptedException {
         // Send message
         aisReader.send(sendRequest, this);
@@ -94,18 +121,38 @@ class ClientSendThread extends Thread implements Consumer<Abk> {
         }
     }
 
+    /**
+     * Gets timeout.
+     *
+     * @return the timeout
+     */
     public long getTimeout() {
         return timeout;
     }
 
+    /**
+     * Sets timeout.
+     *
+     * @param timeout the timeout
+     */
     public void setTimeout(long timeout) {
         this.timeout = timeout;
     }
 
+    /**
+     * Gets abk.
+     *
+     * @return the abk
+     */
     public Abk getAbk() {
         return abk;
     }
 
+    /**
+     * Gets abk result.
+     *
+     * @return the abk result
+     */
     public Abk.Result getAbkResult() {
         synchronized (this) {
             if (abkReceived) {
@@ -115,6 +162,11 @@ class ClientSendThread extends Thread implements Consumer<Abk> {
         return null;
     }
 
+    /**
+     * Is success boolean.
+     *
+     * @return the boolean
+     */
     public boolean isSuccess() {
         synchronized (this) {
             if (!abkReceived) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendException.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendException.java
@@ -22,6 +22,11 @@ import java.io.IOException;
 public class SendException extends IOException {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Send exception.
+     *
+     * @param msg the msg
+     */
     public SendException(String msg) {
         super(msg);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendRequest.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendRequest.java
@@ -38,20 +38,34 @@ public class SendRequest {
     private int destination;
     private String talker;
 
+    /**
+     * Instantiates a new Send request.
+     *
+     * @param aisMessage  the ais message
+     * @param sequence    the sequence
+     * @param destination the destination
+     */
     public SendRequest(AisMessage aisMessage, int sequence, int destination) {
         this.aisMessage = aisMessage;
         this.sequence = sequence;
         this.destination = destination;
     }
 
+    /**
+     * Instantiates a new Send request.
+     *
+     * @param aisMessage the ais message
+     * @param sequence   the sequence
+     */
     public SendRequest(AisMessage aisMessage, int sequence) {
         this(aisMessage, sequence, 0);
     }
 
     /**
      * Generate sentences to send. ABM or BBM. c
-     * 
+     *
      * @return list of actual sentences
+     * @throws SendException the send exception
      */
     public String[] createSentences() throws SendException {
         SendSentence sendSentence = null;
@@ -109,38 +123,83 @@ public class SendRequest {
         return encodedSentences;
     }
 
+    /**
+     * Gets ais message.
+     *
+     * @return the ais message
+     */
     public AisMessage getAisMessage() {
         return aisMessage;
     }
 
+    /**
+     * Sets ais message.
+     *
+     * @param aisMessage the ais message
+     */
     public void setAisMessage(AisMessage aisMessage) {
         this.aisMessage = aisMessage;
     }
 
+    /**
+     * Gets sequence.
+     *
+     * @return the sequence
+     */
     public int getSequence() {
         return sequence;
     }
 
+    /**
+     * Sets sequence.
+     *
+     * @param sequence the sequence
+     */
     public void setSequence(int sequence) {
         this.sequence = sequence;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public int getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(int destination) {
         this.destination = destination;
     }
 
+    /**
+     * Add prefix sentence.
+     *
+     * @param sentence the sentence
+     */
     public void addPrefixSentence(String sentence) {
         this.prefixSentences.add(sentence);
     }
 
+    /**
+     * Gets talker.
+     *
+     * @return the talker
+     */
     public String getTalker() {
         return talker;
     }
 
+    /**
+     * Sets talker.
+     *
+     * @param talker the talker
+     */
     public void setTalker(String talker) {
         this.talker = talker;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendThread.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendThread.java
@@ -47,6 +47,13 @@ public class SendThread extends Thread {
      */
     private Abk abk;
 
+    /**
+     * Instantiates a new Send thread.
+     *
+     * @param hash           the hash
+     * @param resultListener the result listener
+     * @param sendThreadPool the send thread pool
+     */
     public SendThread(String hash, Consumer<Abk> resultListener, SendThreadPool sendThreadPool) {
         setDaemon(true);
         this.hash = hash;
@@ -56,8 +63,8 @@ public class SendThread extends Thread {
 
     /**
      * Set the result for this thread
-     * 
-     * @param abk
+     *
+     * @param abk the abk
      */
     public synchronized void setAbk(Abk abk) {
         if (this.abk != null) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendThreadPool.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/SendThreadPool.java
@@ -37,14 +37,17 @@ public class SendThreadPool {
      */
     private ConcurrentHashMap<String, SendThread> threads = new ConcurrentHashMap<>();
 
+    /**
+     * Instantiates a new Send thread pool.
+     */
     public SendThreadPool() {}
 
     /**
      * Create a new send thread and register in pool
-     * 
-     * @param sendRequest
-     * @param resultListener
-     * @return
+     *
+     * @param sendRequest    the send request
+     * @param resultListener the result listener
+     * @return send thread
      */
     public SendThread createSendThread(SendRequest sendRequest, Consumer<Abk> resultListener) {
         // Generate hash value that uniquely defines message
@@ -63,8 +66,8 @@ public class SendThreadPool {
 
     /**
      * Handle received ABK
-     * 
-     * @param abk
+     *
+     * @param abk the abk
      */
     public void handleAbk(Abk abk) {
         LOG.debug("Handling Abk: " + abk);
@@ -79,6 +82,11 @@ public class SendThreadPool {
         sendThread.setAbk(abk);
     }
 
+    /**
+     * Remove thread.
+     *
+     * @param hash the hash
+     */
     public void removeThread(String hash) {
         LOG.debug("Removing thread with hash: " + hash);
         threads.remove(hash);
@@ -87,9 +95,9 @@ public class SendThreadPool {
 
     /**
      * Static method to generate hash from send request
-     * 
-     * @param sendRequest
-     * @return seq+sentenceStr id+dest
+     *
+     * @param sendRequest the send request
+     * @return seq +sentenceStr id+dest
      */
     public static String sendHash(SendRequest sendRequest) {
         int seq = sendRequest.getSequence();
@@ -100,9 +108,9 @@ public class SendThreadPool {
 
     /**
      * Static method to generate hash from ABK
-     * 
-     * @param abk
-     * @return seq+sentenceStr id+dest
+     *
+     * @param abk the abk
+     * @return seq +sentenceStr id+dest
      */
     public static String abkHash(Abk abk) {
         int seq = abk.getSequence();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/Target.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/Target.java
@@ -18,15 +18,24 @@ package dk.dma.ais.tracker;
 import javax.annotation.concurrent.Immutable;
 import java.io.Serializable;
 
+/**
+ * The type Target.
+ */
 @Immutable
 public abstract class Target implements Serializable {
 
+    /**
+     * Instantiates a new Target.
+     *
+     * @param mmsi the mmsi
+     */
     protected Target(int mmsi) {
         this.mmsi = mmsi;
     }
 
     /**
      * Returns the MMSI of the Track.
+     *
      * @return the MMSI of the Track
      */
     public int getMmsi() {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/Tracker.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/Tracker.java
@@ -25,9 +25,9 @@ import java.io.IOException;
 /**
  * A tracking service receives AisPackets and based on these it maintains a collection of all known tracks,
  * including their position, speed, course, etc.
- *
+ * <p>
  * The AisPackets are assumed to arrive in timely order; i.e. by ever-increasing values of timestamp.
- *
+ * <p>
  * TODO: Identify further methods which can be shared between tracker implementations.
  */
 public interface Tracker {
@@ -46,6 +46,7 @@ public interface Tracker {
      * Start to track targets based on AisPackets received from an AisPacketReader.
      *
      * @param packetReader the AisPacketReader to receive packets from.
+     * @throws IOException the io exception
      */
     default void subscribeToPacketReader(AisPacketReader packetReader) throws IOException {
         packetReader.forEachRemaining(p -> update(p));
@@ -53,6 +54,7 @@ public interface Tracker {
 
     /**
      * Update the tracker with a single AisPacket.
+     *
      * @param aisPacket the AIS packet.
      */
     void update(AisPacket aisPacket);
@@ -60,8 +62,7 @@ public interface Tracker {
     /**
      * Returns the latest target info for the specified MMSI number.
      *
-     * @param mmsi
-     *            the MMSI number
+     * @param mmsi the MMSI number
      * @return the latest target info for the specified MMSI number
      */
     Target get(int mmsi);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/AisTrackingReport.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/AisTrackingReport.java
@@ -33,6 +33,11 @@ public final class AisTrackingReport extends TrackingReport {
 
     private final AisPacket packet;
 
+    /**
+     * Instantiates a new Ais tracking report.
+     *
+     * @param aisPacket the ais packet
+     */
     public AisTrackingReport(AisPacket aisPacket) {
         AisMessage aisMessage = aisPacket.tryGetAisMessage();
         if (! (aisMessage instanceof IVesselPositionMessage)) {
@@ -42,6 +47,11 @@ public final class AisTrackingReport extends TrackingReport {
         this.packet = aisPacket;
     }
 
+    /**
+     * Gets packet.
+     *
+     * @return the packet
+     */
     public AisPacket getPacket() {
         return packet;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/EventEmittingTracker.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/EventEmittingTracker.java
@@ -18,6 +18,14 @@ package dk.dma.ais.tracker.eventEmittingTracker;
 
 import dk.dma.ais.tracker.Tracker;
 
+/**
+ * The interface Event emitting tracker.
+ */
 public interface EventEmittingTracker extends Tracker {
+    /**
+     * Register subscriber.
+     *
+     * @param subscriber the subscriber
+     */
     void registerSubscriber(Object subscriber);
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/InterpolatedTrackingReport.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/InterpolatedTrackingReport.java
@@ -22,6 +22,9 @@ import net.jcip.annotations.NotThreadSafe;
 
 import java.time.LocalDateTime;
 
+/**
+ * The type Interpolated tracking report.
+ */
 @NotThreadSafe
 public final class InterpolatedTrackingReport extends TrackingReport {
     private final long timestamp;
@@ -30,6 +33,15 @@ public final class InterpolatedTrackingReport extends TrackingReport {
     private final float speedOverGround;
     private final float trueHeading;
 
+    /**
+     * Instantiates a new Interpolated tracking report.
+     *
+     * @param timestamp        the timestamp
+     * @param position         the position
+     * @param courseOverGround the course over ground
+     * @param speedOverGround  the speed over ground
+     * @param trueHeading      the true heading
+     */
     public InterpolatedTrackingReport(long timestamp, Position position, float courseOverGround, float speedOverGround, float trueHeading) {
         this.timestamp = timestamp;
         this.position = position;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/TrackingReport.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/TrackingReport.java
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * A tracking report is a unique, separate report concerning a specific vessel's current
  * position, speed, and course.
- *
+ * <p>
  * This piece of information is stored in the tracker to keep track of each vessel's movements
  * and whereabouts.
  */
@@ -35,14 +35,31 @@ public abstract class TrackingReport implements Cloneable {
 
     private Map<String, Object> properties = new HashMap<>(2);
 
+    /**
+     * Gets property.
+     *
+     * @param propertyName the property name
+     * @return the property
+     */
     public Object getProperty(String propertyName) {
         return properties.get(propertyName);
     }
 
+    /**
+     * Sets property.
+     *
+     * @param propertyName  the property name
+     * @param propertyValue the property value
+     */
     public void setProperty(String propertyName, Object propertyValue) {
         properties.put(propertyName, propertyValue);
     }
 
+    /**
+     * Remove property.
+     *
+     * @param propertyName the property name
+     */
     public void removeProperty(String propertyName) {
         properties.remove(propertyName);
     }
@@ -57,10 +74,45 @@ public abstract class TrackingReport implements Cloneable {
 
     // ---
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     public abstract long getTimestamp();
+
+    /**
+     * Gets timestamp typed.
+     *
+     * @return the timestamp typed
+     */
     public abstract LocalDateTime getTimestampTyped();
+
+    /**
+     * Gets position.
+     *
+     * @return the position
+     */
     public abstract Position getPosition();
+
+    /**
+     * Gets course over ground.
+     *
+     * @return the course over ground
+     */
     public abstract float getCourseOverGround();
+
+    /**
+     * Gets speed over ground.
+     *
+     * @return the speed over ground
+     */
     public abstract float getSpeedOverGround();
+
+    /**
+     * Gets true heading.
+     *
+     * @return the true heading
+     */
     public abstract float getTrueHeading();
 }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/CellChangedEvent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/CellChangedEvent.java
@@ -25,11 +25,22 @@ import dk.dma.ais.tracker.eventEmittingTracker.Track;
 public class CellChangedEvent extends TrackEvent {
     private final Long oldCellId;
 
+    /**
+     * Instantiates a new Cell changed event.
+     *
+     * @param track     the track
+     * @param oldCellId the old cell id
+     */
     public CellChangedEvent(Track track, Long oldCellId) {
         super(track);
         this.oldCellId = oldCellId;
     }
 
+    /**
+     * Gets old cell id.
+     *
+     * @return the old cell id
+     */
     public final Long getOldCellId() {
         return oldCellId;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/PositionChangedEvent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/PositionChangedEvent.java
@@ -26,11 +26,22 @@ import dk.dma.enav.model.geometry.Position;
 public class PositionChangedEvent extends TrackEvent {
     private final Position oldPosition;
 
+    /**
+     * Instantiates a new Position changed event.
+     *
+     * @param track       the track
+     * @param oldPosition the old position
+     */
     public PositionChangedEvent(Track track, Position oldPosition) {
         super(track);
         this.oldPosition = oldPosition;
     }
 
+    /**
+     * Gets old position.
+     *
+     * @return the old position
+     */
     public final Position getOldPosition() {
         return oldPosition;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TimeEvent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TimeEvent.java
@@ -30,15 +30,31 @@ public class TimeEvent extends TrackerEvent {
     private final Instant timestamp;
     private final Duration millisSinceLastMark;
 
+    /**
+     * Instantiates a new Time event.
+     *
+     * @param timestamp         the timestamp
+     * @param timeSinceLastMark the time since last mark
+     */
     public TimeEvent(Instant timestamp, Duration timeSinceLastMark) {
         this.timestamp = timestamp;
         this.millisSinceLastMark = timeSinceLastMark;
     }
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     public final Instant getTimestamp() {
         return timestamp;
     }
 
+    /**
+     * Gets millis since last mark.
+     *
+     * @return the millis since last mark
+     */
     public Duration getMillisSinceLastMark() {
         return millisSinceLastMark;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TrackEvent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TrackEvent.java
@@ -26,10 +26,20 @@ public abstract class TrackEvent extends TrackerEvent {
 
     private final Track track;
 
+    /**
+     * Instantiates a new Track event.
+     *
+     * @param track the track
+     */
     TrackEvent(Track track) {
         this.track = track;
     }
 
+    /**
+     * Gets track.
+     *
+     * @return the track
+     */
     public final Track getTrack() {
         return track;
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TrackStaleEvent.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/eventEmittingTracker/events/TrackStaleEvent.java
@@ -25,6 +25,11 @@ import dk.dma.ais.tracker.eventEmittingTracker.Track;
  */
 public class TrackStaleEvent extends TrackEvent {
 
+    /**
+     * Instantiates a new Track stale event.
+     *
+     * @param track the track
+     */
     public TrackStaleEvent(Track track) {
         super(track);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/scenarioTracker/ScenarioTracker.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/scenarioTracker/ScenarioTracker.java
@@ -54,7 +54,8 @@ public class ScenarioTracker implements Tracker {
 
     /**
      * Get the Date of the first update in this scenario.
-     * @return
+     *
+     * @return date date
      */
     public Date scenarioBegin() {
         Date scenarioBegin = null;
@@ -75,7 +76,8 @@ public class ScenarioTracker implements Tracker {
 
     /**
      * Get the Date of the last update in this scenario.
-     * @return
+     *
+     * @return date date
      */
     public Date scenarioEnd() {
         Date scenarioEnd = null;
@@ -96,7 +98,8 @@ public class ScenarioTracker implements Tracker {
 
     /**
      * Get bounding box containing all movements in this scenario.
-     * @return
+     *
+     * @return bounding box
      */
     public BoundingBox boundingBox() {
         return boundingBox;
@@ -104,7 +107,8 @@ public class ScenarioTracker implements Tracker {
 
     /**
      * Return all targets involved in this scenario.
-     * @return
+     *
+     * @return targets targets
      */
     public ImmutableSet<Target> getTargets() {
         return ImmutableSet.copyOf(targets.values());
@@ -123,7 +127,8 @@ public class ScenarioTracker implements Tracker {
 
     /**
      * Return all targets involved in this scenario and with a known location (ie. located inside of the bounding box).
-     * @return
+     *
+     * @return targets having position updates
      */
     public Set<Target> getTargetsHavingPositionUpdates() {
         return Sets.filter(getTargets(), new com.google.common.base.Predicate<Target>() {
@@ -156,6 +161,12 @@ public class ScenarioTracker implements Tracker {
         }
     }
 
+    /**
+     * Tag target.
+     *
+     * @param mmsi the mmsi
+     * @param tag  the tag
+     */
     public void tagTarget(int mmsi, Object tag) {
         targets.get(mmsi).setTag(tag);
     }
@@ -181,47 +192,105 @@ public class ScenarioTracker implements Tracker {
         return aisString.replace('@',' ').trim();
     }
 
+    /**
+     * The type Target.
+     */
     @NotThreadSafe
     public final class Target extends dk.dma.ais.tracker.Target implements Cloneable {
 
+        /**
+         * Instantiates a new Target.
+         *
+         * @param mmsi the mmsi
+         */
         public Target(int mmsi) {
             super(mmsi);
         }
 
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
         public String getName() {
             return StringUtils.isBlank(name) ? String.valueOf(getMmsi()) : name;
         }
 
+        /**
+         * Gets imo.
+         *
+         * @return the imo
+         */
         public int getImo() {
             return imo;
         }
 
+        /**
+         * Gets destination.
+         *
+         * @return the destination
+         */
         public String getDestination() {
             return destination == null ? "" : destination;
         }
 
+        /**
+         * Gets ship type cargo.
+         *
+         * @return the ship type cargo
+         */
         public ShipTypeCargo getShipTypeCargo() { return shipTypeCargo; }
 
+        /**
+         * Gets cargo type as string.
+         *
+         * @return the cargo type as string
+         */
         public String getCargoTypeAsString() {
             return shipTypeCargo == null ? null : shipTypeCargo.prettyCargo();
         }
 
+        /**
+         * Gets ship type as string.
+         *
+         * @return the ship type as string
+         */
         public String getShipTypeAsString() {
             return shipTypeCargo == null ? null : shipTypeCargo.prettyType();
         }
 
+        /**
+         * Gets to bow.
+         *
+         * @return the to bow
+         */
         public int getToBow() {
             return toBow;
         }
 
+        /**
+         * Gets to stern.
+         *
+         * @return the to stern
+         */
         public int getToStern() {
             return toStern;
         }
 
+        /**
+         * Gets to port.
+         *
+         * @return the to port
+         */
         public int getToPort() {
             return toPort;
         }
 
+        /**
+         * Gets to starboard.
+         *
+         * @return the to starboard
+         */
         public int getToStarboard() {
             return toStarboard;
         }
@@ -230,30 +299,56 @@ public class ScenarioTracker implements Tracker {
             tags.add(tag);
         }
 
+        /**
+         * Is tagged boolean.
+         *
+         * @param tag the tag
+         * @return the boolean
+         */
         public boolean isTagged(Object tag) {
             return tags.contains(tag);
         }
 
+        /**
+         * Has position boolean.
+         *
+         * @return the boolean
+         */
         public boolean hasPosition() {
             return positionReports.size() > 0;
         }
 
+        /**
+         * Gets position reports.
+         *
+         * @return the position reports
+         */
         public Set<PositionReport> getPositionReports() {
             return ImmutableSet.copyOf(positionReports.values());
         }
 
+        /**
+         * Time of first position report date.
+         *
+         * @return the date
+         */
         public Date timeOfFirstPositionReport() {
             return positionReports.firstKey();
         }
 
+        /**
+         * Time of last position report date.
+         *
+         * @return the date
+         */
         public Date timeOfLastPositionReport() {
             return positionReports.lastKey();
         }
 
         /**
-         *  Return position at at time atTime. If a real position report which is not older than 'maxAge' seconds compared to
-         *  atTime exists, then that real AIS-based position report will be returned. Otherwise a position report will
-         *  be inter- or extrapolated to provide an estimated position report.
+         * Return position at at time atTime. If a real position report which is not older than 'maxAge' seconds compared to
+         * atTime exists, then that real AIS-based position report will be returned. Otherwise a position report will
+         * be inter- or extrapolated to provide an estimated position report.
          *
          * @param atTime The time at which to return a position report.
          * @param maxAge The max. no. of seconds to look back in history for a position report before estimating one.
@@ -283,7 +378,7 @@ public class ScenarioTracker implements Tracker {
          * Get or estimate a position report. If a real position report exists somewhere in the range
          * (atTime - deltaSeconds; atTime] then return this report. Otherwise return null.
          *
-         * @param atTime the time to which to look for a position report.
+         * @param atTime       the time to which to look for a position report.
          * @param deltaSeconds the maximum number of seconds to go back to find a matching position report.
          * @return a matching position report or null.
          */
@@ -339,6 +434,9 @@ public class ScenarioTracker implements Tracker {
         private final Set<Object> tags = new HashSet<>();
         private final TreeMap<Date, PositionReport> positionReports = new TreeMap<>();
 
+        /**
+         * The type Position report.
+         */
         @Immutable
         public final class PositionReport {
             private PositionReport(PositionTime pt, float cog, float sog, int heading, NavigationalStatus navstat, boolean estimated) {
@@ -359,36 +457,81 @@ public class ScenarioTracker implements Tracker {
                 this.estimated = estimated;
             }
 
+            /**
+             * Gets position time.
+             *
+             * @return the position time
+             */
             public PositionTime getPositionTime() {
                 return positionTime;
             }
 
+            /**
+             * Gets timestamp.
+             *
+             * @return the timestamp
+             */
             public long getTimestamp() {
                 return positionTime.getTime();
             }
 
+            /**
+             * Gets latitude.
+             *
+             * @return the latitude
+             */
             public double getLatitude() {
                 return positionTime.getLatitude();
             }
 
+            /**
+             * Gets longitude.
+             *
+             * @return the longitude
+             */
             public double getLongitude() {
                 return positionTime.getLongitude();
             }
 
+            /**
+             * Gets cog.
+             *
+             * @return the cog
+             */
             public float getCog() {
                 return cog;
             }
 
+            /**
+             * Gets sog.
+             *
+             * @return the sog
+             */
             public float getSog() {
                 return sog;
             }
 
+            /**
+             * Gets heading.
+             *
+             * @return the heading
+             */
             public int getHeading() {
                 return heading;
             }
 
+            /**
+             * Gets navigational status.
+             *
+             * @return the navigational status
+             */
             public NavigationalStatus getNavigationalStatus() { return navstat; }
 
+            /**
+             * Is estimated boolean.
+             *
+             * @return the boolean
+             */
             public boolean isEstimated() {
                 return estimated;
             }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetInfo.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetInfo.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Immutable information about a target. Whenever we receive a new message from the target. We create a new TargetInfo
  * instance via {@link #updateTarget(TargetInfo, AisPacket, AisTargetType, long, AisPacketSource, Map)}.
- * 
+ *
  * @author Kasper Nielsen
  */
 public class TargetInfo extends Target {
@@ -44,34 +44,86 @@ public class TargetInfo extends Target {
     /** serialVersionUID. */
     private static final long serialVersionUID = 2L;
 
-    /** The target type of the info, is never null. */
+    /**
+     * The target type of the info, is never null.
+     */
     final AisTargetType targetType;
-    
-    /** The latest position and time stamp that was received Packet that was received. */
+
+    /**
+     * The latest position and time stamp that was received Packet that was received.
+     */
     final long positionTimestamp;
+    /**
+     * The Position packet.
+     */
     final byte[] positionPacket;
+    /**
+     * The Position.
+     */
     final Position position;
 
+    /**
+     * The Cog.
+     */
     final float cog;
+    /**
+     * The Heading.
+     */
     final int heading;
+    /**
+     * The Nav status.
+     */
     final byte navStatus;
+    /**
+     * The Sog.
+     */
     final float sog;
-    
-    //Do not want serialization of mutable complex object
+
+    /**
+     * The Ais target.
+     */
+//Do not want serialization of mutable complex object
     transient volatile AisTarget aisTarget;
-    //further caching
+    /**
+     * The Position ais packet.
+     */
+//further caching
     transient volatile AisPacket positionAisPacket;
+    /**
+     * The Static ais packet 1.
+     */
     transient volatile AisPacket staticAisPacket1;
+    /**
+     * The Static ais packet 2.
+     */
     transient volatile AisPacket staticAisPacket2;
 
-    // The latest static info
+    /**
+     * The constant staticTimestamp.
+     */
+// The latest static info
     final long staticTimestamp;
+    /**
+     * The Static data 1.
+     */
     final byte[] staticData1;
+    /**
+     * The Static data 2.
+     */
     final byte[] staticData2;
+    /**
+     * The Static ship type.
+     */
     final int staticShipType;
 
-    final AisPacketSource packetSource;
     /**
+     * The Packet source.
+     */
+    final AisPacketSource packetSource;
+
+    /**
+     * Gets packet source.
+     *
      * @return the packetSource
      */
     public AisPacketSource getPacketSource() {
@@ -113,44 +165,90 @@ public class TargetInfo extends Target {
 
     /**
      * Returns the target type of the target.
-     * @return
+     *
+     * @return target type
      */
     public AisTargetType getTargetType() {
         return targetType;
     }
 
+    /**
+     * Gets position timestamp.
+     *
+     * @return the position timestamp
+     */
     public long getPositionTimestamp() {
         return positionTimestamp;
     }
 
+    /**
+     * Gets position.
+     *
+     * @return the position
+     */
     public Position getPosition() {
         return position;
     }
 
+    /**
+     * Gets cog.
+     *
+     * @return the cog
+     */
     public float getCog() {
         return cog;
     }
 
+    /**
+     * Gets heading.
+     *
+     * @return the heading
+     */
     public int getHeading() {
         return heading;
     }
 
+    /**
+     * Gets nav status.
+     *
+     * @return the nav status
+     */
     public byte getNavStatus() {
         return navStatus;
     }
 
+    /**
+     * Gets sog.
+     *
+     * @return the sog
+     */
     public float getSog() {
         return sog;
     }
 
+    /**
+     * Gets static timestamp.
+     *
+     * @return the static timestamp
+     */
     public long getStaticTimestamp() {
         return staticTimestamp;
     }
 
+    /**
+     * Gets static ship type.
+     *
+     * @return the static ship type
+     */
     public int getStaticShipType() {
         return staticShipType;
     }
 
+    /**
+     * Gets ais target.
+     *
+     * @return the ais target
+     */
     public AisTarget getAisTarget() {
         AisTarget t = aisTarget;
         return t == null ?aisTarget = TargetInfoToAisTarget.generateAisTarget(this) : t;
@@ -158,7 +256,7 @@ public class TargetInfo extends Target {
 
     /**
      * Returns the country of the vessel based on its MMSI number.
-     * 
+     *
      * @return the country of the vessel based on its MMSI number
      */
     public Country getCountry() {
@@ -168,7 +266,7 @@ public class TargetInfo extends Target {
     /**
      * Returns the latest received position packet. Or <code>null</code> if no position has been received from the
      * vessel.
-     * 
+     *
      * @return the latest received position packet
      */
     public AisPacket getPositionPacket() {
@@ -183,7 +281,7 @@ public class TargetInfo extends Target {
     /**
      * Returns the number of static packets we have received. Either return 0 if we have received 0 packets. 1 if we
      * have received a single packet. Or 2 we if have received two packets (AisMessage type 24).
-     * 
+     *
      * @return the number of static packets we have received
      */
     public int getStaticCount() {
@@ -192,6 +290,8 @@ public class TargetInfo extends Target {
 
     /**
      * Returns any static packets we have received from the target.
+     *
+     * @return the ais packet [ ]
      */
     public AisPacket[] getStaticPackets() {
         if (staticData1 == null) {
@@ -202,7 +302,12 @@ public class TargetInfo extends Target {
             return new AisPacket[] { getStaticAisPacket1(), getStaticAisPacket2() };
         }
     }
-    
+
+    /**
+     * Get packets ais packet [ ].
+     *
+     * @return the ais packet [ ]
+     */
     public AisPacket[] getPackets() {
         if (!hasPositionInfo()) {
             return getStaticPackets();
@@ -219,6 +324,11 @@ public class TargetInfo extends Target {
         return packets.toArray(new AisPacket[packets.size()]);
     }
 
+    /**
+     * Gets static ais packet 1.
+     *
+     * @return the static ais packet 1
+     */
     public AisPacket getStaticAisPacket1() {
         byte[] staticData1 = this.staticData1;
         if (staticData1 != null) {
@@ -227,7 +337,12 @@ public class TargetInfo extends Target {
         }
         return null;
     }
-    
+
+    /**
+     * Gets static ais packet 2.
+     *
+     * @return the static ais packet 2
+     */
     public AisPacket getStaticAisPacket2() {
         byte[] staticData2 = this.staticData2;
         if (staticData2 != null) {
@@ -235,11 +350,11 @@ public class TargetInfo extends Target {
             return staticAisPacket2 == null ? staticAisPacket2 = AisPacket.fromByteArray(staticData2): staticAisPacket2;
         }
         return null;
-    }    
+    }
 
     /**
      * Returns true if we have positional information.
-     * 
+     *
      * @return true if we have positional information
      */
     public boolean hasPositionInfo() {
@@ -248,13 +363,19 @@ public class TargetInfo extends Target {
 
     /**
      * Returns true if we have static information.
-     * 
+     *
      * @return true if we have static information
      */
     public boolean hasStaticInfo() {
         return staticData1 != null;
     }
 
+    /**
+     * Merge target info.
+     *
+     * @param other the other
+     * @return the target info
+     */
     TargetInfo merge(TargetInfo other) {
         if (positionTimestamp >= other.positionTimestamp && staticTimestamp >= other.staticTimestamp) {
             return this;
@@ -268,8 +389,8 @@ public class TargetInfo extends Target {
     /**
      * Copies the static information from the specified target into a new target. Maintaining the position information
      * of the current target.
-     * 
-     * @param other
+     *
+     * @param other the other
      * @return the new target
      */
     TargetInfo mergeWithStaticFrom(TargetInfo other) {
@@ -280,19 +401,13 @@ public class TargetInfo extends Target {
 
     /**
      * We have received a new AIS message from a target.
-     * 
-     * @param existing
-     *            non-null if an existing target with the same MMSI number already exists
-     * @param packet
-     *            the packet that was received
-     * @param targetType
-     *            the type of target
-     * @param timestamp
-     *            the timestamp of the packet
-     * @param source
-     *            the source of the packet
-     * @param msg24Part0
-     *            a map of cached message type 24 static part 0 messages
+     *
+     * @param existing   non-null if an existing target with the same MMSI number already exists
+     * @param packet     the packet that was received
+     * @param targetType the type of target
+     * @param timestamp  the timestamp of the packet
+     * @param source     the source of the packet
+     * @param msg24Part0 a map of cached message type 24 static part 0 messages
      * @return a new target info
      */
     static TargetInfo updateTarget(TargetInfo existing, AisPacket packet, AisTargetType targetType, long timestamp,
@@ -314,6 +429,18 @@ public class TargetInfo extends Target {
         return updateTargetWithStatic(packet, message, mmsi, targetType, timestamp, source, result, msg24Part0);
     }
 
+    /**
+     * Update target with position target info.
+     *
+     * @param existing   the existing
+     * @param packet     the packet
+     * @param message    the message
+     * @param mmsi       the mmsi
+     * @param targetType the target type
+     * @param timestamp  the timestamp
+     * @param source     the source
+     * @return the target info
+     */
     static TargetInfo updateTargetWithPosition(TargetInfo existing, AisPacket packet, AisMessage message, int mmsi,
             AisTargetType targetType, long timestamp, AisPacketSource source) {
         if (message instanceof IVesselPositionMessage) {
@@ -345,6 +472,19 @@ public class TargetInfo extends Target {
         return existing;
     }
 
+    /**
+     * Update target with static target info.
+     *
+     * @param packet     the packet
+     * @param message    the message
+     * @param mmsi       the mmsi
+     * @param targetType the target type
+     * @param timestamp  the timestamp
+     * @param source     the source
+     * @param existing   the existing
+     * @param msg24Part0 the msg 24 part 0
+     * @return the target info
+     */
     static TargetInfo updateTargetWithStatic(AisPacket packet, AisMessage message, int mmsi, AisTargetType targetType,
             long timestamp, AisPacketSource source, TargetInfo existing, Map<AisPacketSource, byte[]> msg24Part0) {
         if (message instanceof AisStaticCommon) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetInfoToAisTarget.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetInfoToAisTarget.java
@@ -31,12 +31,17 @@ import java.util.function.Consumer;
 
 /**
  * Necessary Evil for legacy resources and convenience
- * 
- * @author Jens Tuxen
  *
+ * @author Jens Tuxen
  */
 public class TargetInfoToAisTarget {
 
+    /**
+     * Gets packets in order.
+     *
+     * @param ti the ti
+     * @return the packets in order
+     */
     static PriorityQueue<AisPacket> getPacketsInOrder(TargetInfo ti) {
 
         // Min-Heap = Oldest first when creating AisTarget (natural)
@@ -62,6 +67,12 @@ public class TargetInfoToAisTarget {
         return messages;
     }
 
+    /**
+     * Generate ais target ais target.
+     *
+     * @param ti the ti
+     * @return the ais target
+     */
     public static AisTarget generateAisTarget(TargetInfo ti) {
         PriorityQueue<AisPacket> normal = getPacketsInOrder(ti);
         // why reversed also? A workaround for AisTargets without static information for some reason
@@ -76,9 +87,9 @@ public class TargetInfoToAisTarget {
     /**
      * Update aisTarget with messages (note that if the packets are of different class type,
      *
-     * @param aisTarget
-     * @param messages
-     * @return
+     * @param aisTarget the ais target
+     * @param messages  the messages
+     * @return ais target
      */
     static AisTarget updateAisTarget(AisTarget aisTarget, PriorityQueue<AisPacket> messages) {
         while (!messages.isEmpty()) {
@@ -118,6 +129,12 @@ public class TargetInfoToAisTarget {
 
     }
 
+    /**
+     * Generate ais target ais target.
+     *
+     * @param messages the messages
+     * @return the ais target
+     */
     static AisTarget generateAisTarget(PriorityQueue<AisPacket> messages) {
         AisTarget aisTarget = null;
 
@@ -128,6 +145,13 @@ public class TargetInfoToAisTarget {
         return updateAisTarget(aisTarget, messages);
     }
 
+    /**
+     * The entry point of application.
+     *
+     * @param args the input arguments
+     * @throws IOException          the io exception
+     * @throws InterruptedException the interrupted exception
+     */
     public static void main(String[] args) throws IOException, InterruptedException {
         AisReader reader = AisReaders.createDirectoryReader("src/test", "s*.txt", true);
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetTracker.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetTracker.java
@@ -39,19 +39,22 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * There are no automatically cleanup instead users must regularly cleanup targets by calling
  * {@link #removeAll(Predicate)}
- * 
+ *
  * @author Kasper Nielsen
  * @author Jens Tuxen
  */
 public class TargetTracker implements Tracker {
 
-    /** All targets that we are currently monitoring. */
+    /**
+     * All targets that we are currently monitoring.
+     */
     final ConcurrentHashMap<Integer, MmsiTarget> targets = new ConcurrentHashMap<>();
 
     /**
      * Returns the number of targets that is being tracked. This is usually a lot faster than invoking
      * <tt>stream(predicate).count()</tt>
-     * 
+     *
+     * @param predicate the predicate
      * @return the number of targets that is being tracked
      */
     public int count(Predicate<? super AisPacketSource> predicate) {
@@ -91,6 +94,13 @@ public class TargetTracker implements Tracker {
         return get(mmsi, e -> true);
     }
 
+    /**
+     * Get target info.
+     *
+     * @param mmsi            the mmsi
+     * @param sourcePredicate the source predicate
+     * @return the target info
+     */
     public TargetInfo get(int mmsi, Predicate<? super AisPacketSource> sourcePredicate) {
         MmsiTarget target = targets.get(mmsi);
         return target == null ? null : target.getLatest(sourcePredicate);
@@ -99,8 +109,7 @@ public class TargetTracker implements Tracker {
     /**
      * Returns a set of all packet sources for a given MMSI number.
      *
-     * @param mmsi
-     *            the MMSI number
+     * @param mmsi the MMSI number
      * @return a set of all packet sources for a given MMSI number
      */
     public Set<AisPacketSource> getPacketSourcesForMMSI(int mmsi) {
@@ -112,8 +121,7 @@ public class TargetTracker implements Tracker {
      * Removes all targets that are accepted by the specified predicate. Is typically used to remove targets based on
      * time stamps.
      *
-     * @param predicate
-     *            the predicate that selects which items to remove
+     * @param predicate the predicate that selects which items to remove
      */
     public void removeAll(Predicate<? super TargetInfo> predicate) {
         requireNonNull(predicate);
@@ -134,8 +142,7 @@ public class TargetTracker implements Tracker {
      * Removes all targets that are accepted by the specified predicate. Is
      * typically used to remove targets based on time stamps.
      *
-     * @param predicate
-     *            the predicate that selects which items to remove
+     * @param predicate the predicate that selects which items to remove
      */
     public void removeAll(BiPredicate<? super AisPacketSource, ? super TargetInfo> predicate) {
         requireNonNull(predicate);
@@ -185,8 +192,9 @@ public class TargetTracker implements Tracker {
 
     /**
      * Creates a sequential stream of targets with the specified source predicate and matching the given targetPredicate.
-     * @param sourcePredicate
-     * @param targetPredicate
+     *
+     * @param sourcePredicate the source predicate
+     * @param targetPredicate the target predicate
      * @return a stream of targets
      */
     public Stream<TargetInfo> stream(Predicate<? super AisPacketSource> sourcePredicate, Predicate<? super TargetInfo> targetPredicate) {
@@ -207,8 +215,7 @@ public class TargetTracker implements Tracker {
     /**
      * Creates a sequential stream of targets with the specified source predicate.
      *
-     * @param sourcePredicate
-     *            the predicate on AIS packet source
+     * @param sourcePredicate the predicate on AIS packet source
      * @return a stream of targets
      */
     public Stream<TargetInfo> streamSequential(Predicate<? super AisPacketSource> sourcePredicate) {
@@ -218,8 +225,9 @@ public class TargetTracker implements Tracker {
 
     /**
      * Creates a sequential stream of targets with the specified source predicate and matching the given targetPredicate.
-     * @param sourcePredicate
-     * @param targetPredicate
+     *
+     * @param sourcePredicate the source predicate
+     * @param targetPredicate the target predicate
      * @return a stream of targets
      */
     public Stream<TargetInfo> streamSequential(Predicate<? super AisPacketSource> sourcePredicate, Predicate<? super TargetInfo> targetPredicate) {
@@ -283,10 +291,8 @@ public class TargetTracker implements Tracker {
     /**
      * Used by the backup routine to restore data.
      *
-     * @param packetSource
-     *            the source
-     * @param targetInfo
-     *            the target info
+     * @param packetSource the source
+     * @param targetInfo   the target info
      */
     void update(AisPacketSource packetSource, TargetInfo targetInfo) {
         tryUpdate(targetInfo.getMmsi(),
@@ -299,12 +305,21 @@ public class TargetTracker implements Tracker {
     @SuppressWarnings("serial")
     static class MmsiTarget extends ConcurrentHashMap<AisPacketSource, TargetInfo> {
 
-        /** The MMSI number */
+        /**
+         * The MMSI number
+         */
         final int mmsi;
 
-        /** A cache of AIS messages 24 part 0. */
+        /**
+         * A cache of AIS messages 24 part 0.
+         */
         final ConcurrentHashMap<AisPacketSource, byte[]> msg24Part0 = new ConcurrentHashMap<>();
 
+        /**
+         * Instantiates a new Mmsi target.
+         *
+         * @param mmsi the mmsi
+         */
         MmsiTarget(int mmsi) {
             this.mmsi = mmsi;
         }
@@ -312,8 +327,7 @@ public class TargetTracker implements Tracker {
         /**
          * Returns the newest position and static data.
          *
-         * @param predicate
-         *            a predicate for filtering on the sources
+         * @param predicate a predicate for filtering on the sources
          * @return the newest position and static data
          */
         TargetInfo getLatest(Predicate<? super AisPacketSource> predicate) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetTrackerFileBackupService.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/tracker/targetTracker/TargetTrackerFileBackupService.java
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Takes care of backing up and restoring in case of a crash.
- * 
+ *
  * @author Kasper Nielsen
  */
 public class TargetTrackerFileBackupService extends AbstractScheduledService {
@@ -58,6 +58,9 @@ public class TargetTrackerFileBackupService extends AbstractScheduledService {
     /** The folder to backup files to. */
     private final Path backupFolder;
 
+    /**
+     * The F.
+     */
     BackupFile f;
 
     /** A random string appended to each backup file. To distinguish them from backup files created by former runs. */
@@ -74,16 +77,20 @@ public class TargetTrackerFileBackupService extends AbstractScheduledService {
     /**
      * Creates a new backup service.
      *
-     * @param tracker
-     *            the target tracker that we are make backups and restoring from
-     * @param backupFolder
-     *            the folder to backup and restore from
+     * @param tracker      the target tracker that we are make backups and restoring from
+     * @param backupFolder the folder to backup and restore from
      */
     public TargetTrackerFileBackupService(dk.dma.ais.tracker.targetTracker.TargetTracker tracker, Path backupFolder) {
         this.tracker = requireNonNull(tracker);
         this.backupFolder = requireNonNull(backupFolder);
     }
 
+    /**
+     * Restore backup files.
+     *
+     * @throws IOException            the io exception
+     * @throws ClassNotFoundException the class not found exception
+     */
     void restoreBackupFiles() throws IOException, ClassNotFoundException {
         List<Path> paths = new ArrayList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(backupFolder)) {
@@ -200,11 +207,22 @@ public class TargetTrackerFileBackupService extends AbstractScheduledService {
         }
     }
 
-    /** Wrapping the versioning */
+    /**
+     * Wrapping the versioning
+     */
     static class BackupFile {
+        /**
+         * The Major backup version.
+         */
         final int majorBackupVersion;
+        /**
+         * The Minor backup version.
+         */
         final int minorBackupVersion;
 
+        /**
+         * Instantiates a new Backup file.
+         */
         BackupFile() {
             this(1, 0);
         }
@@ -214,18 +232,40 @@ public class TargetTrackerFileBackupService extends AbstractScheduledService {
             this.minorBackupVersion = minor;
         }
 
+        /**
+         * Is full boolean.
+         *
+         * @return the boolean
+         */
         boolean isFull() {
             return minorBackupVersion == 0;
         }
 
+        /**
+         * Next backup file.
+         *
+         * @return the backup file
+         */
         BackupFile next() {
             return minorBackupVersion == 99 ? nextFull() : new BackupFile(majorBackupVersion, minorBackupVersion + 1);
         }
 
+        /**
+         * Next full backup file.
+         *
+         * @return the backup file
+         */
         BackupFile nextFull() {
             return new BackupFile((majorBackupVersion + 1) % 100000, 0);
         }
 
+        /**
+         * To path path.
+         *
+         * @param directory the directory
+         * @param prefix    the prefix
+         * @return the path
+         */
         Path toPath(Path directory, String prefix) {
             return directory.resolve("aisviewer_backup-" + prefix + "-"
                     + new DecimalFormat("00000").format(majorBackupVersion) + "-"

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/AisPacketTaggingTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/AisPacketTaggingTransformer.java
@@ -57,6 +57,12 @@ public class AisPacketTaggingTransformer implements IAisPacketTransformer {
          */
         MERGE_PRESERVE;
 
+        /**
+         * From string policy.
+         *
+         * @param str the str
+         * @return the policy
+         */
         public static Policy fromString(String str) {
             if (str.equalsIgnoreCase("PREPEND_MISSING")) {
                 return PREPEND_MISSING;
@@ -78,9 +84,9 @@ public class AisPacketTaggingTransformer implements IAisPacketTransformer {
 
     /**
      * Constructor taking policy and the tagging to be used
-     * 
-     * @param policy
-     * @param tagging
+     *
+     * @param policy  the policy
+     * @param tagging the tagging
      */
     public AisPacketTaggingTransformer(Policy policy, AisPacketTags tagging) {
         Objects.requireNonNull(policy);
@@ -91,13 +97,18 @@ public class AisPacketTaggingTransformer implements IAisPacketTransformer {
 
     /**
      * Get map of optional extra tags to be included in the tagging
-     * 
-     * @return map
+     *
+     * @return map extra tags
      */
     public Map<String, String> getExtraTags() {
         return extraTags;
     }
 
+    /**
+     * Add extra tags.
+     *
+     * @param tags the tags
+     */
     public void addExtraTags(Map<String, String> tags) {
         extraTags.putAll(tags);
     }
@@ -205,10 +216,10 @@ public class AisPacketTaggingTransformer implements IAisPacketTransformer {
 
     /**
      * Remove any thing else than sentences (and proprietary is chosen)
-     * 
-     * @param rawPacket
-     * @param removeProprietary
-     * @return
+     *
+     * @param rawLines          the raw lines
+     * @param removeProprietary the remove proprietary
+     * @return list list
      */
     public static List<String> cropSentences(List<String> rawLines, boolean removeProprietary) {
         List<String> croppedLines = new ArrayList<>();

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/AnonymousTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/AnonymousTransformer.java
@@ -114,6 +114,9 @@ public class AnonymousTransformer implements IAisPacketTransformer {
      */
     private final Random rand;
 
+    /**
+     * Instantiates a new Anonymous transformer.
+     */
     public AnonymousTransformer() {
         rand = new Random(System.currentTimeMillis());
     }
@@ -290,6 +293,15 @@ public class AnonymousTransformer implements IAisPacketTransformer {
         private final String callsign;
         private final String destination;
 
+        /**
+         * Instantiates a new Anon data.
+         *
+         * @param mmsi        the mmsi
+         * @param name        the name
+         * @param imoNo       the imo no
+         * @param callsign    the callsign
+         * @param destination the destination
+         */
         public AnonData(int mmsi, String name, int imoNo, String callsign, String destination) {
             this.mmsi = mmsi;
             this.name = name;
@@ -298,22 +310,47 @@ public class AnonymousTransformer implements IAisPacketTransformer {
             this.destination = destination;
         }
 
+        /**
+         * Gets mmsi.
+         *
+         * @return the mmsi
+         */
         public int getMmsi() {
             return mmsi;
         }
 
+        /**
+         * Gets name.
+         *
+         * @return the name
+         */
         public String getName() {
             return name;
         }
 
+        /**
+         * Gets imo no.
+         *
+         * @return the imo no
+         */
         public int getImoNo() {
             return imoNo;
         }
 
+        /**
+         * Gets callsign.
+         *
+         * @return the callsign
+         */
         public String getCallsign() {
             return callsign;
         }
 
+        /**
+         * Gets destination.
+         *
+         * @return the destination
+         */
         public synchronized String getDestination() {
             return destination;
         }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/IAisPacketTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/IAisPacketTransformer.java
@@ -22,10 +22,11 @@ import net.jcip.annotations.ThreadSafe;
  */
 @ThreadSafe
 public interface IAisPacketTransformer {
-    
+
     /**
-     * Transform AisPacket 
-     * @param packet
+     * Transform AisPacket
+     *
+     * @param packet the packet
      * @return transformed packet
      */
     AisPacket transform(AisPacket packet);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/PacketTransformerCollection.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/PacketTransformerCollection.java
@@ -19,14 +19,27 @@ import java.util.List;
 
 import dk.dma.ais.packet.AisPacket;
 
+/**
+ * The type Packet transformer collection.
+ */
 public class PacketTransformerCollection implements IAisPacketTransformer {
 
     private List<IAisPacketTransformer> collection = new ArrayList<>();
-    
+
+    /**
+     * Gets collection.
+     *
+     * @return the collection
+     */
     public List<IAisPacketTransformer> getCollection() {
         return collection;
     }
 
+    /**
+     * Sets collection.
+     *
+     * @param collection the collection
+     */
     public void setCollection(List<IAisPacketTransformer> collection) {
         this.collection = collection;
     }
@@ -39,7 +52,12 @@ public class PacketTransformerCollection implements IAisPacketTransformer {
         }
         return p;
     }
-    
+
+    /**
+     * Add transformer.
+     *
+     * @param packetTransformer the packet transformer
+     */
     public void addTransformer(IAisPacketTransformer packetTransformer) {
         this.collection.add(packetTransformer);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/ReplayTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/ReplayTransformer.java
@@ -34,10 +34,18 @@ public class ReplayTransformer implements IAisPacketTransformer {
     @GuardedBy("this")
     private Long epochReplay;
 
+    /**
+     * Instantiates a new Replay transformer.
+     */
     public ReplayTransformer() {
 
     }
 
+    /**
+     * Instantiates a new Replay transformer.
+     *
+     * @param speedup the speedup
+     */
     public ReplayTransformer(double speedup) {
         this.speedup = speedup;
     }
@@ -90,8 +98,8 @@ public class ReplayTransformer implements IAisPacketTransformer {
 
     /**
      * Fractional speedup to use
-     * 
-     * @param speedup
+     *
+     * @param speedup the speedup
      */
     public synchronized void setSpeedup(double speedup) {
         this.speedup = speedup;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/SourceTypeSatTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/SourceTypeSatTransformer.java
@@ -29,7 +29,7 @@ import dk.dma.ais.transform.AisPacketTaggingTransformer.Policy;
 
 /**
  * Transformer that maps a number of proprietary taggings into
- * source type SATELLITE tagging 
+ * source type SATELLITE tagging
  */
 @ThreadSafe
 public class SourceTypeSatTransformer implements IAisPacketTransformer {
@@ -47,7 +47,13 @@ public class SourceTypeSatTransformer implements IAisPacketTransformer {
     
     private final AisPacketTags satTagging; 
     private final AisPacketTaggingTransformer transformer;
-    
+
+    /**
+     * Instantiates a new Source type sat transformer.
+     *
+     * @param satGhRegions the sat gh regions
+     * @param satSources   the sat sources
+     */
     public SourceTypeSatTransformer(Collection<String> satGhRegions, Collection<String> satSources) {
         this.satTagging = new AisPacketTags();
         this.satTagging.setSourceType(SourceType.SATELLITE);

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/TimestampTaggingTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/TimestampTaggingTransformer.java
@@ -21,6 +21,9 @@ import dk.dma.ais.packet.AisPacket;
 import dk.dma.ais.packet.AisPacketTags;
 import dk.dma.ais.transform.AisPacketTaggingTransformer.Policy;
 
+/**
+ * The type Timestamp tagging transformer.
+ */
 public class TimestampTaggingTransformer implements IAisPacketTransformer {
     @Override
     public AisPacket transform(AisPacket packet) {

--- a/ais-lib-communication/src/main/java/dk/dma/ais/transform/VdmVdoTransformer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/transform/VdmVdoTransformer.java
@@ -37,10 +37,21 @@ public class VdmVdoTransformer implements IAisPacketTransformer {
     private final int ownMmsi;
     private final String ownTalker;
 
+    /**
+     * Instantiates a new Vdm vdo transformer.
+     *
+     * @param ownMmsi the own mmsi
+     */
     public VdmVdoTransformer(int ownMmsi) {
         this(ownMmsi, null);
     }
 
+    /**
+     * Instantiates a new Vdm vdo transformer.
+     *
+     * @param ownMmsi   the own mmsi
+     * @param ownTalker the own talker
+     */
     public VdmVdoTransformer(int ownMmsi, String ownTalker) {
         this.ownMmsi = ownMmsi;
         this.ownTalker = ownTalker;

--- a/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterBaseVisitor.java
+++ b/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterBaseVisitor.java
@@ -23,8 +23,7 @@ import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
  * which can be extended to create a visitor which only needs to handle a subset
  * of the available methods.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return type.
  */
 public class ExpressionFilterBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements ExpressionFilterVisitor<T> {
 	/**

--- a/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterLexer.java
+++ b/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterLexer.java
@@ -24,28 +24,250 @@ import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.*;
 
+/**
+ * The type Expression filter lexer.
+ */
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class ExpressionFilterLexer extends Lexer {
+	/**
+	 * The constant _decisionToDFA.
+	 */
 	protected static final DFA[] _decisionToDFA;
+	/**
+	 * The constant _sharedContextCache.
+	 */
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
+	/**
+	 * The constant T__15.
+	 */
 	public static final int
-		T__15=1, T__14=2, T__13=3, T__12=4, T__11=5, T__10=6, T__9=7, T__8=8, 
-		T__7=9, T__6=10, T__5=11, T__4=12, T__3=13, T__2=14, T__1=15, T__0=16, 
-		AND=17, OR=18, RANGE=19, LIKE=20, BBOX=21, CIRCLE=22, WITHIN=23, INT=24, 
-		FLOAT=25, STRING=26, WS=27, PREFIX_SOURCE=28, PREFIX_MESSAGE=29, PREFIX_TARGET=30, 
-		SRC_ID=31, SRC_BASESTATION=32, SRC_COUNTRY=33, SRC_TYPE=34, SRC_REGION=35, 
-		MSG_MSGID=36, MSG_MMSI=37, MSG_IMO=38, MSG_TYPE=39, MSG_COUNTRY=40, MSG_NAVSTAT=41, 
-		MSG_NAME=42, MSG_CALLSIGN=43, MSG_SPEED=44, MSG_COURSE=45, MSG_HEADING=46, 
-		MSG_DRAUGHT=47, MSG_LATITUDE=48, MSG_LONGITUDE=49, MSG_POSITION=50, MSG_TIME_YEAR=51, 
-		MSG_TIME_MONTH=52, MSG_TIME_DAY=53, MSG_TIME_WEEKDAY=54, MSG_TIME_HOUR=55, 
-		MSG_TIME_MINUTE=56, TGT_IMO=57, TGT_TYPE=58, TGT_COUNTRY=59, TGT_NAVSTAT=60, 
-		TGT_NAME=61, TGT_CALLSIGN=62, TGT_SPEED=63, TGT_COURSE=64, TGT_HEADING=65, 
-		TGT_DRAUGHT=66, TGT_LATITUDE=67, TGT_LONGITUDE=68, TGT_POSITION=69;
+		T__15=1, /**
+	 * The T __ 14.
+	 */
+	T__14=2, /**
+	 * The T __ 13.
+	 */
+	T__13=3, /**
+	 * The T __ 12.
+	 */
+	T__12=4, /**
+	 * The T __ 11.
+	 */
+	T__11=5, /**
+	 * The T __ 10.
+	 */
+	T__10=6, /**
+	 * The T __ 9.
+	 */
+	T__9=7, /**
+	 * The T __ 8.
+	 */
+	T__8=8,
+	/**
+	 * The T __ 7.
+	 */
+	T__7=9, /**
+	 * The T __ 6.
+	 */
+	T__6=10, /**
+	 * The T __ 5.
+	 */
+	T__5=11, /**
+	 * The T __ 4.
+	 */
+	T__4=12, /**
+	 * The T __ 3.
+	 */
+	T__3=13, /**
+	 * The T __ 2.
+	 */
+	T__2=14, /**
+	 * The T __ 1.
+	 */
+	T__1=15, /**
+	 * The T __ 0.
+	 */
+	T__0=16,
+	/**
+	 * The And.
+	 */
+	AND=17, /**
+	 * The Or.
+	 */
+	OR=18, /**
+	 * The Range.
+	 */
+	RANGE=19, /**
+	 * The Like.
+	 */
+	LIKE=20, /**
+	 * The Bbox.
+	 */
+	BBOX=21, /**
+	 * The Circle.
+	 */
+	CIRCLE=22, /**
+	 * The Within.
+	 */
+	WITHIN=23, /**
+	 * The Int.
+	 */
+	INT=24,
+	/**
+	 * The Float.
+	 */
+	FLOAT=25, /**
+	 * The String.
+	 */
+	STRING=26, /**
+	 * The Ws.
+	 */
+	WS=27, /**
+	 * The Prefix source.
+	 */
+	PREFIX_SOURCE=28, /**
+	 * The Prefix message.
+	 */
+	PREFIX_MESSAGE=29, /**
+	 * The Prefix target.
+	 */
+	PREFIX_TARGET=30,
+	/**
+	 * The Src id.
+	 */
+	SRC_ID=31, /**
+	 * The Src basestation.
+	 */
+	SRC_BASESTATION=32, /**
+	 * The Src country.
+	 */
+	SRC_COUNTRY=33, /**
+	 * The Src type.
+	 */
+	SRC_TYPE=34, /**
+	 * The Src region.
+	 */
+	SRC_REGION=35,
+	/**
+	 * The Msg msgid.
+	 */
+	MSG_MSGID=36, /**
+	 * The Msg mmsi.
+	 */
+	MSG_MMSI=37, /**
+	 * The Msg imo.
+	 */
+	MSG_IMO=38, /**
+	 * The Msg type.
+	 */
+	MSG_TYPE=39, /**
+	 * The Msg country.
+	 */
+	MSG_COUNTRY=40, /**
+	 * The Msg navstat.
+	 */
+	MSG_NAVSTAT=41,
+	/**
+	 * The Msg name.
+	 */
+	MSG_NAME=42, /**
+	 * The Msg callsign.
+	 */
+	MSG_CALLSIGN=43, /**
+	 * The Msg speed.
+	 */
+	MSG_SPEED=44, /**
+	 * The Msg course.
+	 */
+	MSG_COURSE=45, /**
+	 * The Msg heading.
+	 */
+	MSG_HEADING=46,
+	/**
+	 * The Msg draught.
+	 */
+	MSG_DRAUGHT=47, /**
+	 * The Msg latitude.
+	 */
+	MSG_LATITUDE=48, /**
+	 * The Msg longitude.
+	 */
+	MSG_LONGITUDE=49, /**
+	 * The Msg position.
+	 */
+	MSG_POSITION=50, /**
+	 * The Msg time year.
+	 */
+	MSG_TIME_YEAR=51,
+	/**
+	 * The Msg time month.
+	 */
+	MSG_TIME_MONTH=52, /**
+	 * The Msg time day.
+	 */
+	MSG_TIME_DAY=53, /**
+	 * The Msg time weekday.
+	 */
+	MSG_TIME_WEEKDAY=54, /**
+	 * The Msg time hour.
+	 */
+	MSG_TIME_HOUR=55,
+	/**
+	 * The Msg time minute.
+	 */
+	MSG_TIME_MINUTE=56, /**
+	 * The Tgt imo.
+	 */
+	TGT_IMO=57, /**
+	 * The Tgt type.
+	 */
+	TGT_TYPE=58, /**
+	 * The Tgt country.
+	 */
+	TGT_COUNTRY=59, /**
+	 * The Tgt navstat.
+	 */
+	TGT_NAVSTAT=60,
+	/**
+	 * The Tgt name.
+	 */
+	TGT_NAME=61, /**
+	 * The Tgt callsign.
+	 */
+	TGT_CALLSIGN=62, /**
+	 * The Tgt speed.
+	 */
+	TGT_SPEED=63, /**
+	 * The Tgt course.
+	 */
+	TGT_COURSE=64, /**
+	 * The Tgt heading.
+	 */
+	TGT_HEADING=65,
+	/**
+	 * The Tgt draught.
+	 */
+	TGT_DRAUGHT=66, /**
+	 * The Tgt latitude.
+	 */
+	TGT_LATITUDE=67, /**
+	 * The Tgt longitude.
+	 */
+	TGT_LONGITUDE=68, /**
+	 * The Tgt position.
+	 */
+	TGT_POSITION=69;
+	/**
+	 * The Mode names.
+	 */
 	public static String[] modeNames = {
 		"DEFAULT_MODE"
 	};
 
+	/**
+	 * The constant tokenNames.
+	 */
 	public static final String[] tokenNames = {
 		"<INVALID>",
 		"'NOT IN'", "'not in'", "'!='", "'messagetype'", "'!@'", "'>='", "'<'", 
@@ -60,6 +282,9 @@ public class ExpressionFilterLexer extends Lexer {
 		"TGT_NAVSTAT", "TGT_NAME", "TGT_CALLSIGN", "TGT_SPEED", "TGT_COURSE", 
 		"TGT_HEADING", "TGT_DRAUGHT", "TGT_LATITUDE", "TGT_LONGITUDE", "TGT_POSITION"
 	};
+	/**
+	 * The constant ruleNames.
+	 */
 	public static final String[] ruleNames = {
 		"T__15", "T__14", "T__13", "T__12", "T__11", "T__10", "T__9", "T__8", 
 		"T__7", "T__6", "T__5", "T__4", "T__3", "T__2", "T__1", "T__0", "AND", 
@@ -76,6 +301,11 @@ public class ExpressionFilterLexer extends Lexer {
 	};
 
 
+	/**
+	 * Instantiates a new Expression filter lexer.
+	 *
+	 * @param input the input
+	 */
 	public ExpressionFilterLexer(CharStream input) {
 		super(input);
 		_interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
@@ -99,6 +329,9 @@ public class ExpressionFilterLexer extends Lexer {
 	@Override
 	public ATN getATN() { return _ATN; }
 
+	/**
+	 * The constant _serializedATN.
+	 */
 	public static final String _serializedATN =
 		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\2G\u0208\b\1\4\2\t"+
 		"\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
@@ -270,6 +503,9 @@ public class ExpressionFilterLexer extends Lexer {
 		"\7p\2\2\u0202\u008a\3\2\2\2\u0203\u0204\5=\37\2\u0204\u0205\7r\2\2\u0205"+
 		"\u0206\7q\2\2\u0206\u0207\7u\2\2\u0207\u008c\3\2\2\2\r\2\u00d3\u00e9\u00ee"+
 		"\u00f1\u00f6\u00fd\u0102\u0108\u010c\u0111\3\b\2\2";
+	/**
+	 * The constant _ATN.
+	 */
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterParser.java
+++ b/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterParser.java
@@ -24,25 +24,244 @@ import java.util.List;
 import java.util.Iterator;
 import java.util.ArrayList;
 
+/**
+ * The type Expression filter parser.
+ */
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class ExpressionFilterParser extends Parser {
-	protected static final DFA[] _decisionToDFA;
-	protected static final PredictionContextCache _sharedContextCache =
+    /**
+     * The constant _decisionToDFA.
+     */
+    protected static final DFA[] _decisionToDFA;
+    /**
+     * The constant _sharedContextCache.
+     */
+    protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
-	public static final int
-		T__15=1, T__14=2, T__13=3, T__12=4, T__11=5, T__10=6, T__9=7, T__8=8, 
-		T__7=9, T__6=10, T__5=11, T__4=12, T__3=13, T__2=14, T__1=15, T__0=16, 
-		AND=17, OR=18, RANGE=19, LIKE=20, BBOX=21, CIRCLE=22, WITHIN=23, INT=24, 
-		FLOAT=25, STRING=26, WS=27, PREFIX_SOURCE=28, PREFIX_MESSAGE=29, PREFIX_TARGET=30, 
-		SRC_ID=31, SRC_BASESTATION=32, SRC_COUNTRY=33, SRC_TYPE=34, SRC_REGION=35, 
-		MSG_MSGID=36, MSG_MMSI=37, MSG_IMO=38, MSG_TYPE=39, MSG_COUNTRY=40, MSG_NAVSTAT=41, 
-		MSG_NAME=42, MSG_CALLSIGN=43, MSG_SPEED=44, MSG_COURSE=45, MSG_HEADING=46, 
-		MSG_DRAUGHT=47, MSG_LATITUDE=48, MSG_LONGITUDE=49, MSG_POSITION=50, MSG_TIME_YEAR=51, 
-		MSG_TIME_MONTH=52, MSG_TIME_DAY=53, MSG_TIME_WEEKDAY=54, MSG_TIME_HOUR=55, 
-		MSG_TIME_MINUTE=56, TGT_IMO=57, TGT_TYPE=58, TGT_COUNTRY=59, TGT_NAVSTAT=60, 
-		TGT_NAME=61, TGT_CALLSIGN=62, TGT_SPEED=63, TGT_COURSE=64, TGT_HEADING=65, 
-		TGT_DRAUGHT=66, TGT_LATITUDE=67, TGT_LONGITUDE=68, TGT_POSITION=69;
-	public static final String[] tokenNames = {
+    /**
+     * The constant T__15.
+     */
+    public static final int
+		T__15=1, /**
+     * The T __ 14.
+     */
+    T__14=2, /**
+     * The T __ 13.
+     */
+    T__13=3, /**
+     * The T __ 12.
+     */
+    T__12=4, /**
+     * The T __ 11.
+     */
+    T__11=5, /**
+     * The T __ 10.
+     */
+    T__10=6, /**
+     * The T __ 9.
+     */
+    T__9=7, /**
+     * The T __ 8.
+     */
+    T__8=8,
+    /**
+     * The T __ 7.
+     */
+    T__7=9, /**
+     * The T __ 6.
+     */
+    T__6=10, /**
+     * The T __ 5.
+     */
+    T__5=11, /**
+     * The T __ 4.
+     */
+    T__4=12, /**
+     * The T __ 3.
+     */
+    T__3=13, /**
+     * The T __ 2.
+     */
+    T__2=14, /**
+     * The T __ 1.
+     */
+    T__1=15, /**
+     * The T __ 0.
+     */
+    T__0=16,
+    /**
+     * The And.
+     */
+    AND=17, /**
+     * The Or.
+     */
+    OR=18, /**
+     * The Range.
+     */
+    RANGE=19, /**
+     * The Like.
+     */
+    LIKE=20, /**
+     * The Bbox.
+     */
+    BBOX=21, /**
+     * The Circle.
+     */
+    CIRCLE=22, /**
+     * The Within.
+     */
+    WITHIN=23, /**
+     * The Int.
+     */
+    INT=24,
+    /**
+     * The Float.
+     */
+    FLOAT=25, /**
+     * The String.
+     */
+    STRING=26, /**
+     * The Ws.
+     */
+    WS=27, /**
+     * The Prefix source.
+     */
+    PREFIX_SOURCE=28, /**
+     * The Prefix message.
+     */
+    PREFIX_MESSAGE=29, /**
+     * The Prefix target.
+     */
+    PREFIX_TARGET=30,
+    /**
+     * The Src id.
+     */
+    SRC_ID=31, /**
+     * The Src basestation.
+     */
+    SRC_BASESTATION=32, /**
+     * The Src country.
+     */
+    SRC_COUNTRY=33, /**
+     * The Src type.
+     */
+    SRC_TYPE=34, /**
+     * The Src region.
+     */
+    SRC_REGION=35,
+    /**
+     * The Msg msgid.
+     */
+    MSG_MSGID=36, /**
+     * The Msg mmsi.
+     */
+    MSG_MMSI=37, /**
+     * The Msg imo.
+     */
+    MSG_IMO=38, /**
+     * The Msg type.
+     */
+    MSG_TYPE=39, /**
+     * The Msg country.
+     */
+    MSG_COUNTRY=40, /**
+     * The Msg navstat.
+     */
+    MSG_NAVSTAT=41,
+    /**
+     * The Msg name.
+     */
+    MSG_NAME=42, /**
+     * The Msg callsign.
+     */
+    MSG_CALLSIGN=43, /**
+     * The Msg speed.
+     */
+    MSG_SPEED=44, /**
+     * The Msg course.
+     */
+    MSG_COURSE=45, /**
+     * The Msg heading.
+     */
+    MSG_HEADING=46,
+    /**
+     * The Msg draught.
+     */
+    MSG_DRAUGHT=47, /**
+     * The Msg latitude.
+     */
+    MSG_LATITUDE=48, /**
+     * The Msg longitude.
+     */
+    MSG_LONGITUDE=49, /**
+     * The Msg position.
+     */
+    MSG_POSITION=50, /**
+     * The Msg time year.
+     */
+    MSG_TIME_YEAR=51,
+    /**
+     * The Msg time month.
+     */
+    MSG_TIME_MONTH=52, /**
+     * The Msg time day.
+     */
+    MSG_TIME_DAY=53, /**
+     * The Msg time weekday.
+     */
+    MSG_TIME_WEEKDAY=54, /**
+     * The Msg time hour.
+     */
+    MSG_TIME_HOUR=55,
+    /**
+     * The Msg time minute.
+     */
+    MSG_TIME_MINUTE=56, /**
+     * The Tgt imo.
+     */
+    TGT_IMO=57, /**
+     * The Tgt type.
+     */
+    TGT_TYPE=58, /**
+     * The Tgt country.
+     */
+    TGT_COUNTRY=59, /**
+     * The Tgt navstat.
+     */
+    TGT_NAVSTAT=60,
+    /**
+     * The Tgt name.
+     */
+    TGT_NAME=61, /**
+     * The Tgt callsign.
+     */
+    TGT_CALLSIGN=62, /**
+     * The Tgt speed.
+     */
+    TGT_SPEED=63, /**
+     * The Tgt course.
+     */
+    TGT_COURSE=64, /**
+     * The Tgt heading.
+     */
+    TGT_HEADING=65,
+    /**
+     * The Tgt draught.
+     */
+    TGT_DRAUGHT=66, /**
+     * The Tgt latitude.
+     */
+    TGT_LATITUDE=67, /**
+     * The Tgt longitude.
+     */
+    TGT_LONGITUDE=68, /**
+     * The Tgt position.
+     */
+    TGT_POSITION=69;
+    /**
+     * The constant tokenNames.
+     */
+    public static final String[] tokenNames = {
 		"<INVALID>", "'NOT IN'", "'not in'", "'!='", "'messagetype'", "'!@'", 
 		"'>='", "'<'", "'='", "'>'", "'@'", "'<='", "'IN'", "'in'", "'('", "')'", 
 		"','", "'&'", "'|'", "'..'", "LIKE", "BBOX", "CIRCLE", "WITHIN", "INT", 
@@ -56,12 +275,54 @@ public class ExpressionFilterParser extends Parser {
 		"TGT_COURSE", "TGT_HEADING", "TGT_DRAUGHT", "TGT_LATITUDE", "TGT_LONGITUDE", 
 		"TGT_POSITION"
 	};
-	public static final int
-		RULE_filter = 0, RULE_filterExpression = 1, RULE_compareTo = 2, RULE_in = 3, 
-		RULE_notin = 4, RULE_intList = 5, RULE_stringList = 6, RULE_intRange = 7, 
-		RULE_numberRange = 8, RULE_number = 9, RULE_string = 10, RULE_bbox = 11, 
-		RULE_circle = 12;
-	public static final String[] ruleNames = {
+    /**
+     * The constant RULE_filter.
+     */
+    public static final int
+		RULE_filter = 0, /**
+     * The Rule filter expression.
+     */
+    RULE_filterExpression = 1, /**
+     * The Rule compare to.
+     */
+    RULE_compareTo = 2, /**
+     * The Rule in.
+     */
+    RULE_in = 3,
+    /**
+     * The Rule notin.
+     */
+    RULE_notin = 4, /**
+     * The Rule int list.
+     */
+    RULE_intList = 5, /**
+     * The Rule string list.
+     */
+    RULE_stringList = 6, /**
+     * The Rule int range.
+     */
+    RULE_intRange = 7,
+    /**
+     * The Rule number range.
+     */
+    RULE_numberRange = 8, /**
+     * The Rule number.
+     */
+    RULE_number = 9, /**
+     * The Rule string.
+     */
+    RULE_string = 10, /**
+     * The Rule bbox.
+     */
+    RULE_bbox = 11,
+    /**
+     * The Rule circle.
+     */
+    RULE_circle = 12;
+    /**
+     * The constant ruleNames.
+     */
+    public static final String[] ruleNames = {
 		"filter", "filterExpression", "compareTo", "in", "notin", "intList", "stringList", 
 		"intRange", "numberRange", "number", "string", "bbox", "circle"
 	};
@@ -81,16 +342,43 @@ public class ExpressionFilterParser extends Parser {
 	@Override
 	public ATN getATN() { return _ATN; }
 
-	public ExpressionFilterParser(TokenStream input) {
+    /**
+     * Instantiates a new Expression filter parser.
+     *
+     * @param input the input
+     */
+    public ExpressionFilterParser(TokenStream input) {
 		super(input);
 		_interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
 	}
-	public static class FilterContext extends ParserRuleContext {
-		public FilterExpressionContext filterExpression() {
+
+    /**
+     * The type Filter context.
+     */
+    public static class FilterContext extends ParserRuleContext {
+        /**
+         * Filter expression filter expression context.
+         *
+         * @return the filter expression context
+         */
+        public FilterExpressionContext filterExpression() {
 			return getRuleContext(FilterExpressionContext.class,0);
 		}
-		public TerminalNode EOF() { return getToken(ExpressionFilterParser.EOF, 0); }
-		public FilterContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Eof terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode EOF() { return getToken(ExpressionFilterParser.EOF, 0); }
+
+        /**
+         * Instantiates a new Filter context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public FilterContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_filter; }
@@ -101,7 +389,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final FilterContext filter() throws RecognitionException {
+    /**
+     * Filter filter context.
+     *
+     * @return the filter context
+     * @throws RecognitionException the recognition exception
+     */
+    public final FilterContext filter() throws RecognitionException {
 		FilterContext _localctx = new FilterContext(_ctx, getState());
 		enterRule(_localctx, 0, RULE_filter);
 		try {
@@ -122,1269 +416,3661 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class FilterExpressionContext extends ParserRuleContext {
-		public FilterExpressionContext(ParserRuleContext parent, int invokingState) {
+    /**
+     * The type Filter expression context.
+     */
+    public static class FilterExpressionContext extends ParserRuleContext {
+        /**
+         * Instantiates a new Filter expression context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public FilterExpressionContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_filterExpression; }
-	 
-		public FilterExpressionContext() { }
-		public void copyFrom(FilterExpressionContext ctx) {
+
+        /**
+         * Instantiates a new Filter expression context.
+         */
+        public FilterExpressionContext() { }
+
+        /**
+         * Copy from.
+         *
+         * @param ctx the ctx
+         */
+        public void copyFrom(FilterExpressionContext ctx) {
 			super.copyFrom(ctx);
 		}
 	}
-	public static class MessageTrueHeadingContext extends FilterExpressionContext {
-		public TerminalNode MSG_HEADING() { return getToken(ExpressionFilterParser.MSG_HEADING, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message true heading context.
+     */
+    public static class MessageTrueHeadingContext extends FilterExpressionContext {
+        /**
+         * Msg heading terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_HEADING() { return getToken(ExpressionFilterParser.MSG_HEADING, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTrueHeadingContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message true heading context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTrueHeadingContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTrueHeading(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTrueHeadingInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message true heading in context.
+     */
+    public static class MessageTrueHeadingInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public TerminalNode MSG_HEADING() { return getToken(ExpressionFilterParser.MSG_HEADING, 0); }
-		public IntRangeContext intRange() {
+
+        /**
+         * Msg heading terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_HEADING() { return getToken(ExpressionFilterParser.MSG_HEADING, 0); }
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public MessageTrueHeadingInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message true heading in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTrueHeadingInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTrueHeadingIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class ParensContext extends FilterExpressionContext {
-		public FilterExpressionContext filterExpression() {
+
+    /**
+     * The type Parens context.
+     */
+    public static class ParensContext extends FilterExpressionContext {
+        /**
+         * Filter expression filter expression context.
+         *
+         * @return the filter expression context
+         */
+        public FilterExpressionContext filterExpression() {
 			return getRuleContext(FilterExpressionContext.class,0);
 		}
-		public ParensContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Parens context.
+         *
+         * @param ctx the ctx
+         */
+        public ParensContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitParens(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeMinuteContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time minute context.
+     */
+    public static class MessageTimeMinuteContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public TerminalNode MSG_TIME_MINUTE() { return getToken(ExpressionFilterParser.MSG_TIME_MINUTE, 0); }
-		public MessageTimeMinuteContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Msg time minute terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_MINUTE() { return getToken(ExpressionFilterParser.MSG_TIME_MINUTE, 0); }
+
+        /**
+         * Instantiates a new Message time minute context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeMinuteContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeMinute(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeYearContext extends FilterExpressionContext {
-		public TerminalNode MSG_TIME_YEAR() { return getToken(ExpressionFilterParser.MSG_TIME_YEAR, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time year context.
+     */
+    public static class MessageTimeYearContext extends FilterExpressionContext {
+        /**
+         * Msg time year terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_YEAR() { return getToken(ExpressionFilterParser.MSG_TIME_YEAR, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTimeYearContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message time year context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeYearContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeYear(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageNavigationalStatusContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message navigational status context.
+     */
+    public static class MessageNavigationalStatusContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode MSG_NAVSTAT() { return getToken(ExpressionFilterParser.MSG_NAVSTAT, 0); }
-		public MessageNavigationalStatusContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg navstat terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_NAVSTAT() { return getToken(ExpressionFilterParser.MSG_NAVSTAT, 0); }
+
+        /**
+         * Instantiates a new Message navigational status context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageNavigationalStatusContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageNavigationalStatus(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeMinuteInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message time minute in context.
+     */
+    public static class MessageTimeMinuteInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public TerminalNode MSG_TIME_MINUTE() { return getToken(ExpressionFilterParser.MSG_TIME_MINUTE, 0); }
-		public MessageTimeMinuteInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg time minute terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_MINUTE() { return getToken(ExpressionFilterParser.MSG_TIME_MINUTE, 0); }
+
+        /**
+         * Instantiates a new Message time minute in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeMinuteInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeMinuteIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceBasestationContext extends FilterExpressionContext {
-		public TerminalNode SRC_BASESTATION() { return getToken(ExpressionFilterParser.SRC_BASESTATION, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Source basestation context.
+     */
+    public static class SourceBasestationContext extends FilterExpressionContext {
+        /**
+         * Src basestation terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_BASESTATION() { return getToken(ExpressionFilterParser.SRC_BASESTATION, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public SourceBasestationContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Source basestation context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceBasestationContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceBasestation(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetNavigationalStatusInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target navigational status in context.
+     */
+    public static class TargetNavigationalStatusInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public TerminalNode TGT_NAVSTAT() { return getToken(ExpressionFilterParser.TGT_NAVSTAT, 0); }
-		public TargetNavigationalStatusInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt navstat terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_NAVSTAT() { return getToken(ExpressionFilterParser.TGT_NAVSTAT, 0); }
+
+        /**
+         * Instantiates a new Target navigational status in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetNavigationalStatusInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetNavigationalStatusIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetLatitudeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target latitude in context.
+     */
+    public static class TargetLatitudeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public TerminalNode TGT_LATITUDE() { return getToken(ExpressionFilterParser.TGT_LATITUDE, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Tgt latitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_LATITUDE() { return getToken(ExpressionFilterParser.TGT_LATITUDE, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TargetLatitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Target latitude in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetLatitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetLatitudeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetCountryInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target country in context.
+     */
+    public static class TargetCountryInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_COUNTRY() { return getToken(ExpressionFilterParser.TGT_COUNTRY, 0); }
-		public TargetCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt country terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_COUNTRY() { return getToken(ExpressionFilterParser.TGT_COUNTRY, 0); }
+
+        /**
+         * Instantiates a new Target country in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetCountryIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetCallsignContext extends FilterExpressionContext {
-		public TerminalNode TGT_CALLSIGN() { return getToken(ExpressionFilterParser.TGT_CALLSIGN, 0); }
-		public StringContext string() {
+
+    /**
+     * The type Target callsign context.
+     */
+    public static class TargetCallsignContext extends FilterExpressionContext {
+        /**
+         * Tgt callsign terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_CALLSIGN() { return getToken(ExpressionFilterParser.TGT_CALLSIGN, 0); }
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
-		public TargetCallsignContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Like terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
+
+        /**
+         * Instantiates a new Target callsign context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetCallsignContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetCallsign(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeMonthInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message time month in context.
+     */
+    public static class MessageTimeMonthInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_TIME_MONTH() { return getToken(ExpressionFilterParser.MSG_TIME_MONTH, 0); }
-		public IntListContext intList() {
+
+        /**
+         * Msg time month terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_MONTH() { return getToken(ExpressionFilterParser.MSG_TIME_MONTH, 0); }
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageTimeMonthInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message time month in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeMonthInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeMonthIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceBasestationInContext extends FilterExpressionContext {
-		public TerminalNode SRC_BASESTATION() { return getToken(ExpressionFilterParser.SRC_BASESTATION, 0); }
-		public InContext in() {
+
+    /**
+     * The type Source basestation in context.
+     */
+    public static class SourceBasestationInContext extends FilterExpressionContext {
+        /**
+         * Src basestation terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_BASESTATION() { return getToken(ExpressionFilterParser.SRC_BASESTATION, 0); }
+
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public SourceBasestationInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Source basestation in context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceBasestationInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceBasestationIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageImoInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message imo in context.
+     */
+    public static class MessageImoInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public TerminalNode MSG_IMO() { return getToken(ExpressionFilterParser.MSG_IMO, 0); }
-		public IntRangeContext intRange() {
+
+        /**
+         * Msg imo terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_IMO() { return getToken(ExpressionFilterParser.MSG_IMO, 0); }
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageImoInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message imo in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageImoInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageImoIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetImoContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Target imo context.
+     */
+    public static class TargetImoContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public TerminalNode TGT_IMO() { return getToken(ExpressionFilterParser.TGT_IMO, 0); }
-		public TargetImoContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Tgt imo terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_IMO() { return getToken(ExpressionFilterParser.TGT_IMO, 0); }
+
+        /**
+         * Instantiates a new Target imo context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetImoContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetImo(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeWeekdayContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time weekday context.
+     */
+    public static class MessageTimeWeekdayContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode MSG_TIME_WEEKDAY() { return getToken(ExpressionFilterParser.MSG_TIME_WEEKDAY, 0); }
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTimeWeekdayContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg time weekday terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_WEEKDAY() { return getToken(ExpressionFilterParser.MSG_TIME_WEEKDAY, 0); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message time weekday context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeWeekdayContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeWeekday(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageCountryInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message country in context.
+     */
+    public static class MessageCountryInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_COUNTRY() { return getToken(ExpressionFilterParser.MSG_COUNTRY, 0); }
-		public MessageCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg country terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_COUNTRY() { return getToken(ExpressionFilterParser.MSG_COUNTRY, 0); }
+
+        /**
+         * Instantiates a new Message country in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageCountryIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetSpeedOverGroundContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Target speed over ground context.
+     */
+    public static class TargetSpeedOverGroundContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode TGT_SPEED() { return getToken(ExpressionFilterParser.TGT_SPEED, 0); }
-		public TargetSpeedOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt speed terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_SPEED() { return getToken(ExpressionFilterParser.TGT_SPEED, 0); }
+
+        /**
+         * Instantiates a new Target speed over ground context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetSpeedOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetSpeedOverGround(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetTrueHeadingContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Target true heading context.
+     */
+    public static class TargetTrueHeadingContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public TerminalNode TGT_HEADING() { return getToken(ExpressionFilterParser.TGT_HEADING, 0); }
-		public TargetTrueHeadingContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Tgt heading terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_HEADING() { return getToken(ExpressionFilterParser.TGT_HEADING, 0); }
+
+        /**
+         * Instantiates a new Target true heading context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetTrueHeadingContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetTrueHeading(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetTrueHeadingInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target true heading in context.
+     */
+    public static class TargetTrueHeadingInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_HEADING() { return getToken(ExpressionFilterParser.TGT_HEADING, 0); }
-		public TargetTrueHeadingInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt heading terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_HEADING() { return getToken(ExpressionFilterParser.TGT_HEADING, 0); }
+
+        /**
+         * Instantiates a new Target true heading in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetTrueHeadingInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetTrueHeadingIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageLatitudeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message latitude in context.
+     */
+    public static class MessageLatitudeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_LATITUDE() { return getToken(ExpressionFilterParser.MSG_LATITUDE, 0); }
-		public MessageLatitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg latitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_LATITUDE() { return getToken(ExpressionFilterParser.MSG_LATITUDE, 0); }
+
+        /**
+         * Instantiates a new Message latitude in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageLatitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageLatitudeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageIdContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message id context.
+     */
+    public static class MessageIdContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_MSGID() { return getToken(ExpressionFilterParser.MSG_MSGID, 0); }
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageIdContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg msgid terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_MSGID() { return getToken(ExpressionFilterParser.MSG_MSGID, 0); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message id context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageIdContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageId(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageCallsignContext extends FilterExpressionContext {
-		public TerminalNode MSG_CALLSIGN() { return getToken(ExpressionFilterParser.MSG_CALLSIGN, 0); }
-		public StringContext string() {
+
+    /**
+     * The type Message callsign context.
+     */
+    public static class MessageCallsignContext extends FilterExpressionContext {
+        /**
+         * Msg callsign terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_CALLSIGN() { return getToken(ExpressionFilterParser.MSG_CALLSIGN, 0); }
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
-		public MessageCallsignContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Like terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
+
+        /**
+         * Instantiates a new Message callsign context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageCallsignContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageCallsign(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageSpeedOverGroundContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Message speed over ground context.
+     */
+    public static class MessageSpeedOverGroundContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_SPEED() { return getToken(ExpressionFilterParser.MSG_SPEED, 0); }
-		public MessageSpeedOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg speed terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_SPEED() { return getToken(ExpressionFilterParser.MSG_SPEED, 0); }
+
+        /**
+         * Instantiates a new Message speed over ground context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageSpeedOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageSpeedOverGround(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetNameInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target name in context.
+     */
+    public static class TargetNameInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_NAME() { return getToken(ExpressionFilterParser.TGT_NAME, 0); }
-		public TargetNameInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt name terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_NAME() { return getToken(ExpressionFilterParser.TGT_NAME, 0); }
+
+        /**
+         * Instantiates a new Target name in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetNameInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetNameIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageCourseOverGroundInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message course over ground in context.
+     */
+    public static class MessageCourseOverGroundInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_COURSE() { return getToken(ExpressionFilterParser.MSG_COURSE, 0); }
-		public MessageCourseOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg course terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_COURSE() { return getToken(ExpressionFilterParser.MSG_COURSE, 0); }
+
+        /**
+         * Instantiates a new Message course over ground in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageCourseOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageCourseOverGroundIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageDraughtContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Message draught context.
+     */
+    public static class MessageDraughtContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_DRAUGHT() { return getToken(ExpressionFilterParser.MSG_DRAUGHT, 0); }
-		public MessageDraughtContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg draught terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_DRAUGHT() { return getToken(ExpressionFilterParser.MSG_DRAUGHT, 0); }
+
+        /**
+         * Instantiates a new Message draught context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageDraughtContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageDraught(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageMmsiInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message mmsi in context.
+     */
+    public static class MessageMmsiInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public TerminalNode MSG_MMSI() { return getToken(ExpressionFilterParser.MSG_MMSI, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Msg mmsi terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_MMSI() { return getToken(ExpressionFilterParser.MSG_MMSI, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageMmsiInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message mmsi in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageMmsiInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageMmsiIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeHourContext extends FilterExpressionContext {
-		public TerminalNode MSG_TIME_HOUR() { return getToken(ExpressionFilterParser.MSG_TIME_HOUR, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time hour context.
+     */
+    public static class MessageTimeHourContext extends FilterExpressionContext {
+        /**
+         * Msg time hour terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_HOUR() { return getToken(ExpressionFilterParser.MSG_TIME_HOUR, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTimeHourContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message time hour context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeHourContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeHour(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeWeekdayInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message time weekday in context.
+     */
+    public static class MessageTimeWeekdayInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public TerminalNode MSG_TIME_WEEKDAY() { return getToken(ExpressionFilterParser.MSG_TIME_WEEKDAY, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Msg time weekday terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_WEEKDAY() { return getToken(ExpressionFilterParser.MSG_TIME_WEEKDAY, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageTimeWeekdayInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message time weekday in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeWeekdayInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeWeekdayIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceCountryInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Source country in context.
+     */
+    public static class SourceCountryInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode SRC_COUNTRY() { return getToken(ExpressionFilterParser.SRC_COUNTRY, 0); }
-		public SourceCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Src country terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_COUNTRY() { return getToken(ExpressionFilterParser.SRC_COUNTRY, 0); }
+
+        /**
+         * Instantiates a new Source country in context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceCountryInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceCountryIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageIdInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message id in context.
+     */
+    public static class MessageIdInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public TerminalNode MSG_MSGID() { return getToken(ExpressionFilterParser.MSG_MSGID, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Msg msgid terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_MSGID() { return getToken(ExpressionFilterParser.MSG_MSGID, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageIdInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message id in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageIdInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageIdIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetDraughtContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Target draught context.
+     */
+    public static class TargetDraughtContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode TGT_DRAUGHT() { return getToken(ExpressionFilterParser.TGT_DRAUGHT, 0); }
-		public TargetDraughtContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt draught terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_DRAUGHT() { return getToken(ExpressionFilterParser.TGT_DRAUGHT, 0); }
+
+        /**
+         * Instantiates a new Target draught context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetDraughtContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetDraught(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetImoInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target imo in context.
+     */
+    public static class TargetImoInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public TerminalNode TGT_IMO() { return getToken(ExpressionFilterParser.TGT_IMO, 0); }
-		public TargetImoInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt imo terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_IMO() { return getToken(ExpressionFilterParser.TGT_IMO, 0); }
+
+        /**
+         * Instantiates a new Target imo in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetImoInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetImoIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeYearInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message time year in context.
+     */
+    public static class MessageTimeYearInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public TerminalNode MSG_TIME_YEAR() { return getToken(ExpressionFilterParser.MSG_TIME_YEAR, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Msg time year terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_YEAR() { return getToken(ExpressionFilterParser.MSG_TIME_YEAR, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageTimeYearInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message time year in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeYearInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeYearIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageNameContext extends FilterExpressionContext {
-		public TerminalNode MSG_NAME() { return getToken(ExpressionFilterParser.MSG_NAME, 0); }
-		public StringContext string() {
+
+    /**
+     * The type Message name context.
+     */
+    public static class MessageNameContext extends FilterExpressionContext {
+        /**
+         * Msg name terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_NAME() { return getToken(ExpressionFilterParser.MSG_NAME, 0); }
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
-		public MessageNameContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Like terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
+
+        /**
+         * Instantiates a new Message name context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageNameContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageName(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeHourInContext extends FilterExpressionContext {
-		public TerminalNode MSG_TIME_HOUR() { return getToken(ExpressionFilterParser.MSG_TIME_HOUR, 0); }
-		public InContext in() {
+
+    /**
+     * The type Message time hour in context.
+     */
+    public static class MessageTimeHourInContext extends FilterExpressionContext {
+        /**
+         * Msg time hour terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_HOUR() { return getToken(ExpressionFilterParser.MSG_TIME_HOUR, 0); }
+
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageTimeHourInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message time hour in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeHourInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeHourIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetNavigationalStatusContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Target navigational status context.
+     */
+    public static class TargetNavigationalStatusContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode TGT_NAVSTAT() { return getToken(ExpressionFilterParser.TGT_NAVSTAT, 0); }
-		public TargetNavigationalStatusContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt navstat terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_NAVSTAT() { return getToken(ExpressionFilterParser.TGT_NAVSTAT, 0); }
+
+        /**
+         * Instantiates a new Target navigational status context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetNavigationalStatusContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetNavigationalStatus(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetNameContext extends FilterExpressionContext {
-		public StringContext string() {
+
+    /**
+     * The type Target name context.
+     */
+    public static class TargetNameContext extends FilterExpressionContext {
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
-		public TerminalNode TGT_NAME() { return getToken(ExpressionFilterParser.TGT_NAME, 0); }
-		public TargetNameContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Like terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode LIKE() { return getToken(ExpressionFilterParser.LIKE, 0); }
+
+        /**
+         * Tgt name terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_NAME() { return getToken(ExpressionFilterParser.TGT_NAME, 0); }
+
+        /**
+         * Instantiates a new Target name context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetNameContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetName(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageLatitudeContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Message latitude context.
+     */
+    public static class MessageLatitudeContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_LATITUDE() { return getToken(ExpressionFilterParser.MSG_LATITUDE, 0); }
-		public MessageLatitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg latitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_LATITUDE() { return getToken(ExpressionFilterParser.MSG_LATITUDE, 0); }
+
+        /**
+         * Instantiates a new Message latitude context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageLatitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageLatitude(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageDraughtInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message draught in context.
+     */
+    public static class MessageDraughtInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_DRAUGHT() { return getToken(ExpressionFilterParser.MSG_DRAUGHT, 0); }
-		public MessageDraughtInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg draught terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_DRAUGHT() { return getToken(ExpressionFilterParser.MSG_DRAUGHT, 0); }
+
+        /**
+         * Instantiates a new Message draught in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageDraughtInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageDraughtIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetCourseOverGroundInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target course over ground in context.
+     */
+    public static class TargetCourseOverGroundInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public TerminalNode TGT_COURSE() { return getToken(ExpressionFilterParser.TGT_COURSE, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Tgt course terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_COURSE() { return getToken(ExpressionFilterParser.TGT_COURSE, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TargetCourseOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Target course over ground in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetCourseOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetCourseOverGroundIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeDayContext extends FilterExpressionContext {
-		public TerminalNode MSG_TIME_DAY() { return getToken(ExpressionFilterParser.MSG_TIME_DAY, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time day context.
+     */
+    public static class MessageTimeDayContext extends FilterExpressionContext {
+        /**
+         * Msg time day terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_DAY() { return getToken(ExpressionFilterParser.MSG_TIME_DAY, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTimeDayContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message time day context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeDayContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeDay(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageCourseOverGroundContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Message course over ground context.
+     */
+    public static class MessageCourseOverGroundContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_COURSE() { return getToken(ExpressionFilterParser.MSG_COURSE, 0); }
-		public MessageCourseOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg course terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_COURSE() { return getToken(ExpressionFilterParser.MSG_COURSE, 0); }
+
+        /**
+         * Instantiates a new Message course over ground context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageCourseOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageCourseOverGround(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessagePositionInsideContext extends FilterExpressionContext {
-		public TerminalNode MSG_POSITION() { return getToken(ExpressionFilterParser.MSG_POSITION, 0); }
-		public BboxContext bbox() {
+
+    /**
+     * The type Message position inside context.
+     */
+    public static class MessagePositionInsideContext extends FilterExpressionContext {
+        /**
+         * Msg position terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_POSITION() { return getToken(ExpressionFilterParser.MSG_POSITION, 0); }
+
+        /**
+         * Bbox bbox context.
+         *
+         * @return the bbox context
+         */
+        public BboxContext bbox() {
 			return getRuleContext(BboxContext.class,0);
 		}
-		public CircleContext circle() {
+
+        /**
+         * Circle circle context.
+         *
+         * @return the circle context
+         */
+        public CircleContext circle() {
 			return getRuleContext(CircleContext.class,0);
 		}
-		public TerminalNode WITHIN() { return getToken(ExpressionFilterParser.WITHIN, 0); }
-		public MessagePositionInsideContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Within terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode WITHIN() { return getToken(ExpressionFilterParser.WITHIN, 0); }
+
+        /**
+         * Instantiates a new Message position inside context.
+         *
+         * @param ctx the ctx
+         */
+        public MessagePositionInsideContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessagePositionInside(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageShiptypeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message shiptype in context.
+     */
+    public static class MessageShiptypeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public TerminalNode MSG_TYPE() { return getToken(ExpressionFilterParser.MSG_TYPE, 0); }
-		public MessageShiptypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg type terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TYPE() { return getToken(ExpressionFilterParser.MSG_TYPE, 0); }
+
+        /**
+         * Instantiates a new Message shiptype in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageShiptypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageShiptypeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetCourseOverGroundContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Target course over ground context.
+     */
+    public static class TargetCourseOverGroundContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public TerminalNode TGT_COURSE() { return getToken(ExpressionFilterParser.TGT_COURSE, 0); }
-		public CompareToContext compareTo() {
+
+        /**
+         * Tgt course terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_COURSE() { return getToken(ExpressionFilterParser.TGT_COURSE, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TargetCourseOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Target course over ground context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetCourseOverGroundContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetCourseOverGround(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetPositionInsideContext extends FilterExpressionContext {
-		public TerminalNode TGT_POSITION() { return getToken(ExpressionFilterParser.TGT_POSITION, 0); }
-		public BboxContext bbox() {
+
+    /**
+     * The type Target position inside context.
+     */
+    public static class TargetPositionInsideContext extends FilterExpressionContext {
+        /**
+         * Tgt position terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_POSITION() { return getToken(ExpressionFilterParser.TGT_POSITION, 0); }
+
+        /**
+         * Bbox bbox context.
+         *
+         * @return the bbox context
+         */
+        public BboxContext bbox() {
 			return getRuleContext(BboxContext.class,0);
 		}
-		public CircleContext circle() {
+
+        /**
+         * Circle circle context.
+         *
+         * @return the circle context
+         */
+        public CircleContext circle() {
 			return getRuleContext(CircleContext.class,0);
 		}
-		public TerminalNode WITHIN() { return getToken(ExpressionFilterParser.WITHIN, 0); }
-		public TargetPositionInsideContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Within terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode WITHIN() { return getToken(ExpressionFilterParser.WITHIN, 0); }
+
+        /**
+         * Instantiates a new Target position inside context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetPositionInsideContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetPositionInside(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageNavigationalStatusInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message navigational status in context.
+     */
+    public static class MessageNavigationalStatusInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_NAVSTAT() { return getToken(ExpressionFilterParser.MSG_NAVSTAT, 0); }
-		public IntListContext intList() {
+
+        /**
+         * Msg navstat terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_NAVSTAT() { return getToken(ExpressionFilterParser.MSG_NAVSTAT, 0); }
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageNavigationalStatusInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message navigational status in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageNavigationalStatusInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageNavigationalStatusIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetSpeedOverGroundInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target speed over ground in context.
+     */
+    public static class TargetSpeedOverGroundInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_SPEED() { return getToken(ExpressionFilterParser.TGT_SPEED, 0); }
-		public TargetSpeedOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt speed terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_SPEED() { return getToken(ExpressionFilterParser.TGT_SPEED, 0); }
+
+        /**
+         * Instantiates a new Target speed over ground in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetSpeedOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetSpeedOverGroundIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetDraughtInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target draught in context.
+     */
+    public static class TargetDraughtInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_DRAUGHT() { return getToken(ExpressionFilterParser.TGT_DRAUGHT, 0); }
-		public TargetDraughtInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt draught terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_DRAUGHT() { return getToken(ExpressionFilterParser.TGT_DRAUGHT, 0); }
+
+        /**
+         * Instantiates a new Target draught in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetDraughtInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetDraughtIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class OrAndContext extends FilterExpressionContext {
-		public Token op;
-		public TerminalNode AND(int i) {
+
+    /**
+     * The type Or and context.
+     */
+    public static class OrAndContext extends FilterExpressionContext {
+        /**
+         * The Op.
+         */
+        public Token op;
+
+        /**
+         * And terminal node.
+         *
+         * @param i the
+         * @return the terminal node
+         */
+        public TerminalNode AND(int i) {
 			return getToken(ExpressionFilterParser.AND, i);
 		}
-		public List<FilterExpressionContext> filterExpression() {
+
+        /**
+         * Filter expression list.
+         *
+         * @return the list
+         */
+        public List<FilterExpressionContext> filterExpression() {
 			return getRuleContexts(FilterExpressionContext.class);
 		}
-		public FilterExpressionContext filterExpression(int i) {
+
+        /**
+         * Filter expression filter expression context.
+         *
+         * @param i the
+         * @return the filter expression context
+         */
+        public FilterExpressionContext filterExpression(int i) {
 			return getRuleContext(FilterExpressionContext.class,i);
 		}
-		public List<TerminalNode> AND() { return getTokens(ExpressionFilterParser.AND); }
-		public List<TerminalNode> OR() { return getTokens(ExpressionFilterParser.OR); }
-		public TerminalNode OR(int i) {
+
+        /**
+         * And list.
+         *
+         * @return the list
+         */
+        public List<TerminalNode> AND() { return getTokens(ExpressionFilterParser.AND); }
+
+        /**
+         * Or list.
+         *
+         * @return the list
+         */
+        public List<TerminalNode> OR() { return getTokens(ExpressionFilterParser.OR); }
+
+        /**
+         * Or terminal node.
+         *
+         * @param i the
+         * @return the terminal node
+         */
+        public TerminalNode OR(int i) {
 			return getToken(ExpressionFilterParser.OR, i);
 		}
-		public OrAndContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Or and context.
+         *
+         * @param ctx the ctx
+         */
+        public OrAndContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitOrAnd(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetLatitudeContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Target latitude context.
+     */
+    public static class TargetLatitudeContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode TGT_LATITUDE() { return getToken(ExpressionFilterParser.TGT_LATITUDE, 0); }
-		public TargetLatitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt latitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_LATITUDE() { return getToken(ExpressionFilterParser.TGT_LATITUDE, 0); }
+
+        /**
+         * Instantiates a new Target latitude context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetLatitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetLatitude(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetShiptypeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target shiptype in context.
+     */
+    public static class TargetShiptypeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_TYPE() { return getToken(ExpressionFilterParser.TGT_TYPE, 0); }
-		public IntListContext intList() {
+
+        /**
+         * Tgt type terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_TYPE() { return getToken(ExpressionFilterParser.TGT_TYPE, 0); }
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public TargetShiptypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Target shiptype in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetShiptypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetShiptypeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeDayInContext extends FilterExpressionContext {
-		public TerminalNode MSG_TIME_DAY() { return getToken(ExpressionFilterParser.MSG_TIME_DAY, 0); }
-		public InContext in() {
+
+    /**
+     * The type Message time day in context.
+     */
+    public static class MessageTimeDayInContext extends FilterExpressionContext {
+        /**
+         * Msg time day terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_DAY() { return getToken(ExpressionFilterParser.MSG_TIME_DAY, 0); }
+
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public IntRangeContext intRange() {
+
+        /**
+         * Int range int range context.
+         *
+         * @return the int range context
+         */
+        public IntRangeContext intRange() {
 			return getRuleContext(IntRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public IntListContext intList() {
+
+        /**
+         * Int list int list context.
+         *
+         * @return the int list context
+         */
+        public IntListContext intList() {
 			return getRuleContext(IntListContext.class,0);
 		}
-		public MessageTimeDayInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message time day in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeDayInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeDayIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class AisMessagetypeContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Ais messagetype context.
+     */
+    public static class AisMessagetypeContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public AisMessagetypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Ais messagetype context.
+         *
+         * @param ctx the ctx
+         */
+        public AisMessagetypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitAisMessagetype(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceIdInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Source id in context.
+     */
+    public static class SourceIdInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public TerminalNode SRC_ID() { return getToken(ExpressionFilterParser.SRC_ID, 0); }
-		public StringListContext stringList() {
+
+        /**
+         * Src id terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_ID() { return getToken(ExpressionFilterParser.SRC_ID, 0); }
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public SourceIdInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Source id in context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceIdInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceIdIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceRegionInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Source region in context.
+     */
+    public static class SourceRegionInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode SRC_REGION() { return getToken(ExpressionFilterParser.SRC_REGION, 0); }
-		public SourceRegionInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Src region terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_REGION() { return getToken(ExpressionFilterParser.SRC_REGION, 0); }
+
+        /**
+         * Instantiates a new Source region in context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceRegionInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceRegionIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageCallsignInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message callsign in context.
+     */
+    public static class MessageCallsignInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public TerminalNode MSG_CALLSIGN() { return getToken(ExpressionFilterParser.MSG_CALLSIGN, 0); }
-		public StringListContext stringList() {
+
+        /**
+         * Msg callsign terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_CALLSIGN() { return getToken(ExpressionFilterParser.MSG_CALLSIGN, 0); }
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public MessageCallsignInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message callsign in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageCallsignInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageCallsignIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageLongitudeInContext extends FilterExpressionContext {
-		public TerminalNode MSG_LONGITUDE() { return getToken(ExpressionFilterParser.MSG_LONGITUDE, 0); }
-		public InContext in() {
+
+    /**
+     * The type Message longitude in context.
+     */
+    public static class MessageLongitudeInContext extends FilterExpressionContext {
+        /**
+         * Msg longitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_LONGITUDE() { return getToken(ExpressionFilterParser.MSG_LONGITUDE, 0); }
+
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public MessageLongitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message longitude in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageLongitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageLongitudeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class SourceTypeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Source type in context.
+     */
+    public static class SourceTypeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public TerminalNode SRC_TYPE() { return getToken(ExpressionFilterParser.SRC_TYPE, 0); }
-		public StringListContext stringList() {
+
+        /**
+         * Src type terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode SRC_TYPE() { return getToken(ExpressionFilterParser.SRC_TYPE, 0); }
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public SourceTypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Source type in context.
+         *
+         * @param ctx the ctx
+         */
+        public SourceTypeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitSourceTypeIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageNameInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message name in context.
+     */
+    public static class MessageNameInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public TerminalNode MSG_NAME() { return getToken(ExpressionFilterParser.MSG_NAME, 0); }
-		public NotinContext notin() {
+
+        /**
+         * Msg name terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_NAME() { return getToken(ExpressionFilterParser.MSG_NAME, 0); }
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public MessageNameInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message name in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageNameInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageNameIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageSpeedOverGroundInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Message speed over ground in context.
+     */
+    public static class MessageSpeedOverGroundInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode MSG_SPEED() { return getToken(ExpressionFilterParser.MSG_SPEED, 0); }
-		public MessageSpeedOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg speed terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_SPEED() { return getToken(ExpressionFilterParser.MSG_SPEED, 0); }
+
+        /**
+         * Instantiates a new Message speed over ground in context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageSpeedOverGroundInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageSpeedOverGroundIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageMmsiContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message mmsi context.
+     */
+    public static class MessageMmsiContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode MSG_MMSI() { return getToken(ExpressionFilterParser.MSG_MMSI, 0); }
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageMmsiContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg mmsi terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_MMSI() { return getToken(ExpressionFilterParser.MSG_MMSI, 0); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message mmsi context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageMmsiContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageMmsi(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetShiptypeContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Target shiptype context.
+     */
+    public static class TargetShiptypeContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode TGT_TYPE() { return getToken(ExpressionFilterParser.TGT_TYPE, 0); }
-		public TargetShiptypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt type terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_TYPE() { return getToken(ExpressionFilterParser.TGT_TYPE, 0); }
+
+        /**
+         * Instantiates a new Target shiptype context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetShiptypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetShiptype(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageLongitudeContext extends FilterExpressionContext {
-		public TerminalNode MSG_LONGITUDE() { return getToken(ExpressionFilterParser.MSG_LONGITUDE, 0); }
-		public NumberContext number() {
+
+    /**
+     * The type Message longitude context.
+     */
+    public static class MessageLongitudeContext extends FilterExpressionContext {
+        /**
+         * Msg longitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_LONGITUDE() { return getToken(ExpressionFilterParser.MSG_LONGITUDE, 0); }
+
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public MessageLongitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Message longitude context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageLongitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageLongitude(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageTimeMonthContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message time month context.
+     */
+    public static class MessageTimeMonthContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode MSG_TIME_MONTH() { return getToken(ExpressionFilterParser.MSG_TIME_MONTH, 0); }
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageTimeMonthContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg time month terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TIME_MONTH() { return getToken(ExpressionFilterParser.MSG_TIME_MONTH, 0); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message time month context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageTimeMonthContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageTimeMonth(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetLongitudeContext extends FilterExpressionContext {
-		public NumberContext number() {
+
+    /**
+     * The type Target longitude context.
+     */
+    public static class TargetLongitudeContext extends FilterExpressionContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public CompareToContext compareTo() {
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode TGT_LONGITUDE() { return getToken(ExpressionFilterParser.TGT_LONGITUDE, 0); }
-		public TargetLongitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt longitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_LONGITUDE() { return getToken(ExpressionFilterParser.TGT_LONGITUDE, 0); }
+
+        /**
+         * Instantiates a new Target longitude context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetLongitudeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetLongitude(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetCallsignInContext extends FilterExpressionContext {
-		public TerminalNode TGT_CALLSIGN() { return getToken(ExpressionFilterParser.TGT_CALLSIGN, 0); }
-		public InContext in() {
+
+    /**
+     * The type Target callsign in context.
+     */
+    public static class TargetCallsignInContext extends FilterExpressionContext {
+        /**
+         * Tgt callsign terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_CALLSIGN() { return getToken(ExpressionFilterParser.TGT_CALLSIGN, 0); }
+
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public StringListContext stringList() {
+
+        /**
+         * String list string list context.
+         *
+         * @return the string list context
+         */
+        public StringListContext stringList() {
 			return getRuleContext(StringListContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TargetCallsignInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Instantiates a new Target callsign in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetCallsignInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetCallsignIn(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageShiptypeContext extends FilterExpressionContext {
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message shiptype context.
+     */
+    public static class MessageShiptypeContext extends FilterExpressionContext {
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public StringContext string() {
+
+        /**
+         * String string context.
+         *
+         * @return the string context
+         */
+        public StringContext string() {
 			return getRuleContext(StringContext.class,0);
 		}
-		public TerminalNode MSG_TYPE() { return getToken(ExpressionFilterParser.MSG_TYPE, 0); }
-		public MessageShiptypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Msg type terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_TYPE() { return getToken(ExpressionFilterParser.MSG_TYPE, 0); }
+
+        /**
+         * Instantiates a new Message shiptype context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageShiptypeContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageShiptype(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class MessageImoContext extends FilterExpressionContext {
-		public TerminalNode MSG_IMO() { return getToken(ExpressionFilterParser.MSG_IMO, 0); }
-		public CompareToContext compareTo() {
+
+    /**
+     * The type Message imo context.
+     */
+    public static class MessageImoContext extends FilterExpressionContext {
+        /**
+         * Msg imo terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode MSG_IMO() { return getToken(ExpressionFilterParser.MSG_IMO, 0); }
+
+        /**
+         * Compare to compare to context.
+         *
+         * @return the compare to context
+         */
+        public CompareToContext compareTo() {
 			return getRuleContext(CompareToContext.class,0);
 		}
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public MessageImoContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Instantiates a new Message imo context.
+         *
+         * @param ctx the ctx
+         */
+        public MessageImoContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitMessageImo(this);
 			else return visitor.visitChildren(this);
 		}
 	}
-	public static class TargetLongitudeInContext extends FilterExpressionContext {
-		public InContext in() {
+
+    /**
+     * The type Target longitude in context.
+     */
+    public static class TargetLongitudeInContext extends FilterExpressionContext {
+        /**
+         * In in context.
+         *
+         * @return the in context
+         */
+        public InContext in() {
 			return getRuleContext(InContext.class,0);
 		}
-		public NumberRangeContext numberRange() {
+
+        /**
+         * Number range number range context.
+         *
+         * @return the number range context
+         */
+        public NumberRangeContext numberRange() {
 			return getRuleContext(NumberRangeContext.class,0);
 		}
-		public NotinContext notin() {
+
+        /**
+         * Notin notin context.
+         *
+         * @return the notin context
+         */
+        public NotinContext notin() {
 			return getRuleContext(NotinContext.class,0);
 		}
-		public TerminalNode TGT_LONGITUDE() { return getToken(ExpressionFilterParser.TGT_LONGITUDE, 0); }
-		public TargetLongitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
+
+        /**
+         * Tgt longitude terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode TGT_LONGITUDE() { return getToken(ExpressionFilterParser.TGT_LONGITUDE, 0); }
+
+        /**
+         * Instantiates a new Target longitude in context.
+         *
+         * @param ctx the ctx
+         */
+        public TargetLongitudeInContext(FilterExpressionContext ctx) { copyFrom(ctx); }
 		@Override
 		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
 			if ( visitor instanceof ExpressionFilterVisitor ) return ((ExpressionFilterVisitor<? extends T>)visitor).visitTargetLongitudeIn(this);
@@ -1392,7 +4078,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final FilterExpressionContext filterExpression() throws RecognitionException {
+    /**
+     * Filter expression filter expression context.
+     *
+     * @return the filter expression context
+     * @throws RecognitionException the recognition exception
+     */
+    public final FilterExpressionContext filterExpression() throws RecognitionException {
 		return filterExpression(0);
 	}
 
@@ -3364,8 +6056,17 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class CompareToContext extends ParserRuleContext {
-		public CompareToContext(ParserRuleContext parent, int invokingState) {
+    /**
+     * The type Compare to context.
+     */
+    public static class CompareToContext extends ParserRuleContext {
+        /**
+         * Instantiates a new Compare to context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public CompareToContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_compareTo; }
@@ -3376,7 +6077,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final CompareToContext compareTo() throws RecognitionException {
+    /**
+     * Compare to compare to context.
+     *
+     * @return the compare to context
+     * @throws RecognitionException the recognition exception
+     */
+    public final CompareToContext compareTo() throws RecognitionException {
 		CompareToContext _localctx = new CompareToContext(_ctx, getState());
 		enterRule(_localctx, 4, RULE_compareTo);
 		int _la;
@@ -3402,8 +6109,17 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class InContext extends ParserRuleContext {
-		public InContext(ParserRuleContext parent, int invokingState) {
+    /**
+     * The type In context.
+     */
+    public static class InContext extends ParserRuleContext {
+        /**
+         * Instantiates a new In context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public InContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_in; }
@@ -3414,7 +6130,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final InContext in() throws RecognitionException {
+    /**
+     * In in context.
+     *
+     * @return the in context
+     * @throws RecognitionException the recognition exception
+     */
+    public final InContext in() throws RecognitionException {
 		InContext _localctx = new InContext(_ctx, getState());
 		enterRule(_localctx, 6, RULE_in);
 		int _la;
@@ -3440,8 +6162,17 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class NotinContext extends ParserRuleContext {
-		public NotinContext(ParserRuleContext parent, int invokingState) {
+    /**
+     * The type Notin context.
+     */
+    public static class NotinContext extends ParserRuleContext {
+        /**
+         * Instantiates a new Notin context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public NotinContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_notin; }
@@ -3452,7 +6183,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final NotinContext notin() throws RecognitionException {
+    /**
+     * Notin notin context.
+     *
+     * @return the notin context
+     * @throws RecognitionException the recognition exception
+     */
+    public final NotinContext notin() throws RecognitionException {
 		NotinContext _localctx = new NotinContext(_ctx, getState());
 		enterRule(_localctx, 8, RULE_notin);
 		int _la;
@@ -3478,12 +6215,34 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class IntListContext extends ParserRuleContext {
-		public TerminalNode INT(int i) {
+    /**
+     * The type Int list context.
+     */
+    public static class IntListContext extends ParserRuleContext {
+        /**
+         * Int terminal node.
+         *
+         * @param i the
+         * @return the terminal node
+         */
+        public TerminalNode INT(int i) {
 			return getToken(ExpressionFilterParser.INT, i);
 		}
-		public List<TerminalNode> INT() { return getTokens(ExpressionFilterParser.INT); }
-		public IntListContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Int list.
+         *
+         * @return the list
+         */
+        public List<TerminalNode> INT() { return getTokens(ExpressionFilterParser.INT); }
+
+        /**
+         * Instantiates a new Int list context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public IntListContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_intList; }
@@ -3494,7 +6253,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final IntListContext intList() throws RecognitionException {
+    /**
+     * Int list int list context.
+     *
+     * @return the int list context
+     * @throws RecognitionException the recognition exception
+     */
+    public final IntListContext intList() throws RecognitionException {
 		IntListContext _localctx = new IntListContext(_ctx, getState());
 		enterRule(_localctx, 10, RULE_intList);
 		int _la;
@@ -3548,14 +6313,36 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class StringListContext extends ParserRuleContext {
-		public StringContext string(int i) {
+    /**
+     * The type String list context.
+     */
+    public static class StringListContext extends ParserRuleContext {
+        /**
+         * String string context.
+         *
+         * @param i the
+         * @return the string context
+         */
+        public StringContext string(int i) {
 			return getRuleContext(StringContext.class,i);
 		}
-		public List<StringContext> string() {
+
+        /**
+         * String list.
+         *
+         * @return the list
+         */
+        public List<StringContext> string() {
 			return getRuleContexts(StringContext.class);
 		}
-		public StringListContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Instantiates a new String list context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public StringListContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_stringList; }
@@ -3566,7 +6353,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final StringListContext stringList() throws RecognitionException {
+    /**
+     * String list string list context.
+     *
+     * @return the string list context
+     * @throws RecognitionException the recognition exception
+     */
+    public final StringListContext stringList() throws RecognitionException {
 		StringListContext _localctx = new StringListContext(_ctx, getState());
 		enterRule(_localctx, 12, RULE_stringList);
 		int _la;
@@ -3620,13 +6413,41 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class IntRangeContext extends ParserRuleContext {
-		public TerminalNode INT(int i) {
+    /**
+     * The type Int range context.
+     */
+    public static class IntRangeContext extends ParserRuleContext {
+        /**
+         * Int terminal node.
+         *
+         * @param i the
+         * @return the terminal node
+         */
+        public TerminalNode INT(int i) {
 			return getToken(ExpressionFilterParser.INT, i);
 		}
-		public TerminalNode RANGE() { return getToken(ExpressionFilterParser.RANGE, 0); }
-		public List<TerminalNode> INT() { return getTokens(ExpressionFilterParser.INT); }
-		public IntRangeContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Range terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode RANGE() { return getToken(ExpressionFilterParser.RANGE, 0); }
+
+        /**
+         * Int list.
+         *
+         * @return the list
+         */
+        public List<TerminalNode> INT() { return getTokens(ExpressionFilterParser.INT); }
+
+        /**
+         * Instantiates a new Int range context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public IntRangeContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_intRange; }
@@ -3637,7 +6458,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final IntRangeContext intRange() throws RecognitionException {
+    /**
+     * Int range int range context.
+     *
+     * @return the int range context
+     * @throws RecognitionException the recognition exception
+     */
+    public final IntRangeContext intRange() throws RecognitionException {
 		IntRangeContext _localctx = new IntRangeContext(_ctx, getState());
 		enterRule(_localctx, 14, RULE_intRange);
 		int _la;
@@ -3676,15 +6503,43 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class NumberRangeContext extends ParserRuleContext {
-		public List<NumberContext> number() {
+    /**
+     * The type Number range context.
+     */
+    public static class NumberRangeContext extends ParserRuleContext {
+        /**
+         * Number list.
+         *
+         * @return the list
+         */
+        public List<NumberContext> number() {
 			return getRuleContexts(NumberContext.class);
 		}
-		public TerminalNode RANGE() { return getToken(ExpressionFilterParser.RANGE, 0); }
-		public NumberContext number(int i) {
+
+        /**
+         * Range terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode RANGE() { return getToken(ExpressionFilterParser.RANGE, 0); }
+
+        /**
+         * Number number context.
+         *
+         * @param i the
+         * @return the number context
+         */
+        public NumberContext number(int i) {
 			return getRuleContext(NumberContext.class,i);
 		}
-		public NumberRangeContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Instantiates a new Number range context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public NumberRangeContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_numberRange; }
@@ -3695,7 +6550,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final NumberRangeContext numberRange() throws RecognitionException {
+    /**
+     * Number range number range context.
+     *
+     * @return the number range context
+     * @throws RecognitionException the recognition exception
+     */
+    public final NumberRangeContext numberRange() throws RecognitionException {
 		NumberRangeContext _localctx = new NumberRangeContext(_ctx, getState());
 		enterRule(_localctx, 16, RULE_numberRange);
 		int _la;
@@ -3734,10 +6595,31 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class NumberContext extends ParserRuleContext {
-		public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
-		public TerminalNode FLOAT() { return getToken(ExpressionFilterParser.FLOAT, 0); }
-		public NumberContext(ParserRuleContext parent, int invokingState) {
+    /**
+     * The type Number context.
+     */
+    public static class NumberContext extends ParserRuleContext {
+        /**
+         * Int terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode INT() { return getToken(ExpressionFilterParser.INT, 0); }
+
+        /**
+         * Float terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode FLOAT() { return getToken(ExpressionFilterParser.FLOAT, 0); }
+
+        /**
+         * Instantiates a new Number context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public NumberContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_number; }
@@ -3748,7 +6630,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final NumberContext number() throws RecognitionException {
+    /**
+     * Number number context.
+     *
+     * @return the number context
+     * @throws RecognitionException the recognition exception
+     */
+    public final NumberContext number() throws RecognitionException {
 		NumberContext _localctx = new NumberContext(_ctx, getState());
 		enterRule(_localctx, 18, RULE_number);
 		int _la;
@@ -3774,12 +6662,33 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class StringContext extends ParserRuleContext {
-		public NumberContext number() {
+    /**
+     * The type String context.
+     */
+    public static class StringContext extends ParserRuleContext {
+        /**
+         * Number number context.
+         *
+         * @return the number context
+         */
+        public NumberContext number() {
 			return getRuleContext(NumberContext.class,0);
 		}
-		public TerminalNode STRING() { return getToken(ExpressionFilterParser.STRING, 0); }
-		public StringContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * String terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode STRING() { return getToken(ExpressionFilterParser.STRING, 0); }
+
+        /**
+         * Instantiates a new String context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public StringContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_string; }
@@ -3790,7 +6699,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final StringContext string() throws RecognitionException {
+    /**
+     * String string context.
+     *
+     * @return the string context
+     * @throws RecognitionException the recognition exception
+     */
+    public final StringContext string() throws RecognitionException {
 		StringContext _localctx = new StringContext(_ctx, getState());
 		enterRule(_localctx, 20, RULE_string);
 		try {
@@ -3824,15 +6739,43 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class BboxContext extends ParserRuleContext {
-		public List<NumberContext> number() {
+    /**
+     * The type Bbox context.
+     */
+    public static class BboxContext extends ParserRuleContext {
+        /**
+         * Number list.
+         *
+         * @return the list
+         */
+        public List<NumberContext> number() {
 			return getRuleContexts(NumberContext.class);
 		}
-		public NumberContext number(int i) {
+
+        /**
+         * Number number context.
+         *
+         * @param i the
+         * @return the number context
+         */
+        public NumberContext number(int i) {
 			return getRuleContext(NumberContext.class,i);
 		}
-		public TerminalNode BBOX() { return getToken(ExpressionFilterParser.BBOX, 0); }
-		public BboxContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Bbox terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode BBOX() { return getToken(ExpressionFilterParser.BBOX, 0); }
+
+        /**
+         * Instantiates a new Bbox context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public BboxContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_bbox; }
@@ -3843,7 +6786,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final BboxContext bbox() throws RecognitionException {
+    /**
+     * Bbox bbox context.
+     *
+     * @return the bbox context
+     * @throws RecognitionException the recognition exception
+     */
+    public final BboxContext bbox() throws RecognitionException {
 		BboxContext _localctx = new BboxContext(_ctx, getState());
 		enterRule(_localctx, 22, RULE_bbox);
 		int _la;
@@ -3887,15 +6836,43 @@ public class ExpressionFilterParser extends Parser {
 		return _localctx;
 	}
 
-	public static class CircleContext extends ParserRuleContext {
-		public List<NumberContext> number() {
+    /**
+     * The type Circle context.
+     */
+    public static class CircleContext extends ParserRuleContext {
+        /**
+         * Number list.
+         *
+         * @return the list
+         */
+        public List<NumberContext> number() {
 			return getRuleContexts(NumberContext.class);
 		}
-		public NumberContext number(int i) {
+
+        /**
+         * Number number context.
+         *
+         * @param i the
+         * @return the number context
+         */
+        public NumberContext number(int i) {
 			return getRuleContext(NumberContext.class,i);
 		}
-		public TerminalNode CIRCLE() { return getToken(ExpressionFilterParser.CIRCLE, 0); }
-		public CircleContext(ParserRuleContext parent, int invokingState) {
+
+        /**
+         * Circle terminal node.
+         *
+         * @return the terminal node
+         */
+        public TerminalNode CIRCLE() { return getToken(ExpressionFilterParser.CIRCLE, 0); }
+
+        /**
+         * Instantiates a new Circle context.
+         *
+         * @param parent        the parent
+         * @param invokingState the invoking state
+         */
+        public CircleContext(ParserRuleContext parent, int invokingState) {
 			super(parent, invokingState);
 		}
 		@Override public int getRuleIndex() { return RULE_circle; }
@@ -3906,7 +6883,13 @@ public class ExpressionFilterParser extends Parser {
 		}
 	}
 
-	public final CircleContext circle() throws RecognitionException {
+    /**
+     * Circle circle context.
+     *
+     * @return the circle context
+     * @throws RecognitionException the recognition exception
+     */
+    public final CircleContext circle() throws RecognitionException {
 		CircleContext _localctx = new CircleContext(_ctx, getState());
 		enterRule(_localctx, 24, RULE_circle);
 		int _la;
@@ -3961,7 +6944,10 @@ public class ExpressionFilterParser extends Parser {
 		return true;
 	}
 
-	public static final String _serializedATN =
+    /**
+     * The constant _serializedATN.
+     */
+    public static final String _serializedATN =
 		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3G\u0246\4\2\t\2\4"+
 		"\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
 		"\13\4\f\t\f\4\r\t\r\4\16\t\16\3\2\3\2\3\2\3\3\3\3\3\3\3\3\5\3$\n\3\3\3"+
@@ -4200,7 +7186,10 @@ public class ExpressionFilterParser extends Parser {
 		"\u0167\u0172\u0177\u017c\u0182\u0189\u018f\u019a\u01a5\u01b0\u01bb\u01c6"+
 		"\u01d1\u01d9\u01e3\u01ea\u01ee\u01f8\u01ff\u0203\u0206\u020d\u0211\u0214"+
 		"\u021a\u021d\u0223\u0229\u022d\u0237\u023b\u0243";
-	public static final ATN _ATN =
+    /**
+     * The constant _ATN.
+     */
+    public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {
 		_decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];

--- a/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterVisitor.java
+++ b/ais-lib-communication/src/main/java/dk/dma/internal/ais/generated/parser/expressionfilter/ExpressionFilterVisitor.java
@@ -22,602 +22,686 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
  * This interface defines a complete generic visitor for a parse tree produced
  * by {@link ExpressionFilterParser}.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return type.
  */
 public interface ExpressionFilterVisitor<T> extends ParseTreeVisitor<T> {
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTrueHeading}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTrueHeading(@NotNull ExpressionFilterParser.MessageTrueHeadingContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTrueHeadingIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTrueHeadingIn(@NotNull ExpressionFilterParser.MessageTrueHeadingInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#parens}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitParens(@NotNull ExpressionFilterParser.ParensContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeMinute}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeMinute(@NotNull ExpressionFilterParser.MessageTimeMinuteContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeYear}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeYear(@NotNull ExpressionFilterParser.MessageTimeYearContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#intList}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitIntList(@NotNull ExpressionFilterParser.IntListContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#bbox}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitBbox(@NotNull ExpressionFilterParser.BboxContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageNavigationalStatus}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageNavigationalStatus(@NotNull ExpressionFilterParser.MessageNavigationalStatusContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#compareTo}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCompareTo(@NotNull ExpressionFilterParser.CompareToContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeMinuteIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeMinuteIn(@NotNull ExpressionFilterParser.MessageTimeMinuteInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceBasestation}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceBasestation(@NotNull ExpressionFilterParser.SourceBasestationContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetNavigationalStatusIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetNavigationalStatusIn(@NotNull ExpressionFilterParser.TargetNavigationalStatusInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetLatitudeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetLatitudeIn(@NotNull ExpressionFilterParser.TargetLatitudeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetCountryIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetCountryIn(@NotNull ExpressionFilterParser.TargetCountryInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#number}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNumber(@NotNull ExpressionFilterParser.NumberContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetCallsign}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetCallsign(@NotNull ExpressionFilterParser.TargetCallsignContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeMonthIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeMonthIn(@NotNull ExpressionFilterParser.MessageTimeMonthInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceBasestationIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceBasestationIn(@NotNull ExpressionFilterParser.SourceBasestationInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageImoIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageImoIn(@NotNull ExpressionFilterParser.MessageImoInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetImo}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetImo(@NotNull ExpressionFilterParser.TargetImoContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeWeekday}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeWeekday(@NotNull ExpressionFilterParser.MessageTimeWeekdayContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageCountryIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageCountryIn(@NotNull ExpressionFilterParser.MessageCountryInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetSpeedOverGround}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetSpeedOverGround(@NotNull ExpressionFilterParser.TargetSpeedOverGroundContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetTrueHeading}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetTrueHeading(@NotNull ExpressionFilterParser.TargetTrueHeadingContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetTrueHeadingIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetTrueHeadingIn(@NotNull ExpressionFilterParser.TargetTrueHeadingInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#in}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitIn(@NotNull ExpressionFilterParser.InContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageLatitudeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageLatitudeIn(@NotNull ExpressionFilterParser.MessageLatitudeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageId}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageId(@NotNull ExpressionFilterParser.MessageIdContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageCallsign}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageCallsign(@NotNull ExpressionFilterParser.MessageCallsignContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageSpeedOverGround}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageSpeedOverGround(@NotNull ExpressionFilterParser.MessageSpeedOverGroundContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetNameIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetNameIn(@NotNull ExpressionFilterParser.TargetNameInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageCourseOverGroundIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageCourseOverGroundIn(@NotNull ExpressionFilterParser.MessageCourseOverGroundInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageDraught}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageDraught(@NotNull ExpressionFilterParser.MessageDraughtContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageMmsiIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageMmsiIn(@NotNull ExpressionFilterParser.MessageMmsiInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeHour}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeHour(@NotNull ExpressionFilterParser.MessageTimeHourContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeWeekdayIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeWeekdayIn(@NotNull ExpressionFilterParser.MessageTimeWeekdayInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceCountryIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceCountryIn(@NotNull ExpressionFilterParser.SourceCountryInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageIdIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageIdIn(@NotNull ExpressionFilterParser.MessageIdInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetDraught}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetDraught(@NotNull ExpressionFilterParser.TargetDraughtContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetImoIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetImoIn(@NotNull ExpressionFilterParser.TargetImoInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#circle}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCircle(@NotNull ExpressionFilterParser.CircleContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeYearIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeYearIn(@NotNull ExpressionFilterParser.MessageTimeYearInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageName}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageName(@NotNull ExpressionFilterParser.MessageNameContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeHourIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeHourIn(@NotNull ExpressionFilterParser.MessageTimeHourInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetNavigationalStatus}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetNavigationalStatus(@NotNull ExpressionFilterParser.TargetNavigationalStatusContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetName}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetName(@NotNull ExpressionFilterParser.TargetNameContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageLatitude}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageLatitude(@NotNull ExpressionFilterParser.MessageLatitudeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#string}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitString(@NotNull ExpressionFilterParser.StringContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageDraughtIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageDraughtIn(@NotNull ExpressionFilterParser.MessageDraughtInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetCourseOverGroundIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetCourseOverGroundIn(@NotNull ExpressionFilterParser.TargetCourseOverGroundInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeDay}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeDay(@NotNull ExpressionFilterParser.MessageTimeDayContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageCourseOverGround}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageCourseOverGround(@NotNull ExpressionFilterParser.MessageCourseOverGroundContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messagePositionInside}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessagePositionInside(@NotNull ExpressionFilterParser.MessagePositionInsideContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageShiptypeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageShiptypeIn(@NotNull ExpressionFilterParser.MessageShiptypeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#numberRange}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNumberRange(@NotNull ExpressionFilterParser.NumberRangeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetCourseOverGround}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetCourseOverGround(@NotNull ExpressionFilterParser.TargetCourseOverGroundContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetPositionInside}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetPositionInside(@NotNull ExpressionFilterParser.TargetPositionInsideContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageNavigationalStatusIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageNavigationalStatusIn(@NotNull ExpressionFilterParser.MessageNavigationalStatusInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetSpeedOverGroundIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetSpeedOverGroundIn(@NotNull ExpressionFilterParser.TargetSpeedOverGroundInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetDraughtIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetDraughtIn(@NotNull ExpressionFilterParser.TargetDraughtInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#OrAnd}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrAnd(@NotNull ExpressionFilterParser.OrAndContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetLatitude}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetLatitude(@NotNull ExpressionFilterParser.TargetLatitudeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetShiptypeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetShiptypeIn(@NotNull ExpressionFilterParser.TargetShiptypeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeDayIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeDayIn(@NotNull ExpressionFilterParser.MessageTimeDayInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#AisMessagetype}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitAisMessagetype(@NotNull ExpressionFilterParser.AisMessagetypeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceIdIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceIdIn(@NotNull ExpressionFilterParser.SourceIdInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceRegionIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceRegionIn(@NotNull ExpressionFilterParser.SourceRegionInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageCallsignIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageCallsignIn(@NotNull ExpressionFilterParser.MessageCallsignInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#intRange}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitIntRange(@NotNull ExpressionFilterParser.IntRangeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageLongitudeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageLongitudeIn(@NotNull ExpressionFilterParser.MessageLongitudeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#sourceTypeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSourceTypeIn(@NotNull ExpressionFilterParser.SourceTypeInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageNameIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageNameIn(@NotNull ExpressionFilterParser.MessageNameInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageSpeedOverGroundIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageSpeedOverGroundIn(@NotNull ExpressionFilterParser.MessageSpeedOverGroundInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageMmsi}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageMmsi(@NotNull ExpressionFilterParser.MessageMmsiContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#filter}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitFilter(@NotNull ExpressionFilterParser.FilterContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetShiptype}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetShiptype(@NotNull ExpressionFilterParser.TargetShiptypeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageLongitude}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageLongitude(@NotNull ExpressionFilterParser.MessageLongitudeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageTimeMonth}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageTimeMonth(@NotNull ExpressionFilterParser.MessageTimeMonthContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetLongitude}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetLongitude(@NotNull ExpressionFilterParser.TargetLongitudeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#stringList}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitStringList(@NotNull ExpressionFilterParser.StringListContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#notin}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNotin(@NotNull ExpressionFilterParser.NotinContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetCallsignIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetCallsignIn(@NotNull ExpressionFilterParser.TargetCallsignInContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageShiptype}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageShiptype(@NotNull ExpressionFilterParser.MessageShiptypeContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#messageImo}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMessageImo(@NotNull ExpressionFilterParser.MessageImoContext ctx);
-
-	/**
-	 * Visit a parse tree produced by {@link ExpressionFilterParser#targetLongitudeIn}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTargetLongitudeIn(@NotNull ExpressionFilterParser.TargetLongitudeInContext ctx);
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTrueHeadingContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTrueHeading(@NotNull ExpressionFilterParser.MessageTrueHeadingContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTrueHeadingInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTrueHeadingIn(@NotNull ExpressionFilterParser.MessageTrueHeadingInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.ParensContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitParens(@NotNull ExpressionFilterParser.ParensContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeMinuteContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeMinute(@NotNull ExpressionFilterParser.MessageTimeMinuteContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeYearContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeYear(@NotNull ExpressionFilterParser.MessageTimeYearContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#intList}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitIntList(@NotNull ExpressionFilterParser.IntListContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#bbox}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitBbox(@NotNull ExpressionFilterParser.BboxContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageNavigationalStatusContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageNavigationalStatus(@NotNull ExpressionFilterParser.MessageNavigationalStatusContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#compareTo}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCompareTo(@NotNull ExpressionFilterParser.CompareToContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeMinuteInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeMinuteIn(@NotNull ExpressionFilterParser.MessageTimeMinuteInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceBasestationContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceBasestation(@NotNull ExpressionFilterParser.SourceBasestationContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetNavigationalStatusInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetNavigationalStatusIn(@NotNull ExpressionFilterParser.TargetNavigationalStatusInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetLatitudeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetLatitudeIn(@NotNull ExpressionFilterParser.TargetLatitudeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetCountryInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetCountryIn(@NotNull ExpressionFilterParser.TargetCountryInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#number}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNumber(@NotNull ExpressionFilterParser.NumberContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetCallsignContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetCallsign(@NotNull ExpressionFilterParser.TargetCallsignContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeMonthInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeMonthIn(@NotNull ExpressionFilterParser.MessageTimeMonthInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceBasestationInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceBasestationIn(@NotNull ExpressionFilterParser.SourceBasestationInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageImoInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageImoIn(@NotNull ExpressionFilterParser.MessageImoInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetImoContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetImo(@NotNull ExpressionFilterParser.TargetImoContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeWeekdayContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeWeekday(@NotNull ExpressionFilterParser.MessageTimeWeekdayContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageCountryInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageCountryIn(@NotNull ExpressionFilterParser.MessageCountryInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetSpeedOverGroundContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetSpeedOverGround(@NotNull ExpressionFilterParser.TargetSpeedOverGroundContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetTrueHeadingContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetTrueHeading(@NotNull ExpressionFilterParser.TargetTrueHeadingContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetTrueHeadingInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetTrueHeadingIn(@NotNull ExpressionFilterParser.TargetTrueHeadingInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#in}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitIn(@NotNull ExpressionFilterParser.InContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageLatitudeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageLatitudeIn(@NotNull ExpressionFilterParser.MessageLatitudeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageIdContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageId(@NotNull ExpressionFilterParser.MessageIdContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageCallsignContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageCallsign(@NotNull ExpressionFilterParser.MessageCallsignContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageSpeedOverGroundContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageSpeedOverGround(@NotNull ExpressionFilterParser.MessageSpeedOverGroundContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetNameInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetNameIn(@NotNull ExpressionFilterParser.TargetNameInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageCourseOverGroundInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageCourseOverGroundIn(@NotNull ExpressionFilterParser.MessageCourseOverGroundInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageDraughtContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageDraught(@NotNull ExpressionFilterParser.MessageDraughtContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageMmsiInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageMmsiIn(@NotNull ExpressionFilterParser.MessageMmsiInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeHourContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeHour(@NotNull ExpressionFilterParser.MessageTimeHourContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeWeekdayInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeWeekdayIn(@NotNull ExpressionFilterParser.MessageTimeWeekdayInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceCountryInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceCountryIn(@NotNull ExpressionFilterParser.SourceCountryInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageIdInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageIdIn(@NotNull ExpressionFilterParser.MessageIdInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetDraughtContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetDraught(@NotNull ExpressionFilterParser.TargetDraughtContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetImoInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetImoIn(@NotNull ExpressionFilterParser.TargetImoInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#circle}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCircle(@NotNull ExpressionFilterParser.CircleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeYearInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeYearIn(@NotNull ExpressionFilterParser.MessageTimeYearInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageNameContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageName(@NotNull ExpressionFilterParser.MessageNameContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeHourInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeHourIn(@NotNull ExpressionFilterParser.MessageTimeHourInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetNavigationalStatusContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetNavigationalStatus(@NotNull ExpressionFilterParser.TargetNavigationalStatusContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetNameContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetName(@NotNull ExpressionFilterParser.TargetNameContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageLatitudeContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageLatitude(@NotNull ExpressionFilterParser.MessageLatitudeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#string}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitString(@NotNull ExpressionFilterParser.StringContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageDraughtInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageDraughtIn(@NotNull ExpressionFilterParser.MessageDraughtInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetCourseOverGroundInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetCourseOverGroundIn(@NotNull ExpressionFilterParser.TargetCourseOverGroundInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeDayContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeDay(@NotNull ExpressionFilterParser.MessageTimeDayContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageCourseOverGroundContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageCourseOverGround(@NotNull ExpressionFilterParser.MessageCourseOverGroundContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessagePositionInsideContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessagePositionInside(@NotNull ExpressionFilterParser.MessagePositionInsideContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageShiptypeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageShiptypeIn(@NotNull ExpressionFilterParser.MessageShiptypeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#numberRange}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNumberRange(@NotNull ExpressionFilterParser.NumberRangeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetCourseOverGroundContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetCourseOverGround(@NotNull ExpressionFilterParser.TargetCourseOverGroundContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetPositionInsideContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetPositionInside(@NotNull ExpressionFilterParser.TargetPositionInsideContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageNavigationalStatusInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageNavigationalStatusIn(@NotNull ExpressionFilterParser.MessageNavigationalStatusInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetSpeedOverGroundInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetSpeedOverGroundIn(@NotNull ExpressionFilterParser.TargetSpeedOverGroundInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetDraughtInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetDraughtIn(@NotNull ExpressionFilterParser.TargetDraughtInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.OrAndContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrAnd(@NotNull ExpressionFilterParser.OrAndContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetLatitudeContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetLatitude(@NotNull ExpressionFilterParser.TargetLatitudeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetShiptypeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetShiptypeIn(@NotNull ExpressionFilterParser.TargetShiptypeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeDayInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeDayIn(@NotNull ExpressionFilterParser.MessageTimeDayInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.AisMessagetypeContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitAisMessagetype(@NotNull ExpressionFilterParser.AisMessagetypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceIdInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceIdIn(@NotNull ExpressionFilterParser.SourceIdInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceRegionInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceRegionIn(@NotNull ExpressionFilterParser.SourceRegionInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageCallsignInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageCallsignIn(@NotNull ExpressionFilterParser.MessageCallsignInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#intRange}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitIntRange(@NotNull ExpressionFilterParser.IntRangeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageLongitudeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageLongitudeIn(@NotNull ExpressionFilterParser.MessageLongitudeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.SourceTypeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSourceTypeIn(@NotNull ExpressionFilterParser.SourceTypeInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageNameInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageNameIn(@NotNull ExpressionFilterParser.MessageNameInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageSpeedOverGroundInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageSpeedOverGroundIn(@NotNull ExpressionFilterParser.MessageSpeedOverGroundInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageMmsiContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageMmsi(@NotNull ExpressionFilterParser.MessageMmsiContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#filter}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitFilter(@NotNull ExpressionFilterParser.FilterContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetShiptypeContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetShiptype(@NotNull ExpressionFilterParser.TargetShiptypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageLongitudeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageLongitude(@NotNull ExpressionFilterParser.MessageLongitudeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageTimeMonthContext }.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageTimeMonth(@NotNull ExpressionFilterParser.MessageTimeMonthContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetLongitudeContext }.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetLongitude(@NotNull ExpressionFilterParser.TargetLongitudeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#stringList}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitStringList(@NotNull ExpressionFilterParser.StringListContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser#notin}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNotin(@NotNull ExpressionFilterParser.NotinContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetCallsignInContext }.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetCallsignIn(@NotNull ExpressionFilterParser.TargetCallsignInContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageShiptypeContext }.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageShiptype(@NotNull ExpressionFilterParser.MessageShiptypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.MessageImoContext }.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMessageImo(@NotNull ExpressionFilterParser.MessageImoContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link ExpressionFilterParser.TargetLongitudeInContext}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTargetLongitudeIn(@NotNull ExpressionFilterParser.TargetLongitudeInContext ctx);
 }

--- a/ais-lib-json/pom.xml
+++ b/ais-lib-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dk.dma.ais.lib</groupId>
         <artifactId>ais-parent</artifactId>
-        <version>2.4-SNAPSHOT</version>
+        <version>2.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ais-lib-messages/pom.xml
+++ b/ais-lib-messages/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>dk.dma.ais.lib</groupId>
 		<artifactId>ais-parent</artifactId>
-		<version>2.4-SNAPSHOT</version>
+		<version>2.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/binary/BinArray.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/binary/BinArray.java
@@ -59,10 +59,10 @@ public class BinArray {
 
     /**
      * Append bits from a sixbit encoded string
-     * 
-     * @param str
-     * @param padBits
-     * @throws SixbitException
+     *
+     * @param str     the str
+     * @param padBits the pad bits
+     * @throws SixbitException the sixbit exception
      */
     public void appendSixbit(String str, int padBits) throws SixbitException {
         if (str.length() == 0) {
@@ -115,8 +115,8 @@ public class BinArray {
 
     /**
      * Append another binary array
-     * 
-     * @param binArray
+     *
+     * @param binArray the bin array
      */
     public void append(BinArray binArray) {
         int len = binArray.length;
@@ -127,9 +127,9 @@ public class BinArray {
 
     /**
      * Append value with number of bits bits
-     * 
-     * @param val
-     * @param bits
+     *
+     * @param val  the val
+     * @param bits the bits
      */
     public void append(long val, int bits) {
         long powMask = 1;
@@ -143,10 +143,10 @@ public class BinArray {
 
     /**
      * Get six bit string representation of the next len six bit characters and move read ptr
-     * 
-     * @param len
-     * @return string
-     * @throws SixbitException
+     *
+     * @param len the len
+     * @return string string
+     * @throws SixbitException the sixbit exception
      */
     public String getString(int len) throws SixbitException {
         char[] resStr = new char[len];
@@ -158,10 +158,10 @@ public class BinArray {
 
     /**
      * Get value from the next bits number of bits and move read pointer
-     * 
-     * @param bits
-     * @return
-     * @throws SixbitException
+     *
+     * @param bits the bits
+     * @return val
+     * @throws SixbitException the sixbit exception
      */
     public long getVal(int bits) throws SixbitException {
         int to = readPtr + bits - 1;
@@ -172,11 +172,11 @@ public class BinArray {
 
     /**
      * Get value from bit position from and to
-     * 
-     * @param from
-     * @param to
-     * @return
-     * @throws SixbitException
+     *
+     * @param from the from
+     * @param to   the to
+     * @return val
+     * @throws SixbitException the sixbit exception
      */
     public long getVal(int from, int to) throws SixbitException {
         if (to >= length) {
@@ -195,8 +195,8 @@ public class BinArray {
 
     /**
      * Get bit length
-     * 
-     * @return
+     *
+     * @return length
      */
     public int getLength() {
         return length;
@@ -204,21 +204,26 @@ public class BinArray {
 
     /**
      * Get the position of the read ptr within the array
-     * 
-     * @return
+     *
+     * @return read ptr
      */
     public int getReadPtr() {
         return readPtr;
     }
 
+    /**
+     * Size int.
+     *
+     * @return the int
+     */
     public int size() {
         return bitSet.length;
     }
 
     /**
      * Returns true if there are more bits to read
-     * 
-     * @return
+     *
+     * @return boolean
      */
     public boolean hasMoreBits() {
         return readPtr < length - 1;
@@ -226,10 +231,10 @@ public class BinArray {
 
     /**
      * Convert six bit int value to character
-     * 
-     * @param val
-     * @return
-     * @throws SixbitException
+     *
+     * @param val the val
+     * @return int
+     * @throws SixbitException the sixbit exception
      */
     public static int intToascii(int val) throws SixbitException {
         if (val > 63) {
@@ -244,10 +249,10 @@ public class BinArray {
 
     /**
      * Convert a int value to a sixbit ascii value
-     * 
-     * @param val
-     * @return
-     * @throws SixbitException
+     *
+     * @param val the val
+     * @return int
+     * @throws SixbitException the sixbit exception
      */
     public static int intToSixbit(int val) throws SixbitException {
         if (val > 63) {
@@ -268,6 +273,9 @@ public class BinArray {
         return builder.toString();
     }
 
+    /**
+     * Done reading.
+     */
     public void doneReading() {
         readPtr = 0;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/binary/SixbitEncoder.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/binary/SixbitEncoder.java
@@ -31,9 +31,9 @@ public class SixbitEncoder {
 
     /**
      * Add a value using bits number of bits
-     * 
-     * @param value
-     * @param bits
+     *
+     * @param value the value
+     * @param bits  the bits
      */
     public void addVal(long value, int bits) {
         binArray.append(value, bits);
@@ -41,8 +41,8 @@ public class SixbitEncoder {
 
     /**
      * Add string
-     * 
-     * @param str
+     *
+     * @param str the str
      */
     public void addString(String str) {
         for (int i = 0; i < str.length(); i++) {
@@ -56,9 +56,9 @@ public class SixbitEncoder {
 
     /**
      * Add string and a number of spaces to fill length characters
-     * 
-     * @param str
-     * @param length
+     *
+     * @param str    the str
+     * @param length the length
      */
     public void addString(String str, int length) {
         int i = 0;
@@ -76,8 +76,8 @@ public class SixbitEncoder {
 
     /**
      * Append another encoder
-     * 
-     * @param encoder
+     *
+     * @param encoder the encoder
      */
     public void append(SixbitEncoder encoder) {
         binArray.append(encoder.binArray);
@@ -85,8 +85,8 @@ public class SixbitEncoder {
 
     /**
      * Append a binary array
-     * 
-     * @param ba
+     *
+     * @param ba the ba
      */
     public void append(BinArray ba) {
         binArray.append(ba);
@@ -94,9 +94,9 @@ public class SixbitEncoder {
 
     /**
      * Get encoded six bit string
-     * 
-     * @return string
-     * @throws SixbitException
+     *
+     * @return string string
+     * @throws SixbitException the sixbit exception
      */
     public String encode() throws SixbitException {
         StringBuilder buf = new StringBuilder();
@@ -119,8 +119,8 @@ public class SixbitEncoder {
 
     /**
      * The number of padding bits
-     * 
-     * @return
+     *
+     * @return pad bits
      */
     public int getPadBits() {
         return padBits;
@@ -128,8 +128,8 @@ public class SixbitEncoder {
 
     /**
      * Get bit length
-     * 
-     * @return
+     *
+     * @return length
      */
     public int getLength() {
         return binArray.getLength();
@@ -137,8 +137,8 @@ public class SixbitEncoder {
 
     /**
      * Get the underlying binary array
-     * 
-     * @return
+     *
+     * @return bin array
      */
     public BinArray getBinArray() {
         return binArray;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/binary/SixbitException.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/binary/SixbitException.java
@@ -21,6 +21,11 @@ public class SixbitException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Sixbit exception.
+     *
+     * @param msg the msg
+     */
     public SixbitException(String msg) {
         super(msg);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisBinaryMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisBinaryMessage.java
@@ -28,16 +28,31 @@ public abstract class AisBinaryMessage extends AisMessage {
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Spare.
+     */
     protected int spare;
+    /**
+     * The Dac.
+     */
     protected int dac; // 10 bits: Designated area code (DAC)
+    /**
+     * The Fi.
+     */
     protected int fi; // 6 bits: Function identifier
+    /**
+     * The Data.
+     */
     protected BinArray data;
+    /**
+     * The App message.
+     */
     protected AisApplicationMessage appMessage;
 
     /**
      * Construct empty binary message with msgId
-     * 
-     * @param msgId
+     *
+     * @param msgId the msg id
      */
     public AisBinaryMessage(int msgId) {
         super(msgId);
@@ -45,8 +60,8 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Construct binary message from VDM sentence
-     * 
-     * @param vdm
+     *
+     * @param vdm the vdm
      */
     public AisBinaryMessage(Vdm vdm) {
         super(vdm);
@@ -54,9 +69,9 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Get the application specific message, if it is implemented
-     * 
+     *
      * @return application specific message
-     * @throws BitExhaustionException
+     * @throws SixbitException the sixbit exception
      */
     public AisApplicationMessage getApplicationMessage() throws SixbitException {
         if (appMessage != null) {
@@ -73,8 +88,8 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Get binary data for this message
-     * 
-     * @return
+     *
+     * @return binary data
      */
     public SixbitEncoder getBinaryData() {
         SixbitEncoder encoder = new SixbitEncoder();
@@ -84,34 +99,64 @@ public abstract class AisBinaryMessage extends AisMessage {
         return encoder;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets dac.
+     *
+     * @return the dac
+     */
     public int getDac() {
         return dac;
     }
 
+    /**
+     * Sets dac.
+     *
+     * @param dac the dac
+     */
     public void setDac(int dac) {
         this.dac = dac;
     }
 
+    /**
+     * Gets fi.
+     *
+     * @return the fi
+     */
     public int getFi() {
         return fi;
     }
 
+    /**
+     * Sets fi.
+     *
+     * @param fi the fi
+     */
     public void setFi(int fi) {
         this.fi = fi;
     }
 
     /**
      * Get the raw binary data of this message
-     * 
-     * @return
+     *
+     * @return data
      */
     public BinArray getData() {
         return data;
@@ -119,8 +164,8 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Set the raw binary data of this message
-     * 
-     * @param data
+     *
+     * @param data the data
      */
     public void setData(BinArray data) {
         this.data = data;
@@ -128,8 +173,8 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Get the application specific message contained in the sentence
-     * 
-     * @return
+     *
+     * @return app message
      */
     public AisApplicationMessage getAppMessage() {
         return appMessage;
@@ -137,8 +182,8 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Set application specific message to be contained in this message
-     * 
-     * @param appMessage
+     *
+     * @param appMessage the app message
      */
     public void setAppMessage(AisApplicationMessage appMessage) {
         this.dac = appMessage.getDac();
@@ -148,9 +193,9 @@ public abstract class AisBinaryMessage extends AisMessage {
 
     /**
      * Set values from ABM/BBM binary part
-     * 
-     * @param binArray
-     * @throws SixbitException
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
      */
     public void setBinary(BinArray binArray) throws SixbitException {
         this.dac = (int) binArray.getVal(10);

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
@@ -38,19 +38,33 @@ public abstract class AisMessage implements Serializable {
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
-    /** A set of all valid AIS message types. */
+    /**
+     * A set of all valid AIS message types.
+     */
     public static final Set<Integer> VALID_MESSAGE_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(1,
             2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 17, 18, 19, 21, 24)));
 
+    /**
+     * The Msg id.
+     */
     protected int msgId; // 6 bit: message id
+    /**
+     * The Repeat.
+     */
     protected int repeat; // 2 bit: How many times message has been repeated
+    /**
+     * The User id.
+     */
     protected int userId; // 30 bit: MMSI number
+    /**
+     * The Vdm.
+     */
     protected transient Vdm vdm; // The VDM encapsulating the AIS message
 
     /**
      * Constructor given message id
-     * 
-     * @param msgId
+     *
+     * @param msgId the msg id
      */
     public AisMessage(int msgId) {
         this.msgId = msgId;
@@ -59,8 +73,8 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Constructor given VDM with AIS message
-     * 
-     * @param vdm
+     *
+     * @param vdm the vdm
      */
     public AisMessage(Vdm vdm) {
         this.vdm = vdm;
@@ -69,10 +83,10 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Base parse method to be called by all extending classes
-     * 
-     * @param binArray
-     * @throws AisMessageException
-     * @throws SixbitException
+     *
+     * @param binArray the bin array
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
      */
     protected void parse(BinArray binArray) throws AisMessageException, SixbitException {
         this.repeat = (int) binArray.getVal(2);
@@ -81,8 +95,8 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Base encode method to be called by all extending classes
-     * 
-     * @return SixbitEncoder
+     *
+     * @return SixbitEncoder sixbit encoder
      */
     protected SixbitEncoder encode() {
         SixbitEncoder encoder = new SixbitEncoder();
@@ -94,35 +108,60 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Abstract method to be implemented by all extending classes
-     * 
-     * @return SixbitEncoder
+     *
+     * @return SixbitEncoder encoded
      */
     public abstract SixbitEncoder getEncoded();
 
+    /**
+     * Gets msg id.
+     *
+     * @return the msg id
+     */
     public int getMsgId() {
         return msgId;
     }
 
+    /**
+     * Gets repeat.
+     *
+     * @return the repeat
+     */
     public int getRepeat() {
         return repeat;
     }
 
+    /**
+     * Sets repeat.
+     *
+     * @param repeat the repeat
+     */
     public void setRepeat(int repeat) {
         this.repeat = repeat;
     }
 
+    /**
+     * Gets user id.
+     *
+     * @return the user id
+     */
     public int getUserId() {
         return userId;
     }
 
+    /**
+     * Sets user id.
+     *
+     * @param userId the user id
+     */
     public void setUserId(int userId) {
         this.userId = userId;
     }
 
     /**
      * Return the LAST source tag (closest to AIS sentence)
-     * 
-     * @return
+     *
+     * @return source tag
      */
     public IProprietarySourceTag getSourceTag() {
         LinkedList<IProprietaryTag> tags = vdm == null ? null : vdm.getTags();
@@ -141,8 +180,8 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Get all tags
-     * 
-     * @return
+     *
+     * @return tags
      */
     public LinkedList<IProprietaryTag> getTags() {
         return vdm.getTags();
@@ -150,8 +189,8 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Add tag (to front)
-     * 
-     * @param sourceTag
+     *
+     * @param tag the tag
      */
     public void setTag(IProprietaryTag tag) {
         LinkedList<IProprietaryTag> tags = vdm.getTags();
@@ -161,14 +200,19 @@ public abstract class AisMessage implements Serializable {
         tags.addFirst(tag);
     }
 
+    /**
+     * Sets tags.
+     *
+     * @param tags the tags
+     */
     public void setTags(LinkedList<IProprietaryTag> tags) {
         vdm.setTags(tags);
     }
 
     /**
      * Get VDM this message was encapsulated in
-     * 
-     * @return Vdm
+     *
+     * @return Vdm vdm
      */
     public Vdm getVdm() {
         return vdm;
@@ -176,7 +220,7 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Returns a valid position if this message has a valid position, otherwise null.
-     * 
+     *
      * @return a valid position if this message has a valid position, otherwise null
      */
     public Position getValidPosition() {
@@ -185,7 +229,7 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Returns the target type of the message or <code>null</code> if the message does not have a target type.
-     * 
+     *
      * @return the target type of the message or <code>null</code> if the message does not have a target type
      */
     public AisTargetType getTargetType() {
@@ -211,14 +255,14 @@ public abstract class AisMessage implements Serializable {
     /**
      * Given VDM return the encapsulated AIS message. To determine which message is returned use instanceof operator or
      * getMsgId() before casting.
-     * 
+     * <p>
      * Example: AisMessage aisMessage = AisMessage.getInstance(vmd); if (aisMessage instanceof AisPositionMessage) {
      * AisPositionMessage posMessage = (AisPositionMessage)aisMessage; } ...
-     * 
-     * @param vdm
-     * @return AisMessage
-     * @throws AisMessageException
-     * @throws SixbitException
+     *
+     * @param vdm the vdm
+     * @return AisMessage instance
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
      */
     public static AisMessage getInstance(Vdm vdm) throws AisMessageException, SixbitException {
         AisMessage message;
@@ -315,9 +359,9 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Utility to trim text from AIS message
-     * 
-     * @param text
-     * @return
+     *
+     * @param text the text
+     * @return string
      */
     public static String trimText(String text) {
         if (text == null) {
@@ -334,8 +378,8 @@ public abstract class AisMessage implements Serializable {
 
     /**
      * Method for reassembling original message appending possible proprietary source tags
-     * 
-     * @return
+     *
+     * @return string
      */
     public String reassemble() {
         LinkedList<IProprietaryTag> tags = vdm.getTags();

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage1.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage1.java
@@ -21,38 +21,37 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 1
- * 
+ * <p>
  * This class handles the content of an AIS class A transponders general position report as defined by ITU-R M.1371-4.
- * 
+ * <p>
  * Generally the position report is handled in the super class but there are some specific purposes of this class. This
  * is mainly the communication state field, that requires some special attention.
- * 
+ * <p>
  * The communication state field covers 19 bits and this is general to both message 1, message 2 and message 3. The
  * content is though different for the different communication states applied by the different message types.
- * 
+ * <p>
  * This message type is using SOTDMA communication state, which is described below.
- * 
+ * <p>
  * CommState - 19 bits sync state: 2 bits slot timeout: 3 bits sub message: 14 bits
- * 
+ * <p>
  * The sub message depends upon the value of the slot timeout. The slot timeout is defined to be between 0 and 7 both
  * values included.
- * 
+ * <p>
  * The sub message is defined as:
- * 
+ * <p>
  * When slot timeout = 0 - Then the sub message is the slot offset: If the slot time-out value is 0 (zero) then the slot
  * offset should indicate the offset to the slot in which transmission will occur during the next frame. If the slot
  * offset is zero, the slot should be de-allocated after transmission
- * 
+ * <p>
  * When slot timeout = 1 - Then the sub message is UTC hour and minute: If the station has access to UTC, the hour and
  * minute should be indicated in this sub message. Hour (0-23) should be coded in bits 13 to 9 of the sub message (bit
  * 13 is MSB). Minute (0-59) should be coded in bit 8 to 2 (bit 8 is MSB). Bit 1 and bit 0 are not used.
- * 
+ * <p>
  * When slot timeout = 2,4,6 - Then the sub message is the slot number: Slot number used for this transmission (between
  * 0 and 2249).
- * 
+ * <p>
  * When slot timeout = 3,5,7 - Then the sub message is the recieved stations: Number of other stations (not own station)
  * which the station currently is receiving (between 0 and 16383).
- * 
  */
 public class AisMessage1 extends AisPositionMessage {
 
@@ -70,19 +69,40 @@ public class AisMessage1 extends AisPositionMessage {
      */
     protected int subMessage; // 14 bits
 
+    /**
+     * Instantiates a new Ais message 1.
+     */
     public AisMessage1() {
         super(1);
     }
 
+    /**
+     * Instantiates a new Ais message 1.
+     *
+     * @param msgType the msg type
+     */
     AisMessage1(int msgType) {
         super(msgType);
     }
 
+    /**
+     * Instantiates a new Ais message 1.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage1(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         super.parse(binArray);
@@ -98,18 +118,38 @@ public class AisMessage1 extends AisPositionMessage {
         return encoder;
     }
 
+    /**
+     * Gets slot timeout.
+     *
+     * @return the slot timeout
+     */
     public int getSlotTimeout() {
         return slotTimeout;
     }
 
+    /**
+     * Sets slot timeout.
+     *
+     * @param slotTimeout the slot timeout
+     */
     public void setSlotTimeout(int slotTimeout) {
         this.slotTimeout = slotTimeout;
     }
 
+    /**
+     * Gets sub message.
+     *
+     * @return the sub message
+     */
     public int getSubMessage() {
         return subMessage;
     }
 
+    /**
+     * Sets sub message.
+     *
+     * @param subMessage the sub message
+     */
     public void setSubMessage(int subMessage) {
         this.subMessage = subMessage;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage10.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage10.java
@@ -42,10 +42,20 @@ public class AisMessage10 extends AisMessage {
      */
     private int spare2; // 2 bits
 
+    /**
+     * Instantiates a new Ais message 10.
+     */
     public AisMessage10() {
         super(10);
     }
 
+    /**
+     * Instantiates a new Ais message 10.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage10(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse(vdm.getBinArray());
@@ -87,26 +97,56 @@ public class AisMessage10 extends AisMessage {
         return builder.toString();
     }
 
+    /**
+     * Gets spare 1.
+     *
+     * @return the spare 1
+     */
     public int getSpare1() {
         return spare1;
     }
 
+    /**
+     * Sets spare 1.
+     *
+     * @param spare1 the spare 1
+     */
     public void setSpare1(int spare1) {
         this.spare1 = spare1;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public int getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(int destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets spare 2.
+     *
+     * @return the spare 2
+     */
     public int getSpare2() {
         return spare2;
     }
 
+    /**
+     * Sets spare 2.
+     *
+     * @param spare2 the spare 2
+     */
     public void setSpare2(int spare2) {
         this.spare2 = spare2;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage11.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage11.java
@@ -19,19 +19,28 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 4
- *
+ * <p>
  * Base station report as defined by ITU-R M.1371-4
- *
  */
 public class AisMessage11 extends UTCDateResponseMessage {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message 11.
+     */
     public AisMessage11() {
         super(11);
     }
 
+    /**
+     * Instantiates a new Ais message 11.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage11(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage12.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage12.java
@@ -33,15 +33,31 @@ public class AisMessage12 extends AisMessage {
     private int spare; // 1 bit: Spare
     private String message; // Max 936 bit - 156 characters
 
+    /**
+     * Instantiates a new Ais message 12.
+     */
     public AisMessage12() {
         super(12);
     }
 
+    /**
+     * Instantiates a new Ais message 12.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage12(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 72 || binArray.getLength() > 1008) {
@@ -68,9 +84,9 @@ public class AisMessage12 extends AisMessage {
 
     /**
      * Set message from a binary array
-     * 
-     * @param binArray
-     * @throws SixbitException
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
      */
     public void setMessage(BinArray binArray) throws SixbitException {
         message = binArray.getString(binArray.getLength() / 6);
@@ -94,42 +110,92 @@ public class AisMessage12 extends AisMessage {
         return builder.toString();
     }
 
+    /**
+     * Gets seq num.
+     *
+     * @return the seq num
+     */
     public int getSeqNum() {
         return seqNum;
     }
 
+    /**
+     * Sets seq num.
+     *
+     * @param seqNum the seq num
+     */
     public void setSeqNum(int seqNum) {
         this.seqNum = seqNum;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public long getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(long destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets retransmit.
+     *
+     * @return the retransmit
+     */
     public int getRetransmit() {
         return retransmit;
     }
 
+    /**
+     * Sets retransmit.
+     *
+     * @param retransmit the retransmit
+     */
     public void setRetransmit(int retransmit) {
         this.retransmit = retransmit;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets message.
+     *
+     * @return the message
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * Sets message.
+     *
+     * @param message the message
+     */
     public void setMessage(String message) {
         this.message = message;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage13.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage13.java
@@ -19,19 +19,28 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 13
- * 
+ * <p>
  * Acknowledge message as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage13 extends AisMessage7 {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message 13.
+     */
     public AisMessage13() {
         super(13);
     }
 
+    /**
+     * Instantiates a new Ais message 13.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage13(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage14.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage14.java
@@ -30,15 +30,31 @@ public class AisMessage14 extends AisMessage {
     private int spare; // 2 bit: Spare
     private String message; // Max 968 bit - 161 characters
 
+    /**
+     * Instantiates a new Ais message 14.
+     */
     public AisMessage14() {
         super(14);
     }
 
+    /**
+     * Instantiates a new Ais message 14.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage14(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 40 || binArray.getLength() > 1008) {
@@ -59,18 +75,28 @@ public class AisMessage14 extends AisMessage {
 
     /**
      * Set message from a binary array
-     * 
-     * @param binArray
-     * @throws SixbitException
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
      */
     public void setMessage(BinArray binArray) throws SixbitException {
         message = binArray.getString(binArray.getLength() / 6);
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Gets message.
+     *
+     * @return the message
+     */
     public String getMessage() {
         return message;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage17.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage17.java
@@ -21,9 +21,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 17
- * 
+ * <p>
  * GNSS broadcast binary message
- * 
  */
 public class AisMessage17 extends AisMessage {
 
@@ -42,19 +41,40 @@ public class AisMessage17 extends AisMessage {
     private int health; // 3 bits: Reference station health (specified in Recommendation ITU-R M.823)
     private int[] dataWords; // 29 bit each: DGNSS message data words excluding parity
 
+    /**
+     * Instantiates a new Ais message 17.
+     */
     public AisMessage17() {
         super(7);
     }
 
+    /**
+     * Instantiates a new Ais message 17.
+     *
+     * @param num the num
+     */
     public AisMessage17(int num) {
         super(num);
     }
 
+    /**
+     * Instantiates a new Ais message 17.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage17(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray sixbit = vdm.getBinArray();
         if (sixbit.getLength() < 80 || sixbit.getLength() > 816) {
@@ -100,90 +120,200 @@ public class AisMessage17 extends AisMessage {
         return encoder;
     }
 
+    /**
+     * Gets spare 1.
+     *
+     * @return the spare 1
+     */
     public int getSpare1() {
         return spare1;
     }
 
+    /**
+     * Sets spare 1.
+     *
+     * @param spare1 the spare 1
+     */
     public void setSpare1(int spare1) {
         this.spare1 = spare1;
     }
 
+    /**
+     * Gets lon.
+     *
+     * @return the lon
+     */
     public int getLon() {
         return lon;
     }
 
+    /**
+     * Sets lon.
+     *
+     * @param lon the lon
+     */
     public void setLon(int lon) {
         this.lon = lon;
     }
 
+    /**
+     * Gets lat.
+     *
+     * @return the lat
+     */
     public int getLat() {
         return lat;
     }
 
+    /**
+     * Sets lat.
+     *
+     * @param lat the lat
+     */
     public void setLat(int lat) {
         this.lat = lat;
     }
 
+    /**
+     * Gets spare 2.
+     *
+     * @return the spare 2
+     */
     public int getSpare2() {
         return spare2;
     }
 
+    /**
+     * Sets spare 2.
+     *
+     * @param spare2 the spare 2
+     */
     public void setSpare2(int spare2) {
         this.spare2 = spare2;
     }
 
+    /**
+     * Gets message type.
+     *
+     * @return the message type
+     */
     public int getMessageType() {
         return messageType;
     }
 
+    /**
+     * Sets message type.
+     *
+     * @param messageType the message type
+     */
     public void setMessageType(int messageType) {
         this.messageType = messageType;
     }
 
+    /**
+     * Gets station id.
+     *
+     * @return the station id
+     */
     public int getStationId() {
         return stationId;
     }
 
+    /**
+     * Sets station id.
+     *
+     * @param stationId the station id
+     */
     public void setStationId(int stationId) {
         this.stationId = stationId;
     }
 
+    /**
+     * Gets count.
+     *
+     * @return the count
+     */
     public int getzCount() {
         return zCount;
     }
 
+    /**
+     * Sets count.
+     *
+     * @param zCount the z count
+     */
     public void setzCount(int zCount) {
         this.zCount = zCount;
     }
 
+    /**
+     * Gets seq num.
+     *
+     * @return the seq num
+     */
     public int getSeqNum() {
         return seqNum;
     }
 
+    /**
+     * Sets seq num.
+     *
+     * @param seqNum the seq num
+     */
     public void setSeqNum(int seqNum) {
         this.seqNum = seqNum;
     }
 
+    /**
+     * Gets data word count.
+     *
+     * @return the data word count
+     */
     public int getDataWordCount() {
         return dataWordCount;
     }
 
+    /**
+     * Sets data word count.
+     *
+     * @param dataWordCount the data word count
+     */
     public void setDataWordCount(int dataWordCount) {
         this.dataWordCount = dataWordCount;
     }
 
+    /**
+     * Gets health.
+     *
+     * @return the health
+     */
     public int getHealth() {
         return health;
     }
 
+    /**
+     * Sets health.
+     *
+     * @param health the health
+     */
     public void setHealth(int health) {
         this.health = health;
     }
 
+    /**
+     * Get data words int [ ].
+     *
+     * @return the int [ ]
+     */
     public int[] getDataWords() {
         return dataWords;
     }
 
+    /**
+     * Sets data words.
+     *
+     * @param dataWords the data words
+     */
     public void setDataWords(int[] dataWords) {
         this.dataWords = dataWords;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage18.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage18.java
@@ -22,9 +22,8 @@ import dk.dma.enav.model.geometry.Position;
 
 /**
  * AIS message 18
- * 
+ * <p>
  * CLASS B position report implemented according to ITU-R M.1371-4
- * 
  */
 public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
 
@@ -40,7 +39,7 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     private int sog; // 10 bits
 
     /**
-     * AisPosition Accuracy 1 = high ( =< 10 m) 0 = low (>10 m) 0 = default The PA flag should be determined in
+     * AisPosition Accuracy 1 = high ( =&lt; 10 m) 0 = low (&gt;10 m) 0 = default The PA flag should be determined in
      * accordance with Table 47
      */
     private int posAcc; // 1 bit
@@ -124,15 +123,31 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
      */
     private int commState; // 19 bits : SOTDMA sync state
 
+    /**
+     * Instantiates a new Ais message 18.
+     */
     public AisMessage18() {
         super(18);
     }
 
+    /**
+     * Instantiates a new Ais message 18.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage18(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         this.parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray sixbit = vdm.getBinArray();
         if (sixbit.getLength() != 168) {
@@ -193,6 +208,8 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
+     * Gets spare after user id.
+     *
      * @return the spareAfterUserId
      */
     public int getSpareAfterUserId() {
@@ -200,8 +217,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param spareAfterUserId
-     *            the spareAfterUserId to set
+     * Sets spare after user id.
+     *
+     * @param spareAfterUserId the spareAfterUserId to set
      */
     public void setSpareAfterUserId(int spareAfterUserId) {
         this.spareAfterUserId = spareAfterUserId;
@@ -215,8 +233,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param sog
-     *            the sog to set
+     * Sets sog.
+     *
+     * @param sog the sog to set
      */
     public void setSog(int sog) {
         this.sog = sog;
@@ -230,8 +249,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param posAcc
-     *            the posAcc to set
+     * Sets pos acc.
+     *
+     * @param posAcc the posAcc to set
      */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
@@ -251,8 +271,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param pos
-     *            the pos to set
+     * Sets pos.
+     *
+     * @param pos the pos to set
      */
     public void setPos(AisPosition pos) {
         this.pos = pos;
@@ -266,8 +287,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param cog
-     *            the cog to set
+     * Sets cog.
+     *
+     * @param cog the cog to set
      */
     public void setCog(int cog) {
         this.cog = cog;
@@ -281,8 +303,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param trueHeading
-     *            the trueHeading to set
+     * Sets true heading.
+     *
+     * @param trueHeading the trueHeading to set
      */
     public void setTrueHeading(int trueHeading) {
         this.trueHeading = trueHeading;
@@ -296,14 +319,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param utcSec
-     *            the utcSec to set
+     * Sets utc sec.
+     *
+     * @param utcSec the utcSec to set
      */
     public void setUtcSec(int utcSec) {
         this.utcSec = utcSec;
     }
 
     /**
+     * Gets spare.
+     *
      * @return the spare
      */
     public int getSpare() {
@@ -311,14 +337,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param spare
-     *            the spare to set
+     * Sets spare.
+     *
+     * @param spare the spare to set
      */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
     /**
+     * Gets class b unit flag.
+     *
      * @return the classBUnitFlag
      */
     public int getClassBUnitFlag() {
@@ -326,14 +355,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param classBUnitFlag
-     *            the classBUnitFlag to set
+     * Sets class b unit flag.
+     *
+     * @param classBUnitFlag the classBUnitFlag to set
      */
     public void setClassBUnitFlag(int classBUnitFlag) {
         this.classBUnitFlag = classBUnitFlag;
     }
 
     /**
+     * Gets class b display flag.
+     *
      * @return the classBDisplayFlag
      */
     public int getClassBDisplayFlag() {
@@ -341,14 +373,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param classBDisplayFlag
-     *            the classBDisplayFlag to set
+     * Sets class b display flag.
+     *
+     * @param classBDisplayFlag the classBDisplayFlag to set
      */
     public void setClassBDisplayFlag(int classBDisplayFlag) {
         this.classBDisplayFlag = classBDisplayFlag;
     }
 
     /**
+     * Gets class b dsc flag.
+     *
      * @return the classBDscFlag
      */
     public int getClassBDscFlag() {
@@ -356,14 +391,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param classBDscFlag
-     *            the classBDscFlag to set
+     * Sets class b dsc flag.
+     *
+     * @param classBDscFlag the classBDscFlag to set
      */
     public void setClassBDscFlag(int classBDscFlag) {
         this.classBDscFlag = classBDscFlag;
     }
 
     /**
+     * Gets class b band flag.
+     *
      * @return the classBBandFlag
      */
     public int getClassBBandFlag() {
@@ -371,14 +409,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param classBBandFlag
-     *            the classBBandFlag to set
+     * Sets class b band flag.
+     *
+     * @param classBBandFlag the classBBandFlag to set
      */
     public void setClassBBandFlag(int classBBandFlag) {
         this.classBBandFlag = classBBandFlag;
     }
 
     /**
+     * Gets class b msg 22 flag.
+     *
      * @return the classBMsg22Flag
      */
     public int getClassBMsg22Flag() {
@@ -386,14 +427,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param classBMsg22Flag
-     *            the classBMsg22Flag to set
+     * Sets class b msg 22 flag.
+     *
+     * @param classBMsg22Flag the classBMsg22Flag to set
      */
     public void setClassBMsg22Flag(int classBMsg22Flag) {
         this.classBMsg22Flag = classBMsg22Flag;
     }
 
     /**
+     * Gets mode flag.
+     *
      * @return the modeFlag
      */
     public int getModeFlag() {
@@ -401,8 +445,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param modeFlag
-     *            the modeFlag to set
+     * Sets mode flag.
+     *
+     * @param modeFlag the modeFlag to set
      */
     public void setModeFlag(int modeFlag) {
         this.modeFlag = modeFlag;
@@ -416,14 +461,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param raimFlag
-     *            the raimFlag to set
+     * Sets raim.
+     *
+     * @param raim the raim
      */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
     /**
+     * Gets comm state selector flag.
+     *
      * @return the commStateSelectorFlag
      */
     public int getCommStateSelectorFlag() {
@@ -431,14 +479,17 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param commStateSelectorFlag
-     *            the commStateSelectorFlag to set
+     * Sets comm state selector flag.
+     *
+     * @param commStateSelectorFlag the commStateSelectorFlag to set
      */
     public void setCommStateSelectorFlag(int commStateSelectorFlag) {
         this.commStateSelectorFlag = commStateSelectorFlag;
     }
 
     /**
+     * Gets comm state.
+     *
      * @return the commState
      */
     public int getCommState() {
@@ -446,8 +497,9 @@ public class AisMessage18 extends AisMessage implements IVesselPositionMessage {
     }
 
     /**
-     * @param commState
-     *            the commState to set
+     * Sets comm state.
+     *
+     * @param commState the commState to set
      */
     public void setCommState(int commState) {
         this.commState = commState;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage19.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage19.java
@@ -22,9 +22,8 @@ import dk.dma.enav.model.geometry.Position;
 
 /**
  * AIS message 19
- * 
+ * <p>
  * Extended Class B equipment position report as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage19 extends AisStaticCommon implements IVesselPositionMessage {
 
@@ -43,7 +42,7 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
     private int sog; // 10 bits
 
     /**
-     * AisPosition Accuracy 1 = high ( =< 10 m) 0 = low (>10 m) 0 = default The PA flag should be determined in
+     * AisPosition Accuracy 1 = high ( =&lt; 10 m) 0 = low (&gt;10 m) 0 = default The PA flag should be determined in
      * accordance with Table 47
      */
     private int posAcc; // 1 bit
@@ -105,10 +104,20 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
      */
     private int spare3; // 4 bits
 
+    /**
+     * Instantiates a new Ais message 19.
+     */
     public AisMessage19() {
         super(19);
     }
 
+    /**
+     * Instantiates a new Ais message 19.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage19(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse(vdm.getBinArray());
@@ -218,10 +227,20 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return builder.toString();
     }
 
+    /**
+     * Gets spare 1.
+     *
+     * @return the spare 1
+     */
     public int getSpare1() {
         return spare1;
     }
 
+    /**
+     * Sets spare 1.
+     *
+     * @param spare1 the spare 1
+     */
     public void setSpare1(int spare1) {
         this.spare1 = spare1;
     }
@@ -230,6 +249,11 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return sog;
     }
 
+    /**
+     * Sets sog.
+     *
+     * @param sog the sog
+     */
     public void setSog(int sog) {
         this.sog = sog;
     }
@@ -238,6 +262,11 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
@@ -252,6 +281,11 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
@@ -260,6 +294,11 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return cog;
     }
 
+    /**
+     * Sets cog.
+     *
+     * @param cog the cog
+     */
     public void setCog(int cog) {
         this.cog = cog;
     }
@@ -268,6 +307,11 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return trueHeading;
     }
 
+    /**
+     * Sets true heading.
+     *
+     * @param trueHeading the true heading
+     */
     public void setTrueHeading(int trueHeading) {
         this.trueHeading = trueHeading;
     }
@@ -276,54 +320,119 @@ public class AisMessage19 extends AisStaticCommon implements IVesselPositionMess
         return utcSec;
     }
 
+    /**
+     * Sets utc sec.
+     *
+     * @param utcSec the utc sec
+     */
     public void setUtcSec(int utcSec) {
         this.utcSec = utcSec;
     }
 
+    /**
+     * Gets spare 2.
+     *
+     * @return the spare 2
+     */
     public int getSpare2() {
         return spare2;
     }
 
+    /**
+     * Sets spare 2.
+     *
+     * @param spare2 the spare 2
+     */
     public void setSpare2(int spare2) {
         this.spare2 = spare2;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public int getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(int posType) {
         this.posType = posType;
     }
 
+    /**
+     * Gets raim flag.
+     *
+     * @return the raim flag
+     */
     public int getRaimFlag() {
         return raimFlag;
     }
 
+    /**
+     * Sets raim flag.
+     *
+     * @param raimFlag the raim flag
+     */
     public void setRaimFlag(int raimFlag) {
         this.raimFlag = raimFlag;
     }
 
+    /**
+     * Gets dte.
+     *
+     * @return the dte
+     */
     public int getDte() {
         return dte;
     }
 
+    /**
+     * Sets dte.
+     *
+     * @param dte the dte
+     */
     public void setDte(int dte) {
         this.dte = dte;
     }
 
+    /**
+     * Gets mode flag.
+     *
+     * @return the mode flag
+     */
     public int getModeFlag() {
         return modeFlag;
     }
 
+    /**
+     * Sets mode flag.
+     *
+     * @param modeFlag the mode flag
+     */
     public void setModeFlag(int modeFlag) {
         this.modeFlag = modeFlag;
     }
 
+    /**
+     * Gets spare 3.
+     *
+     * @return the spare 3
+     */
     public int getSpare3() {
         return spare3;
     }
 
+    /**
+     * Sets spare 3.
+     *
+     * @param spare3 the spare 3
+     */
     public void setSpare3(int spare3) {
         this.spare3 = spare3;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage2.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage2.java
@@ -19,21 +19,30 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 2
- * 
+ * <p>
  * Assigned scheduled position report
- * 
+ * <p>
  * This class handles the content of an AIS class A transponders general position report as defined by ITU-R M.1371-4.
- * 
  */
 public class AisMessage2 extends AisMessage1 {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message 2.
+     */
     public AisMessage2() {
         super(2);
     }
 
+    /**
+     * Instantiates a new Ais message 2.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage2(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage21.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage21.java
@@ -22,43 +22,112 @@ import dk.dma.enav.model.geometry.Position;
 
 /**
  * AIS message 21
- * 
+ * <p>
  * Aids-to-navigation report (AtoN) as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage21 extends AisMessage implements IPositionMessage, IDimensionMessage, INameMessage {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Aton type.
+     */
     int atonType; // 5 bits : Type of AtoN
+    /**
+     * The Name.
+     */
     String name; // 120 bits : Name of AtoN in ASCII
+    /**
+     * The Pos acc.
+     */
     int posAcc; // 1 bit : AisPosition Accuracy
+    /**
+     * The Pos.
+     */
     AisPosition pos; // : Lat/Long 1/100000 minute
+    /**
+     * The Dim bow.
+     */
     int dimBow; // 9 bits : GPS Ant. Distance from Bow
+    /**
+     * The Dim stern.
+     */
     int dimStern; // 9 bits : GPS Ant. Distance from Stern
+    /**
+     * The Dim port.
+     */
     int dimPort; // 6 bits : GPS Ant. Distance from Port
+    /**
+     * The Dim starboard.
+     */
     int dimStarboard; // 6 bits : GPS Ant. Distance from Starboard
+    /**
+     * The Pos type.
+     */
     int posType; // 4 bits : Type of AisPosition Fixing Device
+    /**
+     * The Utc sec.
+     */
     int utcSec; // 6 bits : UTC Seconds
+    /**
+     * The Off position.
+     */
     int offPosition; // 1 bit : Off AisPosition Flag
+    /**
+     * The Regional.
+     */
     int regional; // 8 bits : Regional Bits
+    /**
+     * The Raim.
+     */
     int raim; // 1 bit : RAIM Flag
+    /**
+     * The Virtual.
+     */
     int virtual; // 1 bit : Virtual/Pseudo AtoN Flag
+    /**
+     * The Assigned.
+     */
     int assigned; // 1 bit : Assigned Mode Flag
+    /**
+     * The Spare 1.
+     */
     int spare1; // 1 bit : Spare
+    /**
+     * The Name ext.
+     */
     String nameExt; // 0-84 bits : Extended name in ASCII
+    /**
+     * The Spare 2.
+     */
     int spare2; // 0-6 bits : Spare
 
+    /**
+     * Instantiates a new Ais message 21.
+     */
     public AisMessage21() {
         super(21);
     }
 
+    /**
+     * Instantiates a new Ais message 21.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage21(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 272 || binArray.getLength() > 360) {
@@ -120,10 +189,20 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return encoder;
     }
 
+    /**
+     * Gets aton type.
+     *
+     * @return the aton type
+     */
     public int getAtonType() {
         return atonType;
     }
 
+    /**
+     * Sets aton type.
+     *
+     * @param atonType the aton type
+     */
     public void setAtonType(int atonType) {
         this.atonType = atonType;
     }
@@ -132,6 +211,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return name;
     }
 
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
     public void setName(String name) {
         this.name = name;
     }
@@ -140,6 +224,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
@@ -154,6 +243,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
@@ -162,6 +256,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return dimBow;
     }
 
+    /**
+     * Sets dim bow.
+     *
+     * @param dimBow the dim bow
+     */
     public void setDimBow(int dimBow) {
         this.dimBow = dimBow;
     }
@@ -170,6 +269,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return dimStern;
     }
 
+    /**
+     * Sets dim stern.
+     *
+     * @param dimStern the dim stern
+     */
     public void setDimStern(int dimStern) {
         this.dimStern = dimStern;
     }
@@ -178,6 +282,11 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return dimPort;
     }
 
+    /**
+     * Sets dim port.
+     *
+     * @param dimPort the dim port
+     */
     public void setDimPort(int dimPort) {
         this.dimPort = dimPort;
     }
@@ -186,86 +295,191 @@ public class AisMessage21 extends AisMessage implements IPositionMessage, IDimen
         return dimStarboard;
     }
 
+    /**
+     * Sets dim starboard.
+     *
+     * @param dimStarboard the dim starboard
+     */
     public void setDimStarboard(int dimStarboard) {
         this.dimStarboard = dimStarboard;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public int getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(int posType) {
         this.posType = posType;
     }
 
+    /**
+     * Gets utc sec.
+     *
+     * @return the utc sec
+     */
     public int getUtcSec() {
         return utcSec;
     }
 
+    /**
+     * Sets utc sec.
+     *
+     * @param utcSec the utc sec
+     */
     public void setUtcSec(int utcSec) {
         this.utcSec = utcSec;
     }
 
+    /**
+     * Gets off position.
+     *
+     * @return the off position
+     */
     public int getOffPosition() {
         return offPosition;
     }
 
+    /**
+     * Sets off position.
+     *
+     * @param offPosition the off position
+     */
     public void setOffPosition(int offPosition) {
         this.offPosition = offPosition;
     }
 
+    /**
+     * Gets regional.
+     *
+     * @return the regional
+     */
     public int getRegional() {
         return regional;
     }
 
+    /**
+     * Sets regional.
+     *
+     * @param regional the regional
+     */
     public void setRegional(int regional) {
         this.regional = regional;
     }
 
+    /**
+     * Gets raim.
+     *
+     * @return the raim
+     */
     public int getRaim() {
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
+    /**
+     * Gets virtual.
+     *
+     * @return the virtual
+     */
     public int getVirtual() {
         return virtual;
     }
 
+    /**
+     * Sets virtual.
+     *
+     * @param virtual the virtual
+     */
     public void setVirtual(int virtual) {
         this.virtual = virtual;
     }
 
+    /**
+     * Gets assigned.
+     *
+     * @return the assigned
+     */
     public int getAssigned() {
         return assigned;
     }
 
+    /**
+     * Sets assigned.
+     *
+     * @param assigned the assigned
+     */
     public void setAssigned(int assigned) {
         this.assigned = assigned;
     }
 
+    /**
+     * Gets spare 1.
+     *
+     * @return the spare 1
+     */
     public int getSpare1() {
         return spare1;
     }
 
+    /**
+     * Sets spare 1.
+     *
+     * @param spare1 the spare 1
+     */
     public void setSpare1(int spare1) {
         this.spare1 = spare1;
     }
 
+    /**
+     * Gets name ext.
+     *
+     * @return the name ext
+     */
     public String getNameExt() {
         return nameExt;
     }
 
+    /**
+     * Sets name ext.
+     *
+     * @param nameExt the name ext
+     */
     public void setNameExt(String nameExt) {
         this.nameExt = nameExt;
     }
 
+    /**
+     * Gets spare 2.
+     *
+     * @return the spare 2
+     */
     public int getSpare2() {
         return spare2;
     }
 
+    /**
+     * Sets spare 2.
+     *
+     * @param spare2 the spare 2
+     */
     public void setSpare2(int spare2) {
         this.spare2 = spare2;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage24.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage24.java
@@ -21,9 +21,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 24
- * 
+ * <p>
  * Static data report as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage24 extends AisStaticCommon {
 
@@ -57,15 +56,31 @@ public class AisMessage24 extends AisStaticCommon {
      */
     int spare; // 2 bits
 
+    /**
+     * Instantiates a new Ais message 24.
+     */
     public AisMessage24() {
         super(24);
     }
 
+    /**
+     * Instantiates a new Ais message 24.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage24(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 160) {
@@ -122,34 +137,74 @@ public class AisMessage24 extends AisStaticCommon {
         return encoder;
     }
 
+    /**
+     * Gets part number.
+     *
+     * @return the part number
+     */
     public int getPartNumber() {
         return partNumber;
     }
 
+    /**
+     * Sets part number.
+     *
+     * @param partNumber the part number
+     */
     public void setPartNumber(int partNumber) {
         this.partNumber = partNumber;
     }
 
+    /**
+     * Gets vendor id.
+     *
+     * @return the vendor id
+     */
     public String getVendorId() {
         return vendorId;
     }
 
+    /**
+     * Sets vendor id.
+     *
+     * @param vendorId the vendor id
+     */
     public void setVendorId(String vendorId) {
         this.vendorId = vendorId;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public int getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(int posType) {
         this.posType = posType;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage27.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage27.java
@@ -21,9 +21,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 27
- *
+ * <p>
  * Long-range broadcast position report implemented according to ITU-R M.1371-4
- *
  */
 public class AisMessage27 extends AisMessage implements IPositionMessage {
 
@@ -71,15 +70,31 @@ public class AisMessage27 extends AisMessage implements IPositionMessage {
      */
     private int spare; // 1 bit
 
+    /**
+     * Instantiates a new Ais message 27.
+     */
     public AisMessage27() {
         super(27);
     }
 
+    /**
+     * Instantiates a new Ais message 27.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage27(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() != 96) {
@@ -114,6 +129,11 @@ public class AisMessage27 extends AisMessage implements IPositionMessage {
         return encoder;
     }
 
+    /**
+     * Gets serial version uid.
+     *
+     * @return the serial version uid
+     */
     public static long getSerialVersionUID() {
         return serialVersionUID;
     }
@@ -122,22 +142,47 @@ public class AisMessage27 extends AisMessage implements IPositionMessage {
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
 
+    /**
+     * Gets raim.
+     *
+     * @return the raim
+     */
     public int getRaim() {
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
+    /**
+     * Gets nav status.
+     *
+     * @return the nav status
+     */
     public int getNavStatus() {
         return navStatus;
     }
 
+    /**
+     * Sets nav status.
+     *
+     * @param navStatus the nav status
+     */
     public void setNavStatus(int navStatus) {
         this.navStatus = navStatus;
     }
@@ -146,38 +191,83 @@ public class AisMessage27 extends AisMessage implements IPositionMessage {
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
 
+    /**
+     * Gets sog.
+     *
+     * @return the sog
+     */
     public int getSog() {
         return sog;
     }
 
+    /**
+     * Sets sog.
+     *
+     * @param sog the sog
+     */
     public void setSog(int sog) {
         this.sog = sog;
     }
 
+    /**
+     * Gets cog.
+     *
+     * @return the cog
+     */
     public int getCog() {
         return cog;
     }
 
+    /**
+     * Sets cog.
+     *
+     * @param cog the cog
+     */
     public void setCog(int cog) {
         this.cog = cog;
     }
 
+    /**
+     * Gets gnss pos status.
+     *
+     * @return the gnss pos status
+     */
     public int getGnssPosStatus() {
         return gnssPosStatus;
     }
 
+    /**
+     * Sets gnss pos status.
+     *
+     * @param gnssPosStatus the gnss pos status
+     */
     public void setGnssPosStatus(int gnssPosStatus) {
         this.gnssPosStatus = gnssPosStatus;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage3.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage3.java
@@ -21,13 +21,12 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 3
- * 
+ * <p>
  * Special position report, response to interrogation;(Class A shipborne mobile equipment)
- * 
+ * <p>
  * This class handles the content of an AIS class A transponders general position report as defined by ITU-R M.1371-4.
- * 
+ * <p>
  * Generally the position report is handled in the super class but there are some ITDMA specific purposes of this class.
- * 
  */
 public class AisMessage3 extends AisPositionMessage {
 
@@ -38,15 +37,31 @@ public class AisMessage3 extends AisPositionMessage {
     private int numSlots; // 3 bits : ITDMA Number of Slots
     private int keep; // 1 bit : ITDMA Keep Flag
 
+    /**
+     * Instantiates a new Ais message 3.
+     */
     public AisMessage3() {
         super(3);
     }
 
+    /**
+     * Instantiates a new Ais message 3.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage3(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         super.parse(binArray);
@@ -64,26 +79,56 @@ public class AisMessage3 extends AisPositionMessage {
         return encoder;
     }
 
+    /**
+     * Gets slot increment.
+     *
+     * @return the slot increment
+     */
     public int getSlotIncrement() {
         return slotIncrement;
     }
 
+    /**
+     * Gets num slots.
+     *
+     * @return the num slots
+     */
     public int getNumSlots() {
         return numSlots;
     }
 
+    /**
+     * Gets keep.
+     *
+     * @return the keep
+     */
     public int getKeep() {
         return keep;
     }
 
+    /**
+     * Sets slot increment.
+     *
+     * @param slotIncrement the slot increment
+     */
     public void setSlotIncrement(int slotIncrement) {
         this.slotIncrement = slotIncrement;
     }
 
+    /**
+     * Sets num slots.
+     *
+     * @param numSlots the num slots
+     */
     public void setNumSlots(int numSlots) {
         this.numSlots = numSlots;
     }
 
+    /**
+     * Sets keep.
+     *
+     * @param keep the keep
+     */
     public void setKeep(int keep) {
         this.keep = keep;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage4.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage4.java
@@ -19,19 +19,28 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 4
- *
+ * <p>
  * Base station report as defined by ITU-R M.1371-4
- *
  */
 public class AisMessage4 extends UTCDateResponseMessage {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message 4.
+     */
     public AisMessage4() {
         super(4);
     }
 
+    /**
+     * Instantiates a new Ais message 4.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage4(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage5.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage5.java
@@ -25,9 +25,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 4
- * 
+ * <p>
  * Ship static and voyage related data as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage5 extends AisStaticCommon {
 
@@ -68,9 +67,8 @@ public class AisMessage5 extends AisStaticCommon {
 
     /**
      * Ship Destination: Maximum 20 characters using 6-bit ASCII;
-     * 
-     * @@@@@@@@@@@@@@@@@@@@ = not available For SAR aircraft, the use of this field may be decided by the responsible
-     *                      administration
+     *
+     * {@code @@@@@@@@@@@@@@@@@@@@} = not available For SAR aircraft, the use of this field may be decided by the responsible                      administration
      */
     String dest; // 6x20 (120) bits
 
@@ -84,15 +82,31 @@ public class AisMessage5 extends AisStaticCommon {
      */
     int spare; // 1 bit : spare
 
+    /**
+     * Instantiates a new Ais message 5.
+     */
     public AisMessage5() {
         super(5);
     }
 
+    /**
+     * Instantiates a new Ais message 5.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage5(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 424) {
@@ -139,38 +153,73 @@ public class AisMessage5 extends AisStaticCommon {
         return encoder;
     }
 
+    /**
+     * Gets version.
+     *
+     * @return the version
+     */
     public int getVersion() {
         return version;
     }
 
+    /**
+     * Sets version.
+     *
+     * @param version the version
+     */
     public void setVersion(int version) {
         this.version = version;
     }
 
+    /**
+     * Gets imo.
+     *
+     * @return the imo
+     */
     public long getImo() {
         return imo;
     }
 
+    /**
+     * Sets imo.
+     *
+     * @param imo the imo
+     */
     public void setImo(long imo) {
         this.imo = imo;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public int getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(int posType) {
         this.posType = posType;
     }
 
+    /**
+     * Gets eta.
+     *
+     * @return the eta
+     */
     public long getEta() {
         return eta;
     }
 
     /**
      * Get ETA as date object
-     * 
-     * @return date
+     *
+     * @return date eta date
      */
     public Date getEtaDate() {
         int min = (int) (eta & 0x3F);
@@ -193,38 +242,83 @@ public class AisMessage5 extends AisStaticCommon {
         return cal.getTime();
     }
 
+    /**
+     * Sets eta.
+     *
+     * @param eta the eta
+     */
     public void setEta(long eta) {
         this.eta = eta;
     }
 
+    /**
+     * Gets draught.
+     *
+     * @return the draught
+     */
     public int getDraught() {
         return draught;
     }
 
+    /**
+     * Sets draught.
+     *
+     * @param draught the draught
+     */
     public void setDraught(int draught) {
         this.draught = draught;
     }
 
+    /**
+     * Gets dest.
+     *
+     * @return the dest
+     */
     public String getDest() {
         return dest;
     }
 
+    /**
+     * Sets dest.
+     *
+     * @param dest the dest
+     */
     public void setDest(String dest) {
         this.dest = dest;
     }
 
+    /**
+     * Gets dte.
+     *
+     * @return the dte
+     */
     public int getDte() {
         return dte;
     }
 
+    /**
+     * Sets dte.
+     *
+     * @param dte the dte
+     */
     public void setDte(int dte) {
         this.dte = dte;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage6.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage6.java
@@ -21,9 +21,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 6
- * 
+ * <p>
  * Addressed binary message as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage6 extends AisBinaryMessage {
 
@@ -34,15 +33,31 @@ public class AisMessage6 extends AisBinaryMessage {
     private long destination; // 30 bits: Destination MMSI
     private int retransmit; // 1 bit: Retransmit flag
 
+    /**
+     * Instantiates a new Ais message 6.
+     */
     public AisMessage6() {
         super(6);
     }
 
+    /**
+     * Instantiates a new Ais message 6.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage6(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray sixbit = vdm.getBinArray();
         if (sixbit.getLength() < 88 || sixbit.getLength() > 1008) {
@@ -71,26 +86,56 @@ public class AisMessage6 extends AisBinaryMessage {
         return encoder;
     }
 
+    /**
+     * Gets seq num.
+     *
+     * @return the seq num
+     */
     public int getSeqNum() {
         return seqNum;
     }
 
+    /**
+     * Sets seq num.
+     *
+     * @param seqNum the seq num
+     */
     public void setSeqNum(int seqNum) {
         this.seqNum = seqNum;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public long getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(long destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets retransmit.
+     *
+     * @return the retransmit
+     */
     public int getRetransmit() {
         return retransmit;
     }
 
+    /**
+     * Sets retransmit.
+     *
+     * @param retransmit the retransmit
+     */
     public void setRetransmit(int retransmit) {
         this.retransmit = retransmit;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage7.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage7.java
@@ -21,9 +21,8 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 7
- * 
+ * <p>
  * Binary acknowledge message as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage7 extends AisMessage {
 
@@ -47,19 +46,40 @@ public class AisMessage7 extends AisMessage {
     private int seq4; // 2 bits: Sequence number of message to be acknowledged;
                       // 0-3
 
+    /**
+     * Instantiates a new Ais message 7.
+     */
     public AisMessage7() {
         super(7);
     }
 
+    /**
+     * Instantiates a new Ais message 7.
+     *
+     * @param num the num
+     */
     public AisMessage7(int num) {
         super(num);
     }
 
+    /**
+     * Instantiates a new Ais message 7.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage7(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray sixbit = vdm.getBinArray();
         if (sixbit.getLength() < 72 || sixbit.getLength() > 168) {
@@ -101,74 +121,164 @@ public class AisMessage7 extends AisMessage {
         return encoder;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets dest 1.
+     *
+     * @return the dest 1
+     */
     public long getDest1() {
         return dest1;
     }
 
+    /**
+     * Sets dest 1.
+     *
+     * @param dest1 the dest 1
+     */
     public void setDest1(long dest1) {
         this.dest1 = dest1;
     }
 
+    /**
+     * Gets seq 1.
+     *
+     * @return the seq 1
+     */
     public int getSeq1() {
         return seq1;
     }
 
+    /**
+     * Sets seq 1.
+     *
+     * @param seq1 the seq 1
+     */
     public void setSeq1(int seq1) {
         this.seq1 = seq1;
     }
 
+    /**
+     * Gets dest 2.
+     *
+     * @return the dest 2
+     */
     public long getDest2() {
         return dest2;
     }
 
+    /**
+     * Sets dest 2.
+     *
+     * @param dest2 the dest 2
+     */
     public void setDest2(long dest2) {
         this.dest2 = dest2;
     }
 
+    /**
+     * Gets seq 2.
+     *
+     * @return the seq 2
+     */
     public int getSeq2() {
         return seq2;
     }
 
+    /**
+     * Sets seq 2.
+     *
+     * @param seq2 the seq 2
+     */
     public void setSeq2(int seq2) {
         this.seq2 = seq2;
     }
 
+    /**
+     * Gets dest 3.
+     *
+     * @return the dest 3
+     */
     public long getDest3() {
         return dest3;
     }
 
+    /**
+     * Sets dest 3.
+     *
+     * @param dest3 the dest 3
+     */
     public void setDest3(long dest3) {
         this.dest3 = dest3;
     }
 
+    /**
+     * Gets seq 3.
+     *
+     * @return the seq 3
+     */
     public int getSeq3() {
         return seq3;
     }
 
+    /**
+     * Sets seq 3.
+     *
+     * @param seq3 the seq 3
+     */
     public void setSeq3(int seq3) {
         this.seq3 = seq3;
     }
 
+    /**
+     * Gets dest 4.
+     *
+     * @return the dest 4
+     */
     public long getDest4() {
         return dest4;
     }
 
+    /**
+     * Sets dest 4.
+     *
+     * @param dest4 the dest 4
+     */
     public void setDest4(long dest4) {
         this.dest4 = dest4;
     }
 
+    /**
+     * Gets seq 4.
+     *
+     * @return the seq 4
+     */
     public int getSeq4() {
         return seq4;
     }
 
+    /**
+     * Sets seq 4.
+     *
+     * @param seq4 the seq 4
+     */
     public void setSeq4(int seq4) {
         this.seq4 = seq4;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage8.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage8.java
@@ -21,24 +21,39 @@ import dk.dma.ais.sentence.Vdm;
 
 /**
  * AIS message 8
- * 
+ * <p>
  * Binary broadcast message as defined by ITU-R M.1371-4
- * 
  */
 public class AisMessage8 extends AisBinaryMessage {
 
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message 8.
+     */
     public AisMessage8() {
         super(8);
     }
 
+    /**
+     * Instantiates a new Ais message 8.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage8(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() < 56 || binArray.getLength() > 1008) {

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage9.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage9.java
@@ -51,7 +51,7 @@ public class AisMessage9 extends AisMessage implements IPositionMessage {
 
     /**
      * AisPosition Accuracy: The position accuracy (PA) flag should be
-     * determined in accordance with Table 47 1 = high ( =< 10 m) 0 = low (>10
+     * determined in accordance with Table 47 1 = high ( =&lt; 10 m) 0 = low (&gt;10
      * m) 0 = default
      */
     private int posAcc; // 1 bit
@@ -142,10 +142,20 @@ public class AisMessage9 extends AisMessage implements IPositionMessage {
      */
     private int subMessage; // 14 bits
 
+    /**
+     * Instantiates a new Ais message 9.
+     */
     public AisMessage9() {
         super(9);
     }
 
+    /**
+     * Instantiates a new Ais message 9.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisMessage9(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse(vdm.getBinArray());
@@ -241,18 +251,38 @@ public class AisMessage9 extends AisMessage implements IPositionMessage {
         return builder.toString();
     }
 
+    /**
+     * Gets altitude.
+     *
+     * @return the altitude
+     */
     public int getAltitude() {
         return altitude;
     }
 
+    /**
+     * Sets altitude.
+     *
+     * @param altitude the altitude
+     */
     public void setAltitude(int altitude) {
         this.altitude = altitude;
     }
 
+    /**
+     * Gets sog.
+     *
+     * @return the sog
+     */
     public int getSog() {
         return sog;
     }
 
+    /**
+     * Sets sog.
+     *
+     * @param sog the sog
+     */
     public void setSog(int sog) {
         this.sog = sog;
     }
@@ -261,6 +291,11 @@ public class AisMessage9 extends AisMessage implements IPositionMessage {
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
@@ -269,94 +304,209 @@ public class AisMessage9 extends AisMessage implements IPositionMessage {
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
 
+    /**
+     * Gets cog.
+     *
+     * @return the cog
+     */
     public int getCog() {
         return cog;
     }
 
+    /**
+     * Sets cog.
+     *
+     * @param cog the cog
+     */
     public void setCog(int cog) {
         this.cog = cog;
     }
 
+    /**
+     * Gets utc sec.
+     *
+     * @return the utc sec
+     */
     public int getUtcSec() {
         return utcSec;
     }
 
+    /**
+     * Sets utc sec.
+     *
+     * @param utcSec the utc sec
+     */
     public void setUtcSec(int utcSec) {
         this.utcSec = utcSec;
     }
 
+    /**
+     * Gets regional reserved.
+     *
+     * @return the regional reserved
+     */
     public int getRegionalReserved() {
         return regionalReserved;
     }
 
+    /**
+     * Sets regional reserved.
+     *
+     * @param regionalReserved the regional reserved
+     */
     public void setRegionalReserved(int regionalReserved) {
         this.regionalReserved = regionalReserved;
     }
 
+    /**
+     * Gets dte.
+     *
+     * @return the dte
+     */
     public int getDte() {
         return dte;
     }
 
+    /**
+     * Sets dte.
+     *
+     * @param dte the dte
+     */
     public void setDte(int dte) {
         this.dte = dte;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets assigned.
+     *
+     * @return the assigned
+     */
     public int getAssigned() {
         return assigned;
     }
 
+    /**
+     * Sets assigned.
+     *
+     * @param assigned the assigned
+     */
     public void setAssigned(int assigned) {
         this.assigned = assigned;
     }
 
+    /**
+     * Gets raim.
+     *
+     * @return the raim
+     */
     public int getRaim() {
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
+    /**
+     * Gets comm state selector flag.
+     *
+     * @return the comm state selector flag
+     */
     public int getCommStateSelectorFlag() {
         return commStateSelectorFlag;
     }
 
+    /**
+     * Sets comm state selector flag.
+     *
+     * @param commStateSelectorFlag the comm state selector flag
+     */
     public void setCommStateSelectorFlag(int commStateSelectorFlag) {
         this.commStateSelectorFlag = commStateSelectorFlag;
     }
 
+    /**
+     * Gets sync state.
+     *
+     * @return the sync state
+     */
     public int getSyncState() {
         return syncState;
     }
 
+    /**
+     * Sets sync state.
+     *
+     * @param syncState the sync state
+     */
     public void setSyncState(int syncState) {
         this.syncState = syncState;
     }
 
+    /**
+     * Gets slot timeout.
+     *
+     * @return the slot timeout
+     */
     public int getSlotTimeout() {
         return slotTimeout;
     }
 
+    /**
+     * Sets slot timeout.
+     *
+     * @param slotTimeout the slot timeout
+     */
     public void setSlotTimeout(int slotTimeout) {
         this.slotTimeout = slotTimeout;
     }
 
+    /**
+     * Gets sub message.
+     *
+     * @return the sub message
+     */
     public int getSubMessage() {
         return subMessage;
     }
 
+    /**
+     * Sets sub message.
+     *
+     * @param subMessage the sub message
+     */
     public void setSubMessage(int subMessage) {
         this.subMessage = subMessage;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessageException.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessageException.java
@@ -21,8 +21,16 @@ public class AisMessageException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais message exception.
+     */
     public AisMessageException() {}
 
+    /**
+     * Instantiates a new Ais message exception.
+     *
+     * @param msg the msg
+     */
     public AisMessageException(String msg) {
         super(msg);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisPosition.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisPosition.java
@@ -20,9 +20,8 @@ import java.io.Serializable;
 
 /**
  * AIS position class
- * 
+ * <p>
  * Convert raw unsigned AIS position to signed 1/10000 degree position and provide helper methods for other formats
- * 
  */
 public class AisPosition implements Serializable{
 
@@ -32,13 +31,16 @@ public class AisPosition implements Serializable{
     private long rawLongitude;
     private double resolution = 10000.0;
 
+    /**
+     * Instantiates a new Ais position.
+     */
     public AisPosition() {}
 
     /**
      * Constructor given raw latitude and raw longitude as received in AIS message
-     * 
-     * @param rawLatitude
-     * @param rawLongitude
+     *
+     * @param rawLatitude  the raw latitude
+     * @param rawLongitude the raw longitude
      */
     public AisPosition(long rawLatitude, long rawLongitude) {
         this.rawLatitude = rawLatitude;
@@ -47,8 +49,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Constructor given a GeoLocation
-     * 
-     * @param location
+     *
+     * @param location the location
      */
     public AisPosition(Position location) {
         setLatitude(Math.round(location.getLatitude() * resolution * 60.0));
@@ -66,8 +68,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Get position as {@link Position} object
-     * 
-     * @return
+     *
+     * @return geo location
      */
     public Position getGeoLocation() {
         double lat = getLatitude() / resolution / 60.0;
@@ -80,8 +82,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Get signed latitude
-     * 
-     * @return
+     *
+     * @return latitude
      */
     public long getLatitude() {
         long latitude;
@@ -94,18 +96,28 @@ public class AisPosition implements Serializable{
         return latitude;
     }
 
+    /**
+     * Gets latitude double.
+     *
+     * @return the latitude double
+     */
     public double getLatitudeDouble() {
         return getLatitude() / resolution / 60.0;
     }
 
+    /**
+     * Gets longitude double.
+     *
+     * @return the longitude double
+     */
     public double getLongitudeDouble() {
         return getLongitude() / resolution / 60.0;
     }
 
     /**
      * Get signed longitude
-     * 
-     * @return
+     *
+     * @return longitude
      */
     public long getLongitude() {
         long longitude;
@@ -118,10 +130,20 @@ public class AisPosition implements Serializable{
         return longitude;
     }
 
+    /**
+     * Gets raw latitude.
+     *
+     * @return the raw latitude
+     */
     public long getRawLatitude() {
         return rawLatitude;
     }
 
+    /**
+     * Gets raw longitude.
+     *
+     * @return the raw longitude
+     */
     public long getRawLongitude() {
         return rawLongitude;
     }
@@ -158,6 +180,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Set signed latitude
+     *
+     * @param latitude the latitude
      */
     public void setLatitude(long latitude) {
         if (latitude < 0) {
@@ -169,6 +193,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Set signed longitude
+     *
+     * @param longitude the longitude
      */
     public void setLongitude(long longitude) {
         if (longitude < 0) {
@@ -180,8 +206,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Set the raw latitude as received from AIS
-     * 
-     * @param rawLatitude
+     *
+     * @param rawLatitude the raw latitude
      */
     public void setRawLatitude(long rawLatitude) {
         this.rawLatitude = rawLatitude;
@@ -189,8 +215,8 @@ public class AisPosition implements Serializable{
 
     /**
      * Set the raw longitude as received from AIS
-     * 
-     * @param rawLongitude
+     *
+     * @param rawLongitude the raw longitude
      */
     public void setRawLongitude(long rawLongitude) {
         this.rawLongitude = rawLongitude;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisPositionMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisPositionMessage.java
@@ -22,15 +22,14 @@ import dk.dma.enav.model.geometry.Position;
 
 /**
  * AIS position message
- *
+ * <p>
  * An AIS position message is defined by ITU-R M.1371-4 in annex 8 - AIS messages section 3.1
- *
+ * <p>
  * This is a generalization for message types 1-3 and possibly more in the future.
- *
+ * <p>
  * Type 1: Scheduled position report (Class A shipborne mobile equipment) Type 2: Assigned scheduled position report
  * (Class A shipborne mobile equipment) Type 3: Special position report, response to interrogation;(Class A shipborne
  * mobile equipment)
- *
  */
 public abstract class AisPositionMessage extends AisMessage implements IVesselPositionMessage {
 
@@ -53,10 +52,10 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
      * up to 708 degrees per min or higher Values between 0 and 708 degrees per min coded by ROTais = 4.733
      * SQRT(ROTsensor) degrees per min where ROTsensor is the Rate of Turn as input by an external Rate of Turn
      * Indicator (TI). ROTais is rounded to the nearest integer value.
-     *
+     * <p>
      * +127 = turning right at more than 5 degrees per 30 s (No TI available) -127 = turning left at more than 5 degrees
      * per 30 s (No TI available) -128 (80 hex) indicates no turn information available (default).
-     *
+     * <p>
      * ROT data should not be derived from COG information.
      */
     protected int rot; // 8 bits :
@@ -69,7 +68,7 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
 
     /**
      * AisPosition Accuracy: The position accuracy (PA) flag should be determined in accordance with Table 47 1 = high (
-     * =< 10 m) 0 = low (>10 m) 0 = default
+     * =&lt; 10 m) 0 = low (&gt;10 m) 0 = default
      */
     protected int posAcc; // 1 bit
 
@@ -100,14 +99,14 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
     /**
      * Special manoeuvre indicator: 0 = not available = default 1 = not engaged in special manoeuvre 2 = engaged in
      * special manoeuvre (i.e.: regional passing arrangement on Inland Waterway)
-     *
+     * <p>
      * NOTE: This field is added in ITU-R M1371-4
      */
     protected int specialManIndicator; // 2 bits
 
     /**
      * Not used. Should be set to zero. Reserved for future use.
-     *
+     * <p>
      * NOTE: In ITU-R M1371-4 this field is 3 bits compared to 1 previously
      */
     protected int spare; // 3 bits
@@ -121,17 +120,27 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
     /**
      * SOTDMA/ITDMA sync state: sync state is part of the defined communication state (19) bits. The sync state is the
      * first 2 bits of the 19 bits in the communication state of the message.
-     *
+     * <p>
      * 0 UTC direct (see 3.1.1.1) 1 UTC indirect (see 3.1.1.2) 2 Station is synchronized to a base station (base direct)
      * 3 Station is synchronized to another station based on the highest number of received stations or to another
      * mobile station, which is directly synchronized to a base station
      */
     protected int syncState; // 2 bits
 
+    /**
+     * Instantiates a new Ais position message.
+     *
+     * @param msgId the msg id
+     */
     public AisPositionMessage(int msgId) {
         super(msgId);
     }
 
+    /**
+     * Instantiates a new Ais position message.
+     *
+     * @param vdm the vdm
+     */
     public AisPositionMessage(Vdm vdm) {
         super(vdm);
     }
@@ -219,18 +228,38 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return builder.toString();
     }
 
+    /**
+     * Gets nav status.
+     *
+     * @return the nav status
+     */
     public int getNavStatus() {
         return navStatus;
     }
 
+    /**
+     * Sets nav status.
+     *
+     * @param navStatus the nav status
+     */
     public void setNavStatus(int navStatus) {
         this.navStatus = navStatus;
     }
 
+    /**
+     * Gets rot.
+     *
+     * @return the rot
+     */
     public int getRot() {
         return rot;
     }
 
+    /**
+     * Gets sensor rot.
+     *
+     * @return the sensor rot
+     */
     public Float getSensorRot() {
         if (rot == 128) {
             return null;
@@ -243,6 +272,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return sensorRot;
     }
 
+    /**
+     * Sets rot.
+     *
+     * @param rot the rot
+     */
     public void setRot(int rot) {
         this.rot = rot;
     }
@@ -251,6 +285,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return sog;
     }
 
+    /**
+     * Sets sog.
+     *
+     * @param sog the sog
+     */
     public void setSog(int sog) {
         this.sog = sog;
     }
@@ -259,6 +298,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
@@ -273,6 +317,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
@@ -281,6 +330,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return cog;
     }
 
+    /**
+     * Sets cog.
+     *
+     * @param cog the cog
+     */
     public void setCog(int cog) {
         this.cog = cog;
     }
@@ -289,6 +343,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return trueHeading;
     }
 
+    /**
+     * Sets true heading.
+     *
+     * @param trueHeading the true heading
+     */
     public void setTrueHeading(int trueHeading) {
         this.trueHeading = trueHeading;
     }
@@ -297,11 +356,18 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return utcSec;
     }
 
+    /**
+     * Sets utc sec.
+     *
+     * @param utcSec the utc sec
+     */
     public void setUtcSec(int utcSec) {
         this.utcSec = utcSec;
     }
 
     /**
+     * Gets special man indicator.
+     *
      * @return the specialManIndicator
      */
     public int getSpecialManIndicator() {
@@ -309,17 +375,28 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
     }
 
     /**
-     * @param specialManIndicator
-     *            the specialManIndicator to set
+     * Sets special man indicator.
+     *
+     * @param specialManIndicator the specialManIndicator to set
      */
     public void setSpecialManIndicator(int specialManIndicator) {
         this.specialManIndicator = specialManIndicator;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
@@ -328,14 +405,29 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
+    /**
+     * Gets sync state.
+     *
+     * @return the sync state
+     */
     public int getSyncState() {
         return syncState;
     }
 
+    /**
+     * Sets sync state.
+     *
+     * @param syncState the sync state
+     */
     public void setSyncState(int syncState) {
         this.syncState = syncState;
     }
@@ -357,6 +449,11 @@ public abstract class AisPositionMessage extends AisMessage implements IVesselPo
         return trueHeading < 360;
     }
 
+    /**
+     * Is rot valid boolean.
+     *
+     * @return the boolean
+     */
     public boolean isRotValid() {
         return rot > -128;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisStaticCommon.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisStaticCommon.java
@@ -31,9 +31,9 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
 
     /**
      * Ship name: Maximum 20 characters 6 bit ASCII, as defined in Table 44
-     * 
-     * @@@@@@@@@@@@@@@@@@@@ = not available = default. For SAR aircraft, it should be set to "SAR AIRCRAFT NNNNNNN"
-     *                      where NNNNNNN equals the aircraft registration number
+     *
+     * {@literal @@@@@@@@@@@@@@@@@@@@ } = not available = default. For SAR aircraft, it should be set to "SAR AIRCRAFT NNNNNNN"
+     * where NNNNNNN equals the aircraft registration number
      */
     protected String name; // 20x6 (120) bits
 
@@ -46,7 +46,7 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
     /**
      * GPS Ant. Distance from bow (A): Reference point for reported position. Also indicates the dimension of ship (m)
      * (see Fig. 42 and § 3.3.3)
-     * 
+     * <p>
      * NOTE: When GPS position is not available, but the ships dimensions is available, then this field should be 0
      */
     protected int dimBow; // 9 bits
@@ -54,7 +54,7 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
     /**
      * GPS Ant. Distance from stern (B) Reference point for reported position. Also indicates the dimension of ship (m)
      * (see Fig. 42 and § 3.3.3)
-     * 
+     * <p>
      * NOTE: When GPS position is not available, but the ships dimensions is available, then this field should be
      * representing the length of the ship
      */
@@ -63,7 +63,7 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
     /**
      * GPS Ant. Distance from port (C) Reference point for reported position. Also indicates the dimension of ship (m)
      * (see Fig. 42 and § 3.3.3)
-     * 
+     * <p>
      * NOTE: When GPS position is not available, but the ships dimensions is available, then this field should be 0
      */
     protected int dimPort; // 6 bits
@@ -71,24 +71,44 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
     /**
      * GPS Ant. Distance from starboard (D): Reference point for reported position. Also indicates the dimension of ship
      * (m) (see Fig. 42 and § 3.3.3)
-     * 
+     * <p>
      * NOTE: When GPS position is not available, but the ships dimensions is available, then this field should be
      * representing the with of the ship
      */
     protected int dimStarboard; // 6 bits
 
+    /**
+     * Instantiates a new Ais static common.
+     *
+     * @param msgId the msg id
+     */
     public AisStaticCommon(int msgId) {
         super(msgId);
     }
 
+    /**
+     * Instantiates a new Ais static common.
+     *
+     * @param vdm the vdm
+     */
     public AisStaticCommon(Vdm vdm) {
         super(vdm);
     }
 
+    /**
+     * Gets callsign.
+     *
+     * @return the callsign
+     */
     public String getCallsign() {
         return callsign;
     }
 
+    /**
+     * Sets callsign.
+     *
+     * @param callsign the callsign
+     */
     public void setCallsign(String callsign) {
         this.callsign = callsign;
     }
@@ -97,14 +117,29 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
         return name;
     }
 
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Gets ship type.
+     *
+     * @return the ship type
+     */
     public int getShipType() {
         return shipType;
     }
 
+    /**
+     * Sets ship type.
+     *
+     * @param shipType the ship type
+     */
     public void setShipType(int shipType) {
         this.shipType = shipType;
     }
@@ -113,6 +148,11 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
         return dimBow;
     }
 
+    /**
+     * Sets dim bow.
+     *
+     * @param dimBow the dim bow
+     */
     public void setDimBow(int dimBow) {
         this.dimBow = dimBow;
     }
@@ -121,6 +161,11 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
         return dimStern;
     }
 
+    /**
+     * Sets dim stern.
+     *
+     * @param dimStern the dim stern
+     */
     public void setDimStern(int dimStern) {
         this.dimStern = dimStern;
     }
@@ -129,6 +174,11 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
         return dimPort;
     }
 
+    /**
+     * Sets dim port.
+     *
+     * @param dimPort the dim port
+     */
     public void setDimPort(int dimPort) {
         this.dimPort = dimPort;
     }
@@ -137,6 +187,11 @@ public abstract class AisStaticCommon extends AisMessage implements IDimensionMe
         return dimStarboard;
     }
 
+    /**
+     * Sets dim starboard.
+     *
+     * @param dimStarboard the dim starboard
+     */
     public void setDimStarboard(int dimStarboard) {
         this.dimStarboard = dimStarboard;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisTargetType.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisTargetType.java
@@ -21,18 +21,28 @@ package dk.dma.ais.message;
  */
 public enum AisTargetType {
 
-    /** A Class A target type. */
+    /**
+     * A Class A target type.
+     */
     A,
 
-    /** A Class B target type. */
+    /**
+     * A Class B target type.
+     */
     B,
 
-    /** A Basestation. */
+    /**
+     * A Basestation.
+     */
     BS,
 
-    /** Aid To Navigation target. */
+    /**
+     * Aid To Navigation target.
+     */
     ATON,
 
-    /** A search and rescue target. */
+    /**
+     * A search and rescue target.
+     */
     SART;
 }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisUnsupportedMessageType.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisUnsupportedMessageType.java
@@ -26,6 +26,13 @@ public class AisUnsupportedMessageType extends AisMessage {
     /** serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Ais unsupported message type.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public AisUnsupportedMessageType(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse(vdm.getBinArray());

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/IDimensionMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/IDimensionMessage.java
@@ -20,12 +20,32 @@ package dk.dma.ais.message;
  */
 public interface IDimensionMessage {
 
+    /**
+     * Gets dim bow.
+     *
+     * @return the dim bow
+     */
     int getDimBow();
 
+    /**
+     * Gets dim stern.
+     *
+     * @return the dim stern
+     */
     int getDimStern();
 
+    /**
+     * Gets dim port.
+     *
+     * @return the dim port
+     */
     int getDimPort();
 
+    /**
+     * Gets dim starboard.
+     *
+     * @return the dim starboard
+     */
     int getDimStarboard();
 
 }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/INameMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/INameMessage.java
@@ -20,6 +20,11 @@ package dk.dma.ais.message;
  */
 public interface INameMessage {
 
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
     String getName();
 
 }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/IPositionMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/IPositionMessage.java
@@ -22,15 +22,15 @@ public interface IPositionMessage {
 
     /**
      * Get position
-     * 
-     * @return
+     *
+     * @return pos
      */
     AisPosition getPos();
 
     /**
      * Position accuracy
-     * 
-     * @return
+     *
+     * @return pos acc
      */
     int getPosAcc();
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/IVesselPositionMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/IVesselPositionMessage.java
@@ -23,69 +23,71 @@ public interface IVesselPositionMessage extends IPositionMessage {
 
     /**
      * Speed over ground
-     * 
-     * @return
+     *
+     * @return sog
      */
     int getSog();
 
     /**
      * Course over ground
+     *
+     * @return the cog
      */
     int getCog();
 
     /**
      * True heading
-     * 
-     * @return
+     *
+     * @return true heading
      */
     int getTrueHeading();
 
     /**
      * Returns a valid position if this message has a valid position, otherwise null.
-     * 
+     *
      * @return a valid position if this message has a valid position, otherwise null
      */
     Position getValidPosition();
 
     /**
      * UTC sec
-     * 
-     * @return
+     *
+     * @return utc sec
      */
     int getUtcSec();
 
     /**
      * Determine if position is valid
-     * 
-     * @return
+     *
+     * @return boolean
      */
     boolean isPositionValid();
 
     /**
      * Course over ground valid
-     * 
-     * @return
+     *
+     * @return boolean
      */
     boolean isCogValid();
 
     /**
      * Speed over ground valid
-     * 
-     * @return
+     *
+     * @return boolean
      */
     boolean isSogValid();
 
     /**
      * Heading valid
-     * 
-     * @return
+     *
+     * @return boolean
      */
     boolean isHeadingValid();
 
     /**
      * Get raim
-     * 
-     * @return
+     *
+     * @return raim
      */
     int getRaim();
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/NavigationalStatus.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/NavigationalStatus.java
@@ -17,35 +17,71 @@ package dk.dma.ais.message;
 /**
  * Navigational status as used in AisMessages of type 1, 2, and 3 and
  * defined in Rec. ITU-R M.1371-4, table 45.
- *
- *
- *     0 = under way using engine,
- *     1 = at anchor,
- *     2 = not under command,
- *     3 = restricted manoeuvrability
- *     4 = constrained by her draught,
- *     5 = moore
- *     6 = aground
- *     7 = engaged in fishing
- *     8 = under way sailing
- *     9 = reserved for future amendment of navigational status for ships carrying DG, HS, or MP, or IMO hazard or pollutant category C, high speed craft (HSC),
- *     10 = reserved for future amendment of navigational status for ships carrying dangerous goods (DG), harmful substances (HS) or marine pollutants (MP), or IMO hazard or pollutant category A, wing in grand (WIG);
- *     11-13 = reserved for future use,
- *     14 = AIS-SART (active),
- *     15 = not defined = default (also used by AIS-SART under test)
+ * <pre>{@code
+ * <p>
+ * <p>
+ * }
+ * </pre>
+ * 0 = under way using engine,
+ * 1 = at anchor,
+ * 2 = not under command,
+ * 3 = restricted manoeuvrability
+ * 4 = constrained by her draught,
+ * 5 = moore
+ * 6 = aground
+ * 7 = engaged in fishing
+ * 8 = under way sailing
+ * 9 = reserved for future amendment of navigational status for ships carrying DG, HS, or MP, or IMO hazard or pollutant category C, high speed craft (HSC),
+ * 10 = reserved for future amendment of navigational status for ships carrying dangerous goods (DG), harmful substances (HS) or marine pollutants (MP), or IMO hazard or pollutant category A, wing in grand (WIG);
+ * 11-13 = reserved for future use,
+ * 14 = AIS-SART (active),
+ * 15 = not defined = default (also used by AIS-SART under test)
  */
 public enum NavigationalStatus {
 
+    /**
+     * Under way using engine navigational status.
+     */
     UNDER_WAY_USING_ENGINE(0),
+    /**
+     * At anchor navigational status.
+     */
     AT_ANCHOR(1),
+    /**
+     * Not under command navigational status.
+     */
     NOT_UNDER_COMMAND(2),
+    /**
+     * Restricted manoeuvrability navigational status.
+     */
     RESTRICTED_MANOEUVRABILITY(3),
+    /**
+     * Constrained by her draught navigational status.
+     */
     CONSTRAINED_BY_HER_DRAUGHT(4),
+    /**
+     * Moored navigational status.
+     */
     MOORED(5),
+    /**
+     * Aground navigational status.
+     */
     AGROUND(6),
+    /**
+     * Engaged in fishing navigational status.
+     */
     ENGAGED_IN_FISHING(7),
+    /**
+     * Under way navigational status.
+     */
     UNDER_WAY(8),
+    /**
+     * Undefined navigational status.
+     */
     UNDEFINED(15),
+    /**
+     * The Ais sart.
+     */
     AIS_SART(14)
     {
         public String prettyStatus() {
@@ -59,10 +95,21 @@ public enum NavigationalStatus {
         this.code = code;
     }
 
+    /**
+     * Gets code.
+     *
+     * @return the code
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Get navigational status.
+     *
+     * @param intNavigationalStatus the int navigational status
+     * @return the navigational status
+     */
     public static NavigationalStatus get(int intNavigationalStatus) {
         for (NavigationalStatus navigationalStatus : NavigationalStatus.values()) {
             if (intNavigationalStatus == navigationalStatus.code) {
@@ -72,6 +119,11 @@ public enum NavigationalStatus {
         return UNDEFINED;
     }
 
+    /**
+     * Pretty status string.
+     *
+     * @return the string
+     */
     public String prettyStatus() {
         String navStat = name().replace("_", " ");
         return navStat.substring(0, 1) + navStat.substring(1).toLowerCase();

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/ShipTypeCargo.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/ShipTypeCargo.java
@@ -16,15 +16,134 @@ package dk.dma.ais.message;
 
 import java.io.Serializable;
 
+/**
+ * The type Ship type cargo.
+ */
 public class ShipTypeCargo implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The enum Ship type.
+     */
     public enum ShipType {
-        UNDEFINED, WIG, PILOT, SAR, TUG, PORT_TENDER, ANTI_POLLUTION, LAW_ENFORCEMENT, MEDICAL, FISHING, TOWING, TOWING_LONG_WIDE, DREDGING, DIVING, MILITARY, SAILING, PLEASURE, HSC, PASSENGER, CARGO, TANKER, SHIPS_ACCORDING_TO_RR, UNKNOWN
+        /**
+         * Undefined ship type.
+         */
+        UNDEFINED,
+        /**
+         * Wig ship type.
+         */
+        WIG,
+        /**
+         * Pilot ship type.
+         */
+        PILOT,
+        /**
+         * Sar ship type.
+         */
+        SAR,
+        /**
+         * Tug ship type.
+         */
+        TUG,
+        /**
+         * Port tender ship type.
+         */
+        PORT_TENDER,
+        /**
+         * Anti pollution ship type.
+         */
+        ANTI_POLLUTION,
+        /**
+         * Law enforcement ship type.
+         */
+        LAW_ENFORCEMENT,
+        /**
+         * Medical ship type.
+         */
+        MEDICAL,
+        /**
+         * Fishing ship type.
+         */
+        FISHING,
+        /**
+         * Towing ship type.
+         */
+        TOWING,
+        /**
+         * Towing long wide ship type.
+         */
+        TOWING_LONG_WIDE,
+        /**
+         * Dredging ship type.
+         */
+        DREDGING,
+        /**
+         * Diving ship type.
+         */
+        DIVING,
+        /**
+         * Military ship type.
+         */
+        MILITARY,
+        /**
+         * Sailing ship type.
+         */
+        SAILING,
+        /**
+         * Pleasure ship type.
+         */
+        PLEASURE,
+        /**
+         * Hsc ship type.
+         */
+        HSC,
+        /**
+         * Passenger ship type.
+         */
+        PASSENGER,
+        /**
+         * Cargo ship type.
+         */
+        CARGO,
+        /**
+         * Tanker ship type.
+         */
+        TANKER,
+        /**
+         * Ships according to rr ship type.
+         */
+        SHIPS_ACCORDING_TO_RR,
+        /**
+         * Unknown ship type.
+         */
+        UNKNOWN
     }
 
+    /**
+     * The enum Cargo type.
+     */
     public enum CargoType {
-        UNDEFINED, A, B, C, D
+        /**
+         * Undefined cargo type.
+         */
+        UNDEFINED,
+        /**
+         * A cargo type.
+         */
+        A,
+        /**
+         * B cargo type.
+         */
+        B,
+        /**
+         * C cargo type.
+         */
+        C,
+        /**
+         * D cargo type.
+         */
+        D
     }
 
     private final ShipType shipType;
@@ -33,6 +152,11 @@ public class ShipTypeCargo implements Serializable {
     /** The original coded value as per ITU 1371.5 table 53 */
     private final int code;
 
+    /**
+     * Instantiates a new Ship type cargo.
+     *
+     * @param intShipType the int ship type
+     */
     public ShipTypeCargo(int intShipType) {
         this.code = intShipType;
 
@@ -153,18 +277,38 @@ public class ShipTypeCargo implements Serializable {
         this.cargoType= cargoTypeTmp;
     }
 
+    /**
+     * Gets ship type.
+     *
+     * @return the ship type
+     */
     public ShipType getShipType() {
         return this.shipType;
     }
 
+    /**
+     * Gets ship cargo.
+     *
+     * @return the ship cargo
+     */
     public CargoType getShipCargo() {
         return this.cargoType;
     }
 
+    /**
+     * Gets code.
+     *
+     * @return the code
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Pretty type string.
+     *
+     * @return the string
+     */
     public String prettyType() {
         ShipTypeCargo shipTypeCargo = this;
         String result;
@@ -183,6 +327,11 @@ public class ShipTypeCargo implements Serializable {
         return result;
     }
 
+    /**
+     * Pretty cargo string.
+     *
+     * @return the string
+     */
     public String prettyCargo() {
         CargoType shipTypeCargo = this.getShipCargo();
         String result;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/ShipTypeColor.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/ShipTypeColor.java
@@ -21,16 +21,42 @@ import java.util.HashMap;
 import static java.util.Objects.requireNonNull;
 
 /**
+ * The enum Ship type color.
+ *
  * @author Kasper Nielsen
  */
 public enum ShipTypeColor {
+    /**
+     * Blue ship type color.
+     */
     BLUE(ShipType.PASSENGER),
+    /**
+     * Grey ship type color.
+     */
     GREY(ShipType.UNDEFINED, ShipType.UNKNOWN),
+    /**
+     * Green ship type color.
+     */
     GREEN(ShipType.CARGO),
+    /**
+     * Orange ship type color.
+     */
     ORANGE(ShipType.FISHING),
+    /**
+     * Purple ship type color.
+     */
     PURPLE(ShipType.SAILING, ShipType.PLEASURE),
+    /**
+     * Red ship type color.
+     */
     RED(ShipType.TANKER),
+    /**
+     * Turquoise ship type color.
+     */
     TURQUOISE,
+    /**
+     * Yellow ship type color.
+     */
     YELLOW(ShipType.HSC, ShipType.WIG);
 
     private static final HashMap<ShipType, ShipTypeColor> REVERSE_LOOKUP = new HashMap<>();
@@ -48,10 +74,21 @@ public enum ShipTypeColor {
         this.shipTypes = shipTypes;
     }
 
+    /**
+     * Get ship types ship type [ ].
+     *
+     * @return the ship type [ ]
+     */
     public ShipType[] getShipTypes() {
         return shipTypes;
     }
 
+    /**
+     * Gets color.
+     *
+     * @param type the type
+     * @return the color
+     */
     public static ShipTypeColor getColor(ShipType type) {
         ShipTypeColor c = REVERSE_LOOKUP.get(requireNonNull(type));
         return c == null ? ShipTypeColor.TURQUOISE : c;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/UTCDateResponseMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/UTCDateResponseMessage.java
@@ -26,9 +26,8 @@ import java.util.TimeZone;
 
 /**
  * AIS message 4
- * 
+ * <p>
  * Base station report as defined by ITU-R M.1371-4
- * 
  */
 public abstract class UTCDateResponseMessage extends AisMessage implements IPositionMessage {
 
@@ -52,15 +51,33 @@ public abstract class UTCDateResponseMessage extends AisMessage implements IPosi
     private int slotTimeout; // 3 bits : SOTDMA Slot Timeout
     private int subMessage; // 14 bits : SOTDMA sub-message
 
+    /**
+     * Instantiates a new Utc date response message.
+     *
+     * @param msgId the msg id
+     */
     protected UTCDateResponseMessage(int msgId) {
         super(msgId);
     }
 
+    /**
+     * Instantiates a new Utc date response message.
+     *
+     * @param vdm the vdm
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public UTCDateResponseMessage(Vdm vdm) throws AisMessageException, SixbitException {
         super(vdm);
         parse();
     }
 
+    /**
+     * Parse.
+     *
+     * @throws AisMessageException the ais message exception
+     * @throws SixbitException     the sixbit exception
+     */
     public void parse() throws AisMessageException, SixbitException {
         BinArray binArray = vdm.getBinArray();
         if (binArray.getLength() != 168) {
@@ -112,54 +129,119 @@ public abstract class UTCDateResponseMessage extends AisMessage implements IPosi
         return encoder;
     }
 
+    /**
+     * Gets utc year.
+     *
+     * @return the utc year
+     */
     public int getUtcYear() {
         return utcYear;
     }
 
+    /**
+     * Sets utc year.
+     *
+     * @param utcYear the utc year
+     */
     public void setUtcYear(int utcYear) {
         this.utcYear = utcYear;
     }
 
+    /**
+     * Gets utc month.
+     *
+     * @return the utc month
+     */
     public int getUtcMonth() {
         return utcMonth;
     }
 
+    /**
+     * Sets utc month.
+     *
+     * @param utcMonth the utc month
+     */
     public void setUtcMonth(int utcMonth) {
         this.utcMonth = utcMonth;
     }
 
+    /**
+     * Gets utc day.
+     *
+     * @return the utc day
+     */
     public int getUtcDay() {
         return utcDay;
     }
 
+    /**
+     * Sets utc day.
+     *
+     * @param utcDay the utc day
+     */
     public void setUtcDay(int utcDay) {
         this.utcDay = utcDay;
     }
 
+    /**
+     * Gets utc hour.
+     *
+     * @return the utc hour
+     */
     public int getUtcHour() {
         return utcHour;
     }
 
+    /**
+     * Sets utc hour.
+     *
+     * @param utcHour the utc hour
+     */
     public void setUtcHour(int utcHour) {
         this.utcHour = utcHour;
     }
 
+    /**
+     * Gets utc minute.
+     *
+     * @return the utc minute
+     */
     public int getUtcMinute() {
         return utcMinute;
     }
 
+    /**
+     * Sets utc minute.
+     *
+     * @param utcMinute the utc minute
+     */
     public void setUtcMinute(int utcMinute) {
         this.utcMinute = utcMinute;
     }
 
+    /**
+     * Gets utc second.
+     *
+     * @return the utc second
+     */
     public int getUtcSecond() {
         return utcSecond;
     }
 
+    /**
+     * Sets utc second.
+     *
+     * @param utcSecond the utc second
+     */
     public void setUtcSecond(int utcSecond) {
         this.utcSecond = utcSecond;
     }
 
+    /**
+     * Gets date.
+     *
+     * @return the date
+     */
     public Date getDate() {
         Calendar cal = Calendar.getInstance();
         cal.set(Calendar.YEAR, getUtcYear());
@@ -176,6 +258,11 @@ public abstract class UTCDateResponseMessage extends AisMessage implements IPosi
         return posAcc;
     }
 
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
     public void setPosAcc(int posAcc) {
         this.posAcc = posAcc;
     }
@@ -190,19 +277,36 @@ public abstract class UTCDateResponseMessage extends AisMessage implements IPosi
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
 
+    /**
+     * Gets pos type.
+     *
+     * @return the pos type
+     */
     public int getPosType() {
         return posType;
     }
 
+    /**
+     * Sets pos type.
+     *
+     * @param posType the pos type
+     */
     public void setPosType(int posType) {
         this.posType = posType;
     }
 
     /**
+     * Gets transmission control.
+     *
      * @return the transmissionControl
      */
     public int getTransmissionControl() {
@@ -210,49 +314,100 @@ public abstract class UTCDateResponseMessage extends AisMessage implements IPosi
     }
 
     /**
-     * @param transmissionControl
-     *            the transmissionControl to set
+     * Sets transmission control.
+     *
+     * @param transmissionControl the transmissionControl to set
      */
     public void setTransmissionControl(int transmissionControl) {
         this.transmissionControl = transmissionControl;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets raim.
+     *
+     * @return the raim
+     */
     public int getRaim() {
         return raim;
     }
 
+    /**
+     * Sets raim.
+     *
+     * @param raim the raim
+     */
     public void setRaim(int raim) {
         this.raim = raim;
     }
 
+    /**
+     * Gets sync state.
+     *
+     * @return the sync state
+     */
     public int getSyncState() {
         return syncState;
     }
 
+    /**
+     * Sets sync state.
+     *
+     * @param syncState the sync state
+     */
     public void setSyncState(int syncState) {
         this.syncState = syncState;
     }
 
+    /**
+     * Gets slot timeout.
+     *
+     * @return the slot timeout
+     */
     public int getSlotTimeout() {
         return slotTimeout;
     }
 
+    /**
+     * Sets slot timeout.
+     *
+     * @param slotTimeout the slot timeout
+     */
     public void setSlotTimeout(int slotTimeout) {
         this.slotTimeout = slotTimeout;
     }
 
+    /**
+     * Gets sub message.
+     *
+     * @return the sub message
+     */
     public int getSubMessage() {
         return subMessage;
     }
 
+    /**
+     * Sets sub message.
+     *
+     * @param subMessage the sub message
+     */
     public void setSubMessage(int subMessage) {
         this.subMessage = subMessage;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AddressedAreaNotice.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AddressedAreaNotice.java
@@ -22,10 +22,19 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class AddressedAreaNotice extends AreaNotice {
 
+    /**
+     * Instantiates a new Addressed area notice.
+     */
     public AddressedAreaNotice() {
         super(23);
     }
 
+    /**
+     * Instantiates a new Addressed area notice.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public AddressedAreaNotice(BinArray binArray) throws SixbitException {
         super(23, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AddressedRouteInformation.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AddressedRouteInformation.java
@@ -17,12 +17,24 @@ package dk.dma.ais.message.binary;
 import dk.dma.ais.binary.BinArray;
 import dk.dma.ais.binary.SixbitException;
 
+/**
+ * The type Addressed route information.
+ */
 public class AddressedRouteInformation extends RouteInformation {
 
+    /**
+     * Instantiates a new Addressed route information.
+     */
     public AddressedRouteInformation() {
         super(1, 28);
     }
 
+    /**
+     * Instantiates a new Addressed route information.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public AddressedRouteInformation(BinArray binArray) throws SixbitException {
         super(1, 28, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AisApplicationMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AisApplicationMessage.java
@@ -24,9 +24,21 @@ import dk.dma.ais.message.AisBinaryMessage;
  */
 public abstract class AisApplicationMessage {
 
+    /**
+     * The Dac.
+     */
     protected int dac; // 10 bits: Designated area code (DAC)
+    /**
+     * The Fi.
+     */
     protected int fi; // 6 bits: Function identifier
 
+    /**
+     * Instantiates a new Ais application message.
+     *
+     * @param dac the dac
+     * @param fi  the fi
+     */
     public AisApplicationMessage(int dac, int fi) {
         this.dac = dac;
         this.fi = fi;
@@ -34,10 +46,11 @@ public abstract class AisApplicationMessage {
 
     /**
      * Constructor that also parses six bit string
-     * 
-     * @param binArray
-     * @throws BitExhaustionException
-     * @throws SixbitException
+     *
+     * @param dac      the dac
+     * @param fi       the fi
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
      */
     public AisApplicationMessage(int dac, int fi, BinArray binArray) throws SixbitException {
         this.dac = dac;
@@ -47,28 +60,26 @@ public abstract class AisApplicationMessage {
 
     /**
      * Method to parse given six bit string
-     * 
-     * @param binArray
-     * @throws BitExhaustionException
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
      */
     public abstract void parse(BinArray binArray) throws SixbitException;
 
     /**
      * Method that returns six bit encoding of message
-     * 
-     * @return
+     *
+     * @return encoded
      */
     public abstract SixbitEncoder getEncoded();
 
     /**
      * Method to get application specific message from an {@link AisBinaryMessage}. When implementing new application
      * specific messages they should be added here.
-     * 
-     * @param binary
-     *            message
+     *
+     * @param binaryMessage the binary message
      * @return application specific message or null if not implemented
-     * @throws SixbitException
-     * @throws BitExhaustionException
+     * @throws SixbitException the sixbit exception
      */
     public static AisApplicationMessage getInstance(AisBinaryMessage binaryMessage) throws SixbitException {
         if (binaryMessage.getFi() == 3) {
@@ -112,10 +123,20 @@ public abstract class AisApplicationMessage {
         return new UnknownAsm(binaryMessage);
     }
 
+    /**
+     * Gets dac.
+     *
+     * @return the dac
+     */
     public int getDac() {
         return dac;
     }
 
+    /**
+     * Gets fi.
+     *
+     * @return the fi
+     */
     public int getFi() {
         return fi;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AreaNotice.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AreaNotice.java
@@ -28,14 +28,53 @@ import dk.dma.ais.binary.SixbitException;
  */
 public abstract class AreaNotice extends AisApplicationMessage {
 
+    /**
+     * The enum Sub area type.
+     */
     public enum SubAreaType {
-        CIRCLE_OR_POINT(0), RECTANGLE(1), SECTOR(2), POLYLINE(3), POLYGON(4), TEXT(5), RESERVED(6), RESERVED2(7);
+        /**
+         * Circle or point sub area type.
+         */
+        CIRCLE_OR_POINT(0),
+        /**
+         * Rectangle sub area type.
+         */
+        RECTANGLE(1),
+        /**
+         * Sector sub area type.
+         */
+        SECTOR(2),
+        /**
+         * Polyline sub area type.
+         */
+        POLYLINE(3),
+        /**
+         * Polygon sub area type.
+         */
+        POLYGON(4),
+        /**
+         * Text sub area type.
+         */
+        TEXT(5),
+        /**
+         * Reserved sub area type.
+         */
+        RESERVED(6),
+        /**
+         * Reserved 2 sub area type.
+         */
+        RESERVED2(7);
         private int astype;
 
         private SubAreaType(int astype) {
             this.astype = astype;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public int getType() {
             return astype;
         }
@@ -59,11 +98,23 @@ public abstract class AreaNotice extends AisApplicationMessage {
 
     // TODO the rest from SN Circ 289
 
+    /**
+     * Instantiates a new Area notice.
+     *
+     * @param fi the fi
+     */
     public AreaNotice(int fi) {
         super(1, fi);
         this.subareas = new ArrayList<>();
     }
 
+    /**
+     * Instantiates a new Area notice.
+     *
+     * @param fi       the fi
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public AreaNotice(int fi, BinArray binArray) throws SixbitException {
         super(1, fi, binArray);
     }
@@ -238,71 +289,156 @@ public abstract class AreaNotice extends AisApplicationMessage {
 
     }
 
+    /**
+     * Gets msg link id.
+     *
+     * @return the msg link id
+     */
     public int getMsgLinkId() {
         return msgLinkId;
     }
 
+    /**
+     * Sets msg link id.
+     *
+     * @param msgLinkId the msg link id
+     */
     public void setMsgLinkId(int msgLinkId) {
         this.msgLinkId = msgLinkId;
     }
 
+    /**
+     * Gets notice.
+     *
+     * @return the notice
+     */
     public int getNotice() {
         return notice;
     }
 
+    /**
+     * Sets notice.
+     *
+     * @param notice the notice
+     */
     public void setNotice(int notice) {
         this.notice = notice;
     }
 
+    /**
+     * Gets start month.
+     *
+     * @return the start month
+     */
     public int getStartMonth() {
         return startMonth;
     }
 
+    /**
+     * Sets start month.
+     *
+     * @param startMonth the start month
+     */
     public void setStartMonth(int startMonth) {
         this.startMonth = startMonth;
     }
 
+    /**
+     * Gets start day.
+     *
+     * @return the start day
+     */
     public int getStartDay() {
         return startDay;
     }
 
+    /**
+     * Sets start day.
+     *
+     * @param startDay the start day
+     */
     public void setStartDay(int startDay) {
         this.startDay = startDay;
     }
 
+    /**
+     * Gets start hour.
+     *
+     * @return the start hour
+     */
     public int getStartHour() {
         return startHour;
     }
 
+    /**
+     * Sets start hour.
+     *
+     * @param startHour the start hour
+     */
     public void setStartHour(int startHour) {
         this.startHour = startHour;
     }
 
+    /**
+     * Gets start min.
+     *
+     * @return the start min
+     */
     public int getStartMin() {
         return startMin;
     }
 
+    /**
+     * Sets start min.
+     *
+     * @param startMin the start min
+     */
     public void setStartMin(int startMin) {
         this.startMin = startMin;
     }
 
+    /**
+     * Gets duration.
+     *
+     * @return the duration
+     */
     public int getDuration() {
         return duration;
     }
 
+    /**
+     * Sets duration.
+     *
+     * @param duration the duration
+     */
     public void setDuration(int duration) {
         this.duration = duration;
     }
 
+    /**
+     * Sets sub areas.
+     *
+     * @param subareas the subareas
+     */
     public void setSubAreas(List<SubArea> subareas) {
         this.subareas = subareas;
     }
 
+    /**
+     * Add sub area.
+     *
+     * @param subarea the subarea
+     */
     public void addSubArea(SubArea subarea) {
         subareas.add(subarea);
         subareasCount = subareas.size();
     }
 
+    /**
+     * Gets sub areas.
+     *
+     * @return the sub areas
+     */
     public List<SubArea> getSubAreas() {
         return subareas;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AsmAcknowledge.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/AsmAcknowledge.java
@@ -49,10 +49,19 @@ public class AsmAcknowledge extends AisApplicationMessage {
     private int aiResponse; // 3 bits
     private int spare; // 49 bits
 
+    /**
+     * Instantiates a new Asm acknowledge.
+     */
     public AsmAcknowledge() {
         super(1, 5);
     }
 
+    /**
+     * Instantiates a new Asm acknowledge.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public AsmAcknowledge(BinArray binArray) throws SixbitException {
         super(1, 5, binArray);
     }
@@ -78,50 +87,110 @@ public class AsmAcknowledge extends AisApplicationMessage {
         return encoder;
     }
 
+    /**
+     * Gets received dac.
+     *
+     * @return the received dac
+     */
     public int getReceivedDac() {
         return receivedDac;
     }
 
+    /**
+     * Sets received dac.
+     *
+     * @param receivedDac the received dac
+     */
     public void setReceivedDac(int receivedDac) {
         this.receivedDac = receivedDac;
     }
 
+    /**
+     * Gets received fi.
+     *
+     * @return the received fi
+     */
     public int getReceivedFi() {
         return receivedFi;
     }
 
+    /**
+     * Sets received fi.
+     *
+     * @param receivedFi the received fi
+     */
     public void setReceivedFi(int receivedFi) {
         this.receivedFi = receivedFi;
     }
 
+    /**
+     * Gets text sequence num.
+     *
+     * @return the text sequence num
+     */
     public int getTextSequenceNum() {
         return textSequenceNum;
     }
 
+    /**
+     * Sets text sequence num.
+     *
+     * @param textSequenceNum the text sequence num
+     */
     public void setTextSequenceNum(int textSequenceNum) {
         this.textSequenceNum = textSequenceNum;
     }
 
+    /**
+     * Gets ai available.
+     *
+     * @return the ai available
+     */
     public int getAiAvailable() {
         return aiAvailable;
     }
 
+    /**
+     * Sets ai available.
+     *
+     * @param aiAvailable the ai available
+     */
     public void setAiAvailable(int aiAvailable) {
         this.aiAvailable = aiAvailable;
     }
 
+    /**
+     * Gets ai response.
+     *
+     * @return the ai response
+     */
     public int getAiResponse() {
         return aiResponse;
     }
 
+    /**
+     * Sets ai response.
+     *
+     * @param aiResponse the ai response
+     */
     public void setAiResponse(int aiResponse) {
         this.aiResponse = aiResponse;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastAreaNotice.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastAreaNotice.java
@@ -22,10 +22,19 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class BroadcastAreaNotice extends AreaNotice {
 
+    /**
+     * Instantiates a new Broadcast area notice.
+     */
     public BroadcastAreaNotice() {
         super(22);
     }
 
+    /**
+     * Instantiates a new Broadcast area notice.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public BroadcastAreaNotice(BinArray binArray) throws SixbitException {
         super(22, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastIntendedRoute.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastIntendedRoute.java
@@ -22,13 +22,28 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class BroadcastIntendedRoute extends RouteExchange {
 
+    /**
+     * The constant DAC.
+     */
     public static final int DAC = 219;
+    /**
+     * The constant FI.
+     */
     public static final int FI = 1;
 
+    /**
+     * Instantiates a new Broadcast intended route.
+     */
     public BroadcastIntendedRoute() {
         super(DAC, FI);
     }
 
+    /**
+     * Instantiates a new Broadcast intended route.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public BroadcastIntendedRoute(BinArray binArray) throws SixbitException {
         super(DAC, FI, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastRouteInformation.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/BroadcastRouteInformation.java
@@ -17,12 +17,24 @@ package dk.dma.ais.message.binary;
 import dk.dma.ais.binary.BinArray;
 import dk.dma.ais.binary.SixbitException;
 
+/**
+ * The type Broadcast route information.
+ */
 public class BroadcastRouteInformation extends RouteInformation {
 
+    /**
+     * Instantiates a new Broadcast route information.
+     */
     public BroadcastRouteInformation() {
         super(1, 27);
     }
 
+    /**
+     * Instantiates a new Broadcast route information.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public BroadcastRouteInformation(BinArray binArray) throws SixbitException {
         super(1, 27, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/Capability.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/Capability.java
@@ -26,10 +26,19 @@ public class Capability extends AisApplicationMessage {
     private int reqDac; // 10 bits
     private int spare; // 70 bits
 
+    /**
+     * Instantiates a new Capability.
+     */
     public Capability() {
         super(1, 3);
     }
 
+    /**
+     * Instantiates a new Capability.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public Capability(BinArray binArray) throws SixbitException {
         super(1, 3, binArray);
     }
@@ -47,18 +56,38 @@ public class Capability extends AisApplicationMessage {
         this.reqDac = (int) binArray.getVal(10);
     }
 
+    /**
+     * Gets req dac.
+     *
+     * @return the req dac
+     */
     public int getReqDac() {
         return reqDac;
     }
 
+    /**
+     * Sets req dac.
+     *
+     * @param reqDac the req dac
+     */
     public void setReqDac(int reqDac) {
         this.reqDac = reqDac;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/InlandVoyage.java
@@ -19,10 +19,9 @@ import dk.dma.ais.binary.SixbitEncoder;
 import dk.dma.ais.binary.SixbitException;
 
 /**
- *
  * Subtype (DAC=200, FI=10) of AIS type 8 binary application message.
  * With title: Inland ship static and voyage related data
- * 
+ *
  * @author oteken
  */
 public class InlandVoyage extends AisApplicationMessage{
@@ -62,6 +61,12 @@ public class InlandVoyage extends AisApplicationMessage{
     
     private int spare; // 8 bit
 
+    /**
+     * Instantiates a new Inland voyage.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public InlandVoyage(BinArray binArray) throws SixbitException {
         super(200, 10, binArray);
     }
@@ -124,90 +129,200 @@ public class InlandVoyage extends AisApplicationMessage{
         return builder.toString();
     }
 
+    /**
+     * Gets length of ship.
+     *
+     * @return the length of ship
+     */
     public int getLengthOfShip() {
         return lengthOfShip;
     }
 
+    /**
+     * Sets length of ship.
+     *
+     * @param lengthOfShip the length of ship
+     */
     public void setLengthOfShip(int lengthOfShip) {
         this.lengthOfShip = lengthOfShip;
     }
 
+    /**
+     * Gets beam of ship.
+     *
+     * @return the beam of ship
+     */
     public int getBeamOfShip() {
         return beamOfShip;
     }
 
+    /**
+     * Sets beam of ship.
+     *
+     * @param beamOfShip the beam of ship
+     */
     public void setBeamOfShip(int beamOfShip) {
         this.beamOfShip = beamOfShip;
     }
 
+    /**
+     * Gets combination type.
+     *
+     * @return the combination type
+     */
     public int getCombinationType() {
         return combinationType;
     }
 
+    /**
+     * Sets combination type.
+     *
+     * @param combinationType the combination type
+     */
     public void setCombinationType(int combinationType) {
         this.combinationType = combinationType;
     }
 
+    /**
+     * Gets hazardous cargo.
+     *
+     * @return the hazardous cargo
+     */
     public int getHazardousCargo() {
         return hazardousCargo;
     }
 
+    /**
+     * Sets hazardous cargo.
+     *
+     * @param hazardousCargo the hazardous cargo
+     */
     public void setHazardousCargo(int hazardousCargo) {
         this.hazardousCargo = hazardousCargo;
     }
 
+    /**
+     * Gets draught.
+     *
+     * @return the draught
+     */
     public int getDraught() {
         return draught;
     }
 
+    /**
+     * Sets draught.
+     *
+     * @param draught the draught
+     */
     public void setDraught(int draught) {
         this.draught = draught;
     }
 
+    /**
+     * Gets loaded or unloaded.
+     *
+     * @return the loaded or unloaded
+     */
     public int getLoadedOrUnloaded() {
         return loadedOrUnloaded;
     }
 
+    /**
+     * Sets loaded or unloaded.
+     *
+     * @param loadedOrUnloaded the loaded or unloaded
+     */
     public void setLoadedOrUnloaded(int loadedOrUnloaded) {
         this.loadedOrUnloaded = loadedOrUnloaded;
     }
 
+    /**
+     * Gets quality of speed data.
+     *
+     * @return the quality of speed data
+     */
     public int getQualityOfSpeedData() {
         return qualityOfSpeedData;
     }
 
+    /**
+     * Sets quality of speed data.
+     *
+     * @param qualityOfSpeedData the quality of speed data
+     */
     public void setQualityOfSpeedData(int qualityOfSpeedData) {
         this.qualityOfSpeedData = qualityOfSpeedData;
     }
 
+    /**
+     * Gets quality of course data.
+     *
+     * @return the quality of course data
+     */
     public int getQualityOfCourseData() {
         return qualityOfCourseData;
     }
 
+    /**
+     * Sets quality of course data.
+     *
+     * @param qualityOfCourseData the quality of course data
+     */
     public void setQualityOfCourseData(int qualityOfCourseData) {
         this.qualityOfCourseData = qualityOfCourseData;
     }
 
+    /**
+     * Gets quality of heading data.
+     *
+     * @return the quality of heading data
+     */
     public int getQualityOfHeadingData() {
         return qualityOfHeadingData;
     }
 
+    /**
+     * Sets quality of heading data.
+     *
+     * @param qualityOfHeadingData the quality of heading data
+     */
     public void setQualityOfHeadingData(int qualityOfHeadingData) {
         this.qualityOfHeadingData = qualityOfHeadingData;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }
 
+    /**
+     * Gets vessel id.
+     *
+     * @return the vessel id
+     */
     public String getVesselId() {
         return vesselId;
     }
 
+    /**
+     * Sets vessel id.
+     *
+     * @param vesselId the vessel id
+     */
     public void setVesselId(String vesselId) {
         this.vesselId = vesselId;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/MetHyd11.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/MetHyd11.java
@@ -19,6 +19,9 @@ import dk.dma.ais.binary.SixbitEncoder;
 import dk.dma.ais.binary.SixbitException;
 import dk.dma.ais.message.AisPosition;
 
+/**
+ * The type Met hyd 11.
+ */
 public class MetHyd11 extends AisApplicationMessage {
 
     private AisPosition pos;
@@ -58,6 +61,12 @@ public class MetHyd11 extends AisApplicationMessage {
     private int ice; // 2 bits
     private int spare; // 6 bits;
 
+    /**
+     * Instantiates a new Met hyd 11.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public MetHyd11(BinArray binArray) throws SixbitException {
         super(1, 11, binArray);
     }
@@ -110,290 +119,650 @@ public class MetHyd11 extends AisApplicationMessage {
         this.spare = (int) binArray.getVal(6);
     }
 
+    /**
+     * Gets pos.
+     *
+     * @return the pos
+     */
     public AisPosition getPos() {
         return pos;
     }
 
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
     public void setPos(AisPosition pos) {
         this.pos = pos;
     }
 
+    /**
+     * Gets utc day.
+     *
+     * @return the utc day
+     */
     public int getUtcDay() {
         return utcDay;
     }
 
+    /**
+     * Sets utc day.
+     *
+     * @param utcDay the utc day
+     */
     public void setUtcDay(int utcDay) {
         this.utcDay = utcDay;
     }
 
+    /**
+     * Gets utc hour.
+     *
+     * @return the utc hour
+     */
     public int getUtcHour() {
         return utcHour;
     }
 
+    /**
+     * Sets utc hour.
+     *
+     * @param utcHour the utc hour
+     */
     public void setUtcHour(int utcHour) {
         this.utcHour = utcHour;
     }
 
+    /**
+     * Gets utc minute.
+     *
+     * @return the utc minute
+     */
     public int getUtcMinute() {
         return utcMinute;
     }
 
+    /**
+     * Sets utc minute.
+     *
+     * @param utcMinute the utc minute
+     */
     public void setUtcMinute(int utcMinute) {
         this.utcMinute = utcMinute;
     }
 
+    /**
+     * Gets wind.
+     *
+     * @return the wind
+     */
     public int getWind() {
         return wind;
     }
 
+    /**
+     * Sets wind.
+     *
+     * @param wind the wind
+     */
     public void setWind(int wind) {
         this.wind = wind;
     }
 
+    /**
+     * Gets gust.
+     *
+     * @return the gust
+     */
     public int getGust() {
         return gust;
     }
 
+    /**
+     * Sets gust.
+     *
+     * @param gust the gust
+     */
     public void setGust(int gust) {
         this.gust = gust;
     }
 
+    /**
+     * Gets wind direction.
+     *
+     * @return the wind direction
+     */
     public int getWindDirection() {
         return windDirection;
     }
 
+    /**
+     * Sets wind direction.
+     *
+     * @param windDirection the wind direction
+     */
     public void setWindDirection(int windDirection) {
         this.windDirection = windDirection;
     }
 
+    /**
+     * Gets gust direction.
+     *
+     * @return the gust direction
+     */
     public int getGustDirection() {
         return gustDirection;
     }
 
+    /**
+     * Sets gust direction.
+     *
+     * @param gustDirection the gust direction
+     */
     public void setGustDirection(int gustDirection) {
         this.gustDirection = gustDirection;
     }
 
+    /**
+     * Gets air temp.
+     *
+     * @return the air temp
+     */
     public int getAirTemp() {
         return airTemp;
     }
 
+    /**
+     * Sets air temp.
+     *
+     * @param airTemp the air temp
+     */
     public void setAirTemp(int airTemp) {
         this.airTemp = airTemp;
     }
 
+    /**
+     * Gets humidity.
+     *
+     * @return the humidity
+     */
     public int getHumidity() {
         return humidity;
     }
 
+    /**
+     * Sets humidity.
+     *
+     * @param humidity the humidity
+     */
     public void setHumidity(int humidity) {
         this.humidity = humidity;
     }
 
+    /**
+     * Gets dew point.
+     *
+     * @return the dew point
+     */
     public int getDewPoint() {
         return dewPoint;
     }
 
+    /**
+     * Sets dew point.
+     *
+     * @param dewPoint the dew point
+     */
     public void setDewPoint(int dewPoint) {
         this.dewPoint = dewPoint;
     }
 
+    /**
+     * Gets air pressure.
+     *
+     * @return the air pressure
+     */
     public int getAirPressure() {
         return airPressure;
     }
 
+    /**
+     * Sets air pressure.
+     *
+     * @param airPressure the air pressure
+     */
     public void setAirPressure(int airPressure) {
         this.airPressure = airPressure;
     }
 
+    /**
+     * Gets air pressure tend.
+     *
+     * @return the air pressure tend
+     */
     public int getAirPressureTend() {
         return airPressureTend;
     }
 
+    /**
+     * Sets air pressure tend.
+     *
+     * @param airPressureTend the air pressure tend
+     */
     public void setAirPressureTend(int airPressureTend) {
         this.airPressureTend = airPressureTend;
     }
 
+    /**
+     * Gets horz visibility.
+     *
+     * @return the horz visibility
+     */
     public int getHorzVisibility() {
         return horzVisibility;
     }
 
+    /**
+     * Sets horz visibility.
+     *
+     * @param horzVisibility the horz visibility
+     */
     public void setHorzVisibility(int horzVisibility) {
         this.horzVisibility = horzVisibility;
     }
 
+    /**
+     * Gets water level.
+     *
+     * @return the water level
+     */
     public int getWaterLevel() {
         return waterLevel;
     }
 
+    /**
+     * Sets water level.
+     *
+     * @param waterLevel the water level
+     */
     public void setWaterLevel(int waterLevel) {
         this.waterLevel = waterLevel;
     }
 
+    /**
+     * Gets water level trend.
+     *
+     * @return the water level trend
+     */
     public int getWaterLevelTrend() {
         return waterLevelTrend;
     }
 
+    /**
+     * Sets water level trend.
+     *
+     * @param waterLevelTrend the water level trend
+     */
     public void setWaterLevelTrend(int waterLevelTrend) {
         this.waterLevelTrend = waterLevelTrend;
     }
 
+    /**
+     * Gets surface current.
+     *
+     * @return the surface current
+     */
     public int getSurfaceCurrent() {
         return surfaceCurrent;
     }
 
+    /**
+     * Sets surface current.
+     *
+     * @param surfaceCurrent the surface current
+     */
     public void setSurfaceCurrent(int surfaceCurrent) {
         this.surfaceCurrent = surfaceCurrent;
     }
 
+    /**
+     * Gets surface current dir.
+     *
+     * @return the surface current dir
+     */
     public int getSurfaceCurrentDir() {
         return surfaceCurrentDir;
     }
 
+    /**
+     * Sets surface current dir.
+     *
+     * @param surfaceCurrentDir the surface current dir
+     */
     public void setSurfaceCurrentDir(int surfaceCurrentDir) {
         this.surfaceCurrentDir = surfaceCurrentDir;
     }
 
+    /**
+     * Gets second current.
+     *
+     * @return the second current
+     */
     public int getSecondCurrent() {
         return secondCurrent;
     }
 
+    /**
+     * Sets second current.
+     *
+     * @param secondCurrent the second current
+     */
     public void setSecondCurrent(int secondCurrent) {
         this.secondCurrent = secondCurrent;
     }
 
+    /**
+     * Gets second current dir.
+     *
+     * @return the second current dir
+     */
     public int getSecondCurrentDir() {
         return secondCurrentDir;
     }
 
+    /**
+     * Sets second current dir.
+     *
+     * @param secondCurrentDir the second current dir
+     */
     public void setSecondCurrentDir(int secondCurrentDir) {
         this.secondCurrentDir = secondCurrentDir;
     }
 
+    /**
+     * Gets second current level.
+     *
+     * @return the second current level
+     */
     public int getSecondCurrentLevel() {
         return secondCurrentLevel;
     }
 
+    /**
+     * Sets second current level.
+     *
+     * @param secondCurrentLevel the second current level
+     */
     public void setSecondCurrentLevel(int secondCurrentLevel) {
         this.secondCurrentLevel = secondCurrentLevel;
     }
 
+    /**
+     * Gets third current.
+     *
+     * @return the third current
+     */
     public int getThirdCurrent() {
         return thirdCurrent;
     }
 
+    /**
+     * Sets third current.
+     *
+     * @param thirdCurrent the third current
+     */
     public void setThirdCurrent(int thirdCurrent) {
         this.thirdCurrent = thirdCurrent;
     }
 
+    /**
+     * Gets third current dir.
+     *
+     * @return the third current dir
+     */
     public int getThirdCurrentDir() {
         return thirdCurrentDir;
     }
 
+    /**
+     * Sets third current dir.
+     *
+     * @param thirdCurrentDir the third current dir
+     */
     public void setThirdCurrentDir(int thirdCurrentDir) {
         this.thirdCurrentDir = thirdCurrentDir;
     }
 
+    /**
+     * Gets third current level.
+     *
+     * @return the third current level
+     */
     public int getThirdCurrentLevel() {
         return thirdCurrentLevel;
     }
 
+    /**
+     * Sets third current level.
+     *
+     * @param thirdCurrentLevel the third current level
+     */
     public void setThirdCurrentLevel(int thirdCurrentLevel) {
         this.thirdCurrentLevel = thirdCurrentLevel;
     }
 
+    /**
+     * Gets wave height.
+     *
+     * @return the wave height
+     */
     public int getWaveHeight() {
         return waveHeight;
     }
 
+    /**
+     * Sets wave height.
+     *
+     * @param waveHeight the wave height
+     */
     public void setWaveHeight(int waveHeight) {
         this.waveHeight = waveHeight;
     }
 
+    /**
+     * Gets wave period.
+     *
+     * @return the wave period
+     */
     public int getWavePeriod() {
         return wavePeriod;
     }
 
+    /**
+     * Sets wave period.
+     *
+     * @param wavePeriod the wave period
+     */
     public void setWavePeriod(int wavePeriod) {
         this.wavePeriod = wavePeriod;
     }
 
+    /**
+     * Gets wave direction.
+     *
+     * @return the wave direction
+     */
     public int getWaveDirection() {
         return waveDirection;
     }
 
+    /**
+     * Sets wave direction.
+     *
+     * @param waveDirection the wave direction
+     */
     public void setWaveDirection(int waveDirection) {
         this.waveDirection = waveDirection;
     }
 
+    /**
+     * Gets swell height.
+     *
+     * @return the swell height
+     */
     public int getSwellHeight() {
         return swellHeight;
     }
 
+    /**
+     * Sets swell height.
+     *
+     * @param swellHeight the swell height
+     */
     public void setSwellHeight(int swellHeight) {
         this.swellHeight = swellHeight;
     }
 
+    /**
+     * Gets swell period.
+     *
+     * @return the swell period
+     */
     public int getSwellPeriod() {
         return swellPeriod;
     }
 
+    /**
+     * Sets swell period.
+     *
+     * @param swellPeriod the swell period
+     */
     public void setSwellPeriod(int swellPeriod) {
         this.swellPeriod = swellPeriod;
     }
 
+    /**
+     * Gets swell direction.
+     *
+     * @return the swell direction
+     */
     public int getSwellDirection() {
         return swellDirection;
     }
 
+    /**
+     * Sets swell direction.
+     *
+     * @param swellDirection the swell direction
+     */
     public void setSwellDirection(int swellDirection) {
         this.swellDirection = swellDirection;
     }
 
+    /**
+     * Gets sea state.
+     *
+     * @return the sea state
+     */
     public int getSeaState() {
         return seaState;
     }
 
+    /**
+     * Sets sea state.
+     *
+     * @param seaState the sea state
+     */
     public void setSeaState(int seaState) {
         this.seaState = seaState;
     }
 
+    /**
+     * Gets water temp.
+     *
+     * @return the water temp
+     */
     public int getWaterTemp() {
         return waterTemp;
     }
 
+    /**
+     * Sets water temp.
+     *
+     * @param waterTemp the water temp
+     */
     public void setWaterTemp(int waterTemp) {
         this.waterTemp = waterTemp;
     }
 
+    /**
+     * Gets precipitation.
+     *
+     * @return the precipitation
+     */
     public int getPrecipitation() {
         return precipitation;
     }
 
+    /**
+     * Sets precipitation.
+     *
+     * @param precipitation the precipitation
+     */
     public void setPrecipitation(int precipitation) {
         this.precipitation = precipitation;
     }
 
+    /**
+     * Gets salinity.
+     *
+     * @return the salinity
+     */
     public int getSalinity() {
         return salinity;
     }
 
+    /**
+     * Sets salinity.
+     *
+     * @param salinity the salinity
+     */
     public void setSalinity(int salinity) {
         this.salinity = salinity;
     }
 
+    /**
+     * Gets ice.
+     *
+     * @return the ice
+     */
     public int getIce() {
         return ice;
     }
 
+    /**
+     * Sets ice.
+     *
+     * @param ice the ice
+     */
     public void setIce(int ice) {
         this.ice = ice;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return spare;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
     public void setSpare(int spare) {
         this.spare = spare;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/MetHyd31.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/MetHyd31.java
@@ -20,6 +20,9 @@ import dk.dma.ais.binary.SixbitException;
 import dk.dma.ais.message.AisPosition;
 import dk.dma.ais.message.binary.AisApplicationMessage;
 
+/**
+ * The type Met hyd 31.
+ */
 public class MetHyd31 extends AisApplicationMessage {
 
 	private AisPosition pos;
@@ -60,7 +63,13 @@ public class MetHyd31 extends AisApplicationMessage {
 	private int spare; // 6 bits
 	private int posAcc; // 1 bit
 
-	public MetHyd31(BinArray binArray) throws SixbitException {
+    /**
+     * Instantiates a new Met hyd 31.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
+    public MetHyd31(BinArray binArray) throws SixbitException {
 		super(1, 31, binArray);
 	}
 
@@ -113,299 +122,669 @@ public class MetHyd31 extends AisApplicationMessage {
 		this.spare = (int) binArray.getVal(6);
 	}
 
-	public AisPosition getPos() {
+    /**
+     * Gets pos.
+     *
+     * @return the pos
+     */
+    public AisPosition getPos() {
 		return pos;
 	}
 
-	public void setPos(AisPosition pos) {
+    /**
+     * Sets pos.
+     *
+     * @param pos the pos
+     */
+    public void setPos(AisPosition pos) {
 		this.pos = pos;
 	}
 
-	public int getUtcDay() {
+    /**
+     * Gets utc day.
+     *
+     * @return the utc day
+     */
+    public int getUtcDay() {
 		return utcDay;
 	}
 
-	public void setUtcDay(int utcDay) {
+    /**
+     * Sets utc day.
+     *
+     * @param utcDay the utc day
+     */
+    public void setUtcDay(int utcDay) {
 		this.utcDay = utcDay;
 	}
 
-	public int getUtcHour() {
+    /**
+     * Gets utc hour.
+     *
+     * @return the utc hour
+     */
+    public int getUtcHour() {
 		return utcHour;
 	}
 
-	public void setUtcHour(int utcHour) {
+    /**
+     * Sets utc hour.
+     *
+     * @param utcHour the utc hour
+     */
+    public void setUtcHour(int utcHour) {
 		this.utcHour = utcHour;
 	}
 
-	public int getUtcMinute() {
+    /**
+     * Gets utc minute.
+     *
+     * @return the utc minute
+     */
+    public int getUtcMinute() {
 		return utcMinute;
 	}
 
-	public void setUtcMinute(int utcMinute) {
+    /**
+     * Sets utc minute.
+     *
+     * @param utcMinute the utc minute
+     */
+    public void setUtcMinute(int utcMinute) {
 		this.utcMinute = utcMinute;
 	}
 
-	public int getWind() {
+    /**
+     * Gets wind.
+     *
+     * @return the wind
+     */
+    public int getWind() {
 		return wind;
 	}
 
-	public void setWind(int wind) {
+    /**
+     * Sets wind.
+     *
+     * @param wind the wind
+     */
+    public void setWind(int wind) {
 		this.wind = wind;
 	}
 
-	public int getGust() {
+    /**
+     * Gets gust.
+     *
+     * @return the gust
+     */
+    public int getGust() {
 		return gust;
 	}
 
-	public void setGust(int gust) {
+    /**
+     * Sets gust.
+     *
+     * @param gust the gust
+     */
+    public void setGust(int gust) {
 		this.gust = gust;
 	}
 
-	public int getWindDirection() {
+    /**
+     * Gets wind direction.
+     *
+     * @return the wind direction
+     */
+    public int getWindDirection() {
 		return windDirection;
 	}
 
-	public void setWindDirection(int windDirection) {
+    /**
+     * Sets wind direction.
+     *
+     * @param windDirection the wind direction
+     */
+    public void setWindDirection(int windDirection) {
 		this.windDirection = windDirection;
 	}
 
-	public int getGustDirection() {
+    /**
+     * Gets gust direction.
+     *
+     * @return the gust direction
+     */
+    public int getGustDirection() {
 		return gustDirection;
 	}
 
-	public void setGustDirection(int gustDirection) {
+    /**
+     * Sets gust direction.
+     *
+     * @param gustDirection the gust direction
+     */
+    public void setGustDirection(int gustDirection) {
 		this.gustDirection = gustDirection;
 	}
 
-	public int getAirTemp() {
+    /**
+     * Gets air temp.
+     *
+     * @return the air temp
+     */
+    public int getAirTemp() {
 		return airTemp;
 	}
 
-	public void setAirTemp(int airTemp) {
+    /**
+     * Sets air temp.
+     *
+     * @param airTemp the air temp
+     */
+    public void setAirTemp(int airTemp) {
 		this.airTemp = airTemp;
 	}
 
-	public int getHumidity() {
+    /**
+     * Gets humidity.
+     *
+     * @return the humidity
+     */
+    public int getHumidity() {
 		return humidity;
 	}
 
-	public void setHumidity(int humidity) {
+    /**
+     * Sets humidity.
+     *
+     * @param humidity the humidity
+     */
+    public void setHumidity(int humidity) {
 		this.humidity = humidity;
 	}
 
-	public int getDewPoint() {
+    /**
+     * Gets dew point.
+     *
+     * @return the dew point
+     */
+    public int getDewPoint() {
 		return dewPoint;
 	}
 
-	public void setDewPoint(int dewPoint) {
+    /**
+     * Sets dew point.
+     *
+     * @param dewPoint the dew point
+     */
+    public void setDewPoint(int dewPoint) {
 		this.dewPoint = dewPoint;
 	}
 
-	public int getAirPressure() {
+    /**
+     * Gets air pressure.
+     *
+     * @return the air pressure
+     */
+    public int getAirPressure() {
 		return airPressure;
 	}
 
-	public void setAirPressure(int airPressure) {
+    /**
+     * Sets air pressure.
+     *
+     * @param airPressure the air pressure
+     */
+    public void setAirPressure(int airPressure) {
 		this.airPressure = airPressure;
 	}
 
-	public int getAirPressureTend() {
+    /**
+     * Gets air pressure tend.
+     *
+     * @return the air pressure tend
+     */
+    public int getAirPressureTend() {
 		return airPressureTend;
 	}
 
-	public void setAirPressureTend(int airPressureTend) {
+    /**
+     * Sets air pressure tend.
+     *
+     * @param airPressureTend the air pressure tend
+     */
+    public void setAirPressureTend(int airPressureTend) {
 		this.airPressureTend = airPressureTend;
 	}
 
-	public int getHorzVisibility() {
+    /**
+     * Gets horz visibility.
+     *
+     * @return the horz visibility
+     */
+    public int getHorzVisibility() {
 		return horzVisibility;
 	}
 
-	public void setHorzVisibility(int horzVisibility) {
+    /**
+     * Sets horz visibility.
+     *
+     * @param horzVisibility the horz visibility
+     */
+    public void setHorzVisibility(int horzVisibility) {
 		this.horzVisibility = horzVisibility;
 	}
 
-	public int getWaterLevel() {
+    /**
+     * Gets water level.
+     *
+     * @return the water level
+     */
+    public int getWaterLevel() {
 		return waterLevel;
 	}
 
-	public void setWaterLevel(int waterLevel) {
+    /**
+     * Sets water level.
+     *
+     * @param waterLevel the water level
+     */
+    public void setWaterLevel(int waterLevel) {
 		this.waterLevel = waterLevel;
 	}
 
-	public int getWaterLevelTrend() {
+    /**
+     * Gets water level trend.
+     *
+     * @return the water level trend
+     */
+    public int getWaterLevelTrend() {
 		return waterLevelTrend;
 	}
 
-	public void setWaterLevelTrend(int waterLevelTrend) {
+    /**
+     * Sets water level trend.
+     *
+     * @param waterLevelTrend the water level trend
+     */
+    public void setWaterLevelTrend(int waterLevelTrend) {
 		this.waterLevelTrend = waterLevelTrend;
 	}
 
-	public int getSurfaceCurrent() {
+    /**
+     * Gets surface current.
+     *
+     * @return the surface current
+     */
+    public int getSurfaceCurrent() {
 		return surfaceCurrent;
 	}
 
-	public void setSurfaceCurrent(int surfaceCurrent) {
+    /**
+     * Sets surface current.
+     *
+     * @param surfaceCurrent the surface current
+     */
+    public void setSurfaceCurrent(int surfaceCurrent) {
 		this.surfaceCurrent = surfaceCurrent;
 	}
 
-	public int getSurfaceCurrentDir() {
+    /**
+     * Gets surface current dir.
+     *
+     * @return the surface current dir
+     */
+    public int getSurfaceCurrentDir() {
 		return surfaceCurrentDir;
 	}
 
-	public void setSurfaceCurrentDir(int surfaceCurrentDir) {
+    /**
+     * Sets surface current dir.
+     *
+     * @param surfaceCurrentDir the surface current dir
+     */
+    public void setSurfaceCurrentDir(int surfaceCurrentDir) {
 		this.surfaceCurrentDir = surfaceCurrentDir;
 	}
 
-	public int getSecondCurrent() {
+    /**
+     * Gets second current.
+     *
+     * @return the second current
+     */
+    public int getSecondCurrent() {
 		return secondCurrent;
 	}
 
-	public void setSecondCurrent(int secondCurrent) {
+    /**
+     * Sets second current.
+     *
+     * @param secondCurrent the second current
+     */
+    public void setSecondCurrent(int secondCurrent) {
 		this.secondCurrent = secondCurrent;
 	}
 
-	public int getSecondCurrentDir() {
+    /**
+     * Gets second current dir.
+     *
+     * @return the second current dir
+     */
+    public int getSecondCurrentDir() {
 		return secondCurrentDir;
 	}
 
-	public void setSecondCurrentDir(int secondCurrentDir) {
+    /**
+     * Sets second current dir.
+     *
+     * @param secondCurrentDir the second current dir
+     */
+    public void setSecondCurrentDir(int secondCurrentDir) {
 		this.secondCurrentDir = secondCurrentDir;
 	}
 
-	public int getSecondCurrentLevel() {
+    /**
+     * Gets second current level.
+     *
+     * @return the second current level
+     */
+    public int getSecondCurrentLevel() {
 		return secondCurrentLevel;
 	}
 
-	public void setSecondCurrentLevel(int secondCurrentLevel) {
+    /**
+     * Sets second current level.
+     *
+     * @param secondCurrentLevel the second current level
+     */
+    public void setSecondCurrentLevel(int secondCurrentLevel) {
 		this.secondCurrentLevel = secondCurrentLevel;
 	}
 
-	public int getThirdCurrent() {
+    /**
+     * Gets third current.
+     *
+     * @return the third current
+     */
+    public int getThirdCurrent() {
 		return thirdCurrent;
 	}
 
-	public void setThirdCurrent(int thirdCurrent) {
+    /**
+     * Sets third current.
+     *
+     * @param thirdCurrent the third current
+     */
+    public void setThirdCurrent(int thirdCurrent) {
 		this.thirdCurrent = thirdCurrent;
 	}
 
-	public int getThirdCurrentDir() {
+    /**
+     * Gets third current dir.
+     *
+     * @return the third current dir
+     */
+    public int getThirdCurrentDir() {
 		return thirdCurrentDir;
 	}
 
-	public void setThirdCurrentDir(int thirdCurrentDir) {
+    /**
+     * Sets third current dir.
+     *
+     * @param thirdCurrentDir the third current dir
+     */
+    public void setThirdCurrentDir(int thirdCurrentDir) {
 		this.thirdCurrentDir = thirdCurrentDir;
 	}
 
-	public int getThirdCurrentLevel() {
+    /**
+     * Gets third current level.
+     *
+     * @return the third current level
+     */
+    public int getThirdCurrentLevel() {
 		return thirdCurrentLevel;
 	}
 
-	public void setThirdCurrentLevel(int thirdCurrentLevel) {
+    /**
+     * Sets third current level.
+     *
+     * @param thirdCurrentLevel the third current level
+     */
+    public void setThirdCurrentLevel(int thirdCurrentLevel) {
 		this.thirdCurrentLevel = thirdCurrentLevel;
 	}
 
-	public int getWaveHeight() {
+    /**
+     * Gets wave height.
+     *
+     * @return the wave height
+     */
+    public int getWaveHeight() {
 		return waveHeight;
 	}
 
-	public void setWaveHeight(int waveHeight) {
+    /**
+     * Sets wave height.
+     *
+     * @param waveHeight the wave height
+     */
+    public void setWaveHeight(int waveHeight) {
 		this.waveHeight = waveHeight;
 	}
 
-	public int getWavePeriod() {
+    /**
+     * Gets wave period.
+     *
+     * @return the wave period
+     */
+    public int getWavePeriod() {
 		return wavePeriod;
 	}
 
-	public void setWavePeriod(int wavePeriod) {
+    /**
+     * Sets wave period.
+     *
+     * @param wavePeriod the wave period
+     */
+    public void setWavePeriod(int wavePeriod) {
 		this.wavePeriod = wavePeriod;
 	}
 
-	public int getWaveDirection() {
+    /**
+     * Gets wave direction.
+     *
+     * @return the wave direction
+     */
+    public int getWaveDirection() {
 		return waveDirection;
 	}
 
-	public void setWaveDirection(int waveDirection) {
+    /**
+     * Sets wave direction.
+     *
+     * @param waveDirection the wave direction
+     */
+    public void setWaveDirection(int waveDirection) {
 		this.waveDirection = waveDirection;
 	}
 
-	public int getSwellHeight() {
+    /**
+     * Gets swell height.
+     *
+     * @return the swell height
+     */
+    public int getSwellHeight() {
 		return swellHeight;
 	}
 
-	public void setSwellHeight(int swellHeight) {
+    /**
+     * Sets swell height.
+     *
+     * @param swellHeight the swell height
+     */
+    public void setSwellHeight(int swellHeight) {
 		this.swellHeight = swellHeight;
 	}
 
-	public int getSwellPeriod() {
+    /**
+     * Gets swell period.
+     *
+     * @return the swell period
+     */
+    public int getSwellPeriod() {
 		return swellPeriod;
 	}
 
-	public void setSwellPeriod(int swellPeriod) {
+    /**
+     * Sets swell period.
+     *
+     * @param swellPeriod the swell period
+     */
+    public void setSwellPeriod(int swellPeriod) {
 		this.swellPeriod = swellPeriod;
 	}
 
-	public int getSwellDirection() {
+    /**
+     * Gets swell direction.
+     *
+     * @return the swell direction
+     */
+    public int getSwellDirection() {
 		return swellDirection;
 	}
 
-	public void setSwellDirection(int swellDirection) {
+    /**
+     * Sets swell direction.
+     *
+     * @param swellDirection the swell direction
+     */
+    public void setSwellDirection(int swellDirection) {
 		this.swellDirection = swellDirection;
 	}
 
-	public int getSeaState() {
+    /**
+     * Gets sea state.
+     *
+     * @return the sea state
+     */
+    public int getSeaState() {
 		return seaState;
 	}
 
-	public void setSeaState(int seaState) {
+    /**
+     * Sets sea state.
+     *
+     * @param seaState the sea state
+     */
+    public void setSeaState(int seaState) {
 		this.seaState = seaState;
 	}
 
-	public int getWaterTemp() {
+    /**
+     * Gets water temp.
+     *
+     * @return the water temp
+     */
+    public int getWaterTemp() {
 		return waterTemp;
 	}
 
-	public void setWaterTemp(int waterTemp) {
+    /**
+     * Sets water temp.
+     *
+     * @param waterTemp the water temp
+     */
+    public void setWaterTemp(int waterTemp) {
 		this.waterTemp = waterTemp;
 	}
 
-	public int getPrecipitation() {
+    /**
+     * Gets precipitation.
+     *
+     * @return the precipitation
+     */
+    public int getPrecipitation() {
 		return precipitation;
 	}
 
-	public void setPrecipitation(int precipitation) {
+    /**
+     * Sets precipitation.
+     *
+     * @param precipitation the precipitation
+     */
+    public void setPrecipitation(int precipitation) {
 		this.precipitation = precipitation;
 	}
 
-	public int getSalinity() {
+    /**
+     * Gets salinity.
+     *
+     * @return the salinity
+     */
+    public int getSalinity() {
 		return salinity;
 	}
 
-	public void setSalinity(int salinity) {
+    /**
+     * Sets salinity.
+     *
+     * @param salinity the salinity
+     */
+    public void setSalinity(int salinity) {
 		this.salinity = salinity;
 	}
 
-	public int getIce() {
+    /**
+     * Gets ice.
+     *
+     * @return the ice
+     */
+    public int getIce() {
 		return ice;
 	}
 
-	public void setIce(int ice) {
+    /**
+     * Sets ice.
+     *
+     * @param ice the ice
+     */
+    public void setIce(int ice) {
 		this.ice = ice;
 	}
 
-	public int getSpare() {
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
+    public int getSpare() {
 		return spare;
 	}
 
-	public void setSpare(int spare) {
+    /**
+     * Sets spare.
+     *
+     * @param spare the spare
+     */
+    public void setSpare(int spare) {
 		this.spare = spare;
 	}
 
-	public int getPosAcc() {
+    /**
+     * Gets pos acc.
+     *
+     * @return the pos acc
+     */
+    public int getPosAcc() {
 		return posAcc;
 	}
 
-	public void setPosAcc(int posAcc) {
+    /**
+     * Sets pos acc.
+     *
+     * @param posAcc the pos acc
+     */
+    public void setPosAcc(int posAcc) {
 		this.posAcc = posAcc;
 	}
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteExchange.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteExchange.java
@@ -22,10 +22,24 @@ import dk.dma.ais.binary.SixbitException;
  */
 public abstract class RouteExchange extends RouteMessage {
 
+    /**
+     * Instantiates a new Route exchange.
+     *
+     * @param dac the dac
+     * @param fi  the fi
+     */
     public RouteExchange(int dac, int fi) {
         super(dac, fi);
     }
 
+    /**
+     * Instantiates a new Route exchange.
+     *
+     * @param dac      the dac
+     * @param fi       the fi
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public RouteExchange(int dac, int fi, BinArray binArray) throws SixbitException {
         super(dac, fi, binArray);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteInformation.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteInformation.java
@@ -25,8 +25,38 @@ import dk.dma.ais.binary.SixbitException;
  */
 public abstract class RouteInformation extends RouteMessage {
 
+    /**
+     * The enum Route type.
+     */
     public enum RouteType {
-        NOT_AVAIABLE(0), MANDATORY(1), RECOMMENDED(2), ALTERNATIVE(3), RECOMMENDED_THROUGH_ICE(4), SHIP_ROUTE(5), CANCELLATION(
+        /**
+         * Not avaiable route type.
+         */
+        NOT_AVAIABLE(0),
+        /**
+         * Mandatory route type.
+         */
+        MANDATORY(1),
+        /**
+         * Recommended route type.
+         */
+        RECOMMENDED(2),
+        /**
+         * Alternative route type.
+         */
+        ALTERNATIVE(3),
+        /**
+         * Recommended through ice route type.
+         */
+        RECOMMENDED_THROUGH_ICE(4),
+        /**
+         * Ship route route type.
+         */
+        SHIP_ROUTE(5),
+        /**
+         * Cancellation route type.
+         */
+        CANCELLATION(
                 31);
 
         private int type;
@@ -35,6 +65,11 @@ public abstract class RouteInformation extends RouteMessage {
             this.type = type;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public int getType() {
             return type;
         }
@@ -45,11 +80,25 @@ public abstract class RouteInformation extends RouteMessage {
     private int senderClassification; // 3 bits: 0=ship, 1=authority
     private int routeType; // 5 bits
 
+    /**
+     * Instantiates a new Route information.
+     *
+     * @param dac the dac
+     * @param fi  the fi
+     */
     public RouteInformation(int dac, int fi) {
         super(dac, fi);
         this.waypoints = new ArrayList<>();
     }
 
+    /**
+     * Instantiates a new Route information.
+     *
+     * @param dac      the dac
+     * @param fi       the fi
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public RouteInformation(int dac, int fi, BinArray binArray) throws SixbitException {
         super(dac, fi, binArray);
     }
@@ -73,26 +122,56 @@ public abstract class RouteInformation extends RouteMessage {
         super.parse(binArray);
     }
 
+    /**
+     * Gets msg link id.
+     *
+     * @return the msg link id
+     */
     public int getMsgLinkId() {
         return msgLinkId;
     }
 
+    /**
+     * Sets msg link id.
+     *
+     * @param msgLinkId the msg link id
+     */
     public void setMsgLinkId(int msgLinkId) {
         this.msgLinkId = msgLinkId;
     }
 
+    /**
+     * Gets sender classification.
+     *
+     * @return the sender classification
+     */
     public int getSenderClassification() {
         return senderClassification;
     }
 
+    /**
+     * Sets sender classification.
+     *
+     * @param senderClassification the sender classification
+     */
     public void setSenderClassification(int senderClassification) {
         this.senderClassification = senderClassification;
     }
 
+    /**
+     * Gets route type.
+     *
+     * @return the route type
+     */
     public int getRouteType() {
         return routeType;
     }
 
+    /**
+     * Sets route type.
+     *
+     * @param routeType the route type
+     */
     public void setRouteType(int routeType) {
         this.routeType = routeType;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteMessage.java
@@ -27,21 +27,56 @@ import dk.dma.ais.message.AisPosition;
  */
 public abstract class RouteMessage extends AisApplicationMessage {
 
+    /**
+     * The Start month.
+     */
     protected int startMonth; // 4 bits
+    /**
+     * The Start day.
+     */
     protected int startDay; // 5 bits
+    /**
+     * The Start hour.
+     */
     protected int startHour; // 5 bits
+    /**
+     * The Start min.
+     */
     protected int startMin; // 6 bits
+    /**
+     * The Duration.
+     */
     protected int duration; // 18 bits: Minutes until end of validity 0=cancel
-                            // route
+    /**
+     * The Waypoint count.
+     */
+// route
     protected int waypointCount; // 5 bits: 0 - 16
+    /**
+     * The Waypoints.
+     */
     protected List<AisPosition> waypoints; // 55 bits each longitude 28 bit,
                                            // latitude 27 bit
 
+    /**
+     * Instantiates a new Route message.
+     *
+     * @param dac the dac
+     * @param fi  the fi
+     */
     public RouteMessage(int dac, int fi) {
         super(dac, fi);
         this.waypoints = new ArrayList<>();
     }
 
+    /**
+     * Instantiates a new Route message.
+     *
+     * @param dac      the dac
+     * @param fi       the fi
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public RouteMessage(int dac, int fi, BinArray binArray) throws SixbitException {
         super(dac, fi, binArray);
     }
@@ -63,6 +98,11 @@ public abstract class RouteMessage extends AisApplicationMessage {
         }
     }
 
+    /**
+     * Encode.
+     *
+     * @param encoder the encoder
+     */
     public void encode(SixbitEncoder encoder) {
         encoder.addVal(startMonth, 4);
         encoder.addVal(startDay, 5);
@@ -83,62 +123,137 @@ public abstract class RouteMessage extends AisApplicationMessage {
         return encoder;
     }
 
+    /**
+     * Gets start month.
+     *
+     * @return the start month
+     */
     public int getStartMonth() {
         return startMonth;
     }
 
+    /**
+     * Sets start month.
+     *
+     * @param startMonth the start month
+     */
     public void setStartMonth(int startMonth) {
         this.startMonth = startMonth;
     }
 
+    /**
+     * Gets start day.
+     *
+     * @return the start day
+     */
     public int getStartDay() {
         return startDay;
     }
 
+    /**
+     * Sets start day.
+     *
+     * @param startDay the start day
+     */
     public void setStartDay(int startDay) {
         this.startDay = startDay;
     }
 
+    /**
+     * Gets start hour.
+     *
+     * @return the start hour
+     */
     public int getStartHour() {
         return startHour;
     }
 
+    /**
+     * Sets start hour.
+     *
+     * @param startHour the start hour
+     */
     public void setStartHour(int startHour) {
         this.startHour = startHour;
     }
 
+    /**
+     * Gets start min.
+     *
+     * @return the start min
+     */
     public int getStartMin() {
         return startMin;
     }
 
+    /**
+     * Sets start min.
+     *
+     * @param startMin the start min
+     */
     public void setStartMin(int startMin) {
         this.startMin = startMin;
     }
 
+    /**
+     * Gets duration.
+     *
+     * @return the duration
+     */
     public int getDuration() {
         return duration;
     }
 
+    /**
+     * Sets duration.
+     *
+     * @param duration the duration
+     */
     public void setDuration(int duration) {
         this.duration = duration;
     }
 
+    /**
+     * Gets waypoint count.
+     *
+     * @return the waypoint count
+     */
     public int getWaypointCount() {
         return waypointCount;
     }
 
+    /**
+     * Sets waypoint count.
+     *
+     * @param waypointCount the waypoint count
+     */
     public void setWaypointCount(int waypointCount) {
         this.waypointCount = waypointCount;
     }
 
+    /**
+     * Gets waypoints.
+     *
+     * @return the waypoints
+     */
     public List<AisPosition> getWaypoints() {
         return waypoints;
     }
 
+    /**
+     * Sets waypoints.
+     *
+     * @param waypoints the waypoints
+     */
     public void setWaypoints(List<AisPosition> waypoints) {
         this.waypoints = waypoints;
     }
 
+    /**
+     * Add waypoint.
+     *
+     * @param waypoint the waypoint
+     */
     public void addWaypoint(AisPosition waypoint) {
         waypoints.add(waypoint);
         waypointCount = waypoints.size();

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteSuggestion.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteSuggestion.java
@@ -25,8 +25,22 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class RouteSuggestion extends RouteExchange {
 
+    /**
+     * The enum Route type.
+     */
     public enum RouteType {
-        MANDATORY(1), RECOMMENDED(2), ALTERNATIVE(3);
+        /**
+         * Mandatory route type.
+         */
+        MANDATORY(1),
+        /**
+         * Recommended route type.
+         */
+        RECOMMENDED(2),
+        /**
+         * Alternative route type.
+         */
+        ALTERNATIVE(3);
 
         private int type;
 
@@ -34,22 +48,42 @@ public class RouteSuggestion extends RouteExchange {
             this.type = type;
         }
 
+        /**
+         * Gets type.
+         *
+         * @return the type
+         */
         public int getType() {
             return type;
         }
     }
 
+    /**
+     * The constant DAC.
+     */
     public static final int DAC = 219;
+    /**
+     * The constant FI.
+     */
     public static final int FI = 2;
 
     private int msgLinkId; // 10 bits: Source specific running number linking
                            // binary messages
     private int routeType; // 5 bits
 
+    /**
+     * Instantiates a new Route suggestion.
+     */
     public RouteSuggestion() {
         super(DAC, FI);
     }
 
+    /**
+     * Instantiates a new Route suggestion.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public RouteSuggestion(BinArray binArray) throws SixbitException {
         super(DAC, FI, binArray);
     }
@@ -71,18 +105,38 @@ public class RouteSuggestion extends RouteExchange {
         super.parse(binArray);
     }
 
+    /**
+     * Gets msg link id.
+     *
+     * @return the msg link id
+     */
     public int getMsgLinkId() {
         return msgLinkId;
     }
 
+    /**
+     * Sets msg link id.
+     *
+     * @param msgLinkId the msg link id
+     */
     public void setMsgLinkId(int msgLinkId) {
         this.msgLinkId = msgLinkId;
     }
 
+    /**
+     * Gets route type.
+     *
+     * @return the route type
+     */
     public int getRouteType() {
         return routeType;
     }
 
+    /**
+     * Sets route type.
+     *
+     * @param routeType the route type
+     */
     public void setRouteType(int routeType) {
         this.routeType = routeType;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteSuggestionReply.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/RouteSuggestionReply.java
@@ -33,10 +33,19 @@ public class RouteSuggestionReply extends AisApplicationMessage {
      */
     private int response; // 6 bits
 
+    /**
+     * Instantiates a new Route suggestion reply.
+     */
     public RouteSuggestionReply() {
         super(0, 32);
     }
 
+    /**
+     * Instantiates a new Route suggestion reply.
+     *
+     * @param binArray the bin array
+     * @throws SixbitException the sixbit exception
+     */
     public RouteSuggestionReply(BinArray binArray) throws SixbitException {
         super(0, 32, binArray);
     }
@@ -57,26 +66,56 @@ public class RouteSuggestionReply extends AisApplicationMessage {
         return encoder;
     }
 
+    /**
+     * Gets msg link id.
+     *
+     * @return the msg link id
+     */
     public int getMsgLinkId() {
         return msgLinkId;
     }
 
+    /**
+     * Sets msg link id.
+     *
+     * @param msgLinkId the msg link id
+     */
     public void setMsgLinkId(int msgLinkId) {
         this.msgLinkId = msgLinkId;
     }
 
+    /**
+     * Gets ref msg link id.
+     *
+     * @return the ref msg link id
+     */
     public int getRefMsgLinkId() {
         return refMsgLinkId;
     }
 
+    /**
+     * Sets ref msg link id.
+     *
+     * @param refMsgLinkId the ref msg link id
+     */
     public void setRefMsgLinkId(int refMsgLinkId) {
         this.refMsgLinkId = refMsgLinkId;
     }
 
+    /**
+     * Gets response.
+     *
+     * @return the response
+     */
     public int getResponse() {
         return response;
     }
 
+    /**
+     * Sets response.
+     *
+     * @param response the response
+     */
     public void setResponse(int response) {
         this.response = response;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/SubArea.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/SubArea.java
@@ -46,6 +46,9 @@ public class SubArea {
 
     // private double resolution = 1000.0;
 
+    /**
+     * Instantiates a new Sub area.
+     */
     public SubArea() {}
 
     @Override
@@ -127,94 +130,209 @@ public class SubArea {
         return equalz;
     }
 
+    /**
+     * Gets raw area shape.
+     *
+     * @return the raw area shape
+     */
     public int getRawAreaShape() {
         return rawsSAreaShape;
     }
 
+    /**
+     * Gets raw e dim.
+     *
+     * @return the raw e dim
+     */
     public int getRawEDim() {
         return rawSEDim;
     }
 
+    /**
+     * Gets raw latitude.
+     *
+     * @return the raw latitude
+     */
     public int getRawLatitude() {
         return rawSLatitude;
     }
 
+    /**
+     * Gets raw left bound.
+     *
+     * @return the raw left bound
+     */
     public int getRawLeftBound() {
         return rawSLeftBound;
     }
 
+    /**
+     * Gets raw longitude.
+     *
+     * @return the raw longitude
+     */
     public int getRawLongitude() {
         return rawSLongitude;
     }
 
+    /**
+     * Gets raw n dim.
+     *
+     * @return the raw n dim
+     */
     public int getRawNDim() {
         return rawSNDim;
     }
 
+    /**
+     * Gets raw orient.
+     *
+     * @return the raw orient
+     */
     public int getRawOrient() {
         return rawSOrient;
     }
 
+    /**
+     * Gets raw p 1 angle.
+     *
+     * @return the raw p 1 angle
+     */
     public int getRawP1Angle() {
         return rawSP1Angle;
     }
 
+    /**
+     * Gets raw p 1 dist.
+     *
+     * @return the raw p 1 dist
+     */
     public int getRawP1Dist() {
         return rawSP1Dist;
     }
 
+    /**
+     * Gets raw p 2 angle.
+     *
+     * @return the raw p 2 angle
+     */
     public int getRawP2Angle() {
         return rawSP2Angle;
     }
 
+    /**
+     * Gets raw p 2 dist.
+     *
+     * @return the raw p 2 dist
+     */
     public int getRawP2Dist() {
         return rawSP2Dist;
     }
 
+    /**
+     * Gets raw p 3 angle.
+     *
+     * @return the raw p 3 angle
+     */
     public int getRawP3Angle() {
         return rawSP3Angle;
     }
 
+    /**
+     * Gets raw p 3 dist.
+     *
+     * @return the raw p 3 dist
+     */
     public int getRawP3Dist() {
         return rawSP3Dist;
     }
 
+    /**
+     * Gets raw p 4 angle.
+     *
+     * @return the raw p 4 angle
+     */
     public int getRawP4Angle() {
         return rawSP4Angle;
     }
 
+    /**
+     * Gets raw p 4 dist.
+     *
+     * @return the raw p 4 dist
+     */
     public int getRawP4Dist() {
         return rawSP4Dist;
     }
 
+    /**
+     * Gets raw precision.
+     *
+     * @return the raw precision
+     */
     public int getRawPrecision() {
         return rawSPrecision;
     }
 
+    /**
+     * Gets raw radius.
+     *
+     * @return the raw radius
+     */
     public int getRawRadius() {
         return rawSRadius;
     }
 
+    /**
+     * Gets raw right bound.
+     *
+     * @return the raw right bound
+     */
     public int getRawRightBound() {
         return rawSRightBound;
     }
 
+    /**
+     * Gets raw scale factor.
+     *
+     * @return the raw scale factor
+     */
     public int getRawScaleFactor() {
         return rawSScaleFactor;
     }
 
+    /**
+     * Gets spare.
+     *
+     * @return the spare
+     */
     public int getSpare() {
         return rawSSpare;
     }
 
+    /**
+     * Gets text.
+     *
+     * @return the text
+     */
     public int getText() {
         return sText;
     }
 
+    /**
+     * Gets text 1.
+     *
+     * @return the text 1
+     */
     public int getText1() {
         return sText2;
     }
 
+    /**
+     * Gets text 2.
+     *
+     * @return the text 2
+     */
     public int getText2() {
         return sText2;
     }
@@ -250,94 +368,209 @@ public class SubArea {
         return result;
     }
 
+    /**
+     * Sets raw area shape.
+     *
+     * @param rawsSAreaShape the raws s area shape
+     */
     public void setRawAreaShape(int rawsSAreaShape) {
         this.rawsSAreaShape = rawsSAreaShape;
     }
 
+    /**
+     * Sets raw e dim.
+     *
+     * @param rawSEDim the raw se dim
+     */
     public void setRawEDim(int rawSEDim) {
         this.rawSEDim = rawSEDim;
     }
 
+    /**
+     * Sets raw latitude.
+     *
+     * @param rawSLatitude the raw s latitude
+     */
     public void setRawLatitude(int rawSLatitude) {
         this.rawSLatitude = rawSLatitude;
     }
 
+    /**
+     * Sets raw left bound.
+     *
+     * @param rawSLeftBound the raw s left bound
+     */
     public void setRawLeftBound(int rawSLeftBound) {
         this.rawSLeftBound = rawSLeftBound;
     }
 
+    /**
+     * Sets raw longitude.
+     *
+     * @param rawSLongitude the raw s longitude
+     */
     public void setRawLongitude(int rawSLongitude) {
         this.rawSLongitude = rawSLongitude;
     }
 
+    /**
+     * Sets raw n dim.
+     *
+     * @param rawSNDim the raw sn dim
+     */
     public void setRawNDim(int rawSNDim) {
         this.rawSNDim = rawSNDim;
     }
 
+    /**
+     * Sets raw orient.
+     *
+     * @param rawSOrient the raw s orient
+     */
     public void setRawOrient(int rawSOrient) {
         this.rawSOrient = rawSOrient;
     }
 
+    /**
+     * Sets raw p 1 angle.
+     *
+     * @param rawSP1Angle the raw sp 1 angle
+     */
     public void setRawP1Angle(int rawSP1Angle) {
         this.rawSP1Angle = rawSP1Angle;
     }
 
+    /**
+     * Sets raw p 1 dist.
+     *
+     * @param rawSP1Dist the raw sp 1 dist
+     */
     public void setRawP1Dist(int rawSP1Dist) {
         this.rawSP1Dist = rawSP1Dist;
     }
 
+    /**
+     * Sets raw p 2 angle.
+     *
+     * @param rawSP2Angle the raw sp 2 angle
+     */
     public void setRawP2Angle(int rawSP2Angle) {
         this.rawSP2Angle = rawSP2Angle;
     }
 
+    /**
+     * Sets raw p 2 dist.
+     *
+     * @param rawSP2Dist the raw sp 2 dist
+     */
     public void setRawP2Dist(int rawSP2Dist) {
         this.rawSP2Dist = rawSP2Dist;
     }
 
+    /**
+     * Sets raw p 3 angle.
+     *
+     * @param rawSP3Angle the raw sp 3 angle
+     */
     public void setRawP3Angle(int rawSP3Angle) {
         this.rawSP3Angle = rawSP3Angle;
     }
 
+    /**
+     * Sets raw p 3 dist.
+     *
+     * @param rawSP3Dist the raw sp 3 dist
+     */
     public void setRawP3Dist(int rawSP3Dist) {
         this.rawSP3Dist = rawSP3Dist;
     }
 
+    /**
+     * Sets raw p 4 angle.
+     *
+     * @param rawSP4Angle the raw sp 4 angle
+     */
     public void setRawP4Angle(int rawSP4Angle) {
         this.rawSP4Angle = rawSP4Angle;
     }
 
+    /**
+     * Sets raw p 4 dist.
+     *
+     * @param rawSP4Dist the raw sp 4 dist
+     */
     public void setRawP4Dist(int rawSP4Dist) {
         this.rawSP4Dist = rawSP4Dist;
     }
 
+    /**
+     * Sets raw precision.
+     *
+     * @param rawSPrecision the raw s precision
+     */
     public void setRawPrecision(int rawSPrecision) {
         this.rawSPrecision = rawSPrecision;
     }
 
+    /**
+     * Sets raw radius.
+     *
+     * @param rawSRadius the raw s radius
+     */
     public void setRawRadius(int rawSRadius) {
         this.rawSRadius = rawSRadius;
     }
 
+    /**
+     * Sets raw right bound.
+     *
+     * @param rawSRightBound the raw s right bound
+     */
     public void setRawRightBound(int rawSRightBound) {
         this.rawSRightBound = rawSRightBound;
     }
 
+    /**
+     * Sets raw scale factor.
+     *
+     * @param rawSScaleFactor the raw s scale factor
+     */
     public void setRawScaleFactor(int rawSScaleFactor) {
         this.rawSScaleFactor = rawSScaleFactor;
     }
 
+    /**
+     * Sets spare.
+     *
+     * @param rawSSpare the raw s spare
+     */
     public void setSpare(int rawSSpare) {
         this.rawSSpare = rawSSpare;
     }
 
+    /**
+     * Sets text.
+     *
+     * @param sText the s text
+     */
     public void setText(int sText) {
         this.sText = sText;
     }
 
+    /**
+     * Sets text 1.
+     *
+     * @param sText1 the s text 1
+     */
     public void setText1(int sText1) {
         this.sText1 = sText1;
     }
 
+    /**
+     * Sets text 2.
+     *
+     * @param sText2 the s text 2
+     */
     public void setText2(int sText2) {
         this.sText2 = sText2;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/UnknownAsm.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/binary/UnknownAsm.java
@@ -26,10 +26,21 @@ public class UnknownAsm extends AisApplicationMessage {
 
     private BinArray binArray;
 
+    /**
+     * Instantiates a new Unknown asm.
+     *
+     * @param dac the dac
+     * @param fi  the fi
+     */
     public UnknownAsm(int dac, int fi) {
         super(dac, fi);
     }
 
+    /**
+     * Instantiates a new Unknown asm.
+     *
+     * @param binaryMessage the binary message
+     */
     public UnknownAsm(AisBinaryMessage binaryMessage) {
         this(binaryMessage.getDac(), binaryMessage.getFi());
         this.binArray = binaryMessage.getData();        

--- a/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/GatehouseFactory.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/GatehouseFactory.java
@@ -26,11 +26,15 @@ import dk.dma.ais.sentence.SentenceLine;
 import dk.dma.enav.model.Country;
 
 /**
+ * The type Gatehouse factory.
  *
  * @author Kasper Nielsen
  */
 public class GatehouseFactory extends ProprietaryFactory {
 
+    /**
+     * Instantiates a new Gatehouse factory.
+     */
     public GatehouseFactory() {
         super("GHP");
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/GatehouseSourceTag.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/GatehouseSourceTag.java
@@ -32,6 +32,15 @@ public class GatehouseSourceTag implements IProprietarySourceTag {
     private final Date timestamp;
     private final String orgSentence;
 
+    /**
+     * Instantiates a new Gatehouse source tag.
+     *
+     * @param baseMmsi    the base mmsi
+     * @param country     the country
+     * @param region      the region
+     * @param timestamp   the timestamp
+     * @param orgSentence the org sentence
+     */
     public GatehouseSourceTag(Integer baseMmsi, Country country, String region, Date timestamp, String orgSentence) {
         this.baseMmsi = baseMmsi;
         this.country = country;

--- a/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/IProprietarySourceTag.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/IProprietarySourceTag.java
@@ -25,29 +25,29 @@ public interface IProprietarySourceTag extends IProprietaryTag {
 
     /**
      * Time of message receival at source
-     * 
-     * @return
+     *
+     * @return timestamp
      */
     Date getTimestamp();
 
     /**
      * Country origin of message
-     * 
-     * @return
+     *
+     * @return country
      */
     Country getCountry();
 
     /**
      * Unique region identifier
-     * 
-     * @return
+     *
+     * @return region
      */
     String getRegion();
 
     /**
      * Base station MMSI
-     * 
-     * @return
+     *
+     * @return base mmsi
      */
     Integer getBaseMmsi();
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/IProprietaryTag.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/IProprietaryTag.java
@@ -21,8 +21,8 @@ public interface IProprietaryTag {
 
     /**
      * Get the original sentence
-     * 
-     * @return
+     *
+     * @return sentence
      */
     String getSentence();
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/ProprietaryFactory.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/proprietary/ProprietaryFactory.java
@@ -25,11 +25,15 @@ import java.util.ServiceLoader;
 import dk.dma.ais.sentence.SentenceLine;
 
 /**
- * 
+ * The type Proprietary factory.
+ *
  * @author Kasper Nielsen
  */
 public abstract class ProprietaryFactory {
 
+    /**
+     * The All factories.
+     */
     static Map<String, ProprietaryFactory> ALL_FACTORIES;
 
     static {
@@ -43,6 +47,11 @@ public abstract class ProprietaryFactory {
 
     private final String prefix;
 
+    /**
+     * Instantiates a new Proprietary factory.
+     *
+     * @param prefix the prefix
+     */
     public ProprietaryFactory(String prefix) {
         this.prefix = requireNonNull(prefix);
         if (prefix.length() != 3) {
@@ -50,31 +59,59 @@ public abstract class ProprietaryFactory {
         }
     }
 
+    /**
+     * Gets prefix.
+     *
+     * @return the prefix
+     */
     public String getPrefix() {
         return prefix;
     }
 
     /**
      * Return the tag for line, if matches, otherwise null is returned
-     * 
-     * @param line
-     * @return
+     *
+     * @param sl the sl
+     * @return tag
      */
     public abstract IProprietaryTag getTag(SentenceLine sl);
 
+    /**
+     * Gets all factories.
+     *
+     * @return the all factories
+     */
     public static Collection<ProprietaryFactory> getAllFactories() {
         return ALL_FACTORIES.values();
     }
 
+    /**
+     * Parse tag proprietary tag.
+     *
+     * @param sl the sl
+     * @return the proprietary tag
+     */
     public static IProprietaryTag parseTag(SentenceLine sl) {
         ProprietaryFactory psf = match(sl.getSentenceHead());
         return psf == null ? null : psf.getTag(sl);
     }
 
+    /**
+     * Is proprietary tag boolean.
+     *
+     * @param line the line
+     * @return the boolean
+     */
     public static boolean isProprietaryTag(String line) {
         return line != null && line.length() >= 5 && line.startsWith("$P");
     }
 
+    /**
+     * Match proprietary factory.
+     *
+     * @param line the line
+     * @return the proprietary factory
+     */
     public static ProprietaryFactory match(String line) {
         if (isProprietaryTag(line)) {
             String p = line.substring(2, 5);

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Abk.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Abk.java
@@ -24,17 +24,47 @@ public class Abk extends ParametricSentence {
      * Type of acknowledgement
      */
     public enum Result {
-        ADDRESSED_SUCCESS(0), ADDRESSED_NO_ACKNOWLEDGE(1), COULD_NOT_BROADCAST(2), BROADCAST_SENT(3), LATE_RECEPTION(4);
+        /**
+         * Addressed success result.
+         */
+        ADDRESSED_SUCCESS(0),
+        /**
+         * Addressed no acknowledge result.
+         */
+        ADDRESSED_NO_ACKNOWLEDGE(1),
+        /**
+         * Could not broadcast result.
+         */
+        COULD_NOT_BROADCAST(2),
+        /**
+         * Broadcast sent result.
+         */
+        BROADCAST_SENT(3),
+        /**
+         * Late reception result.
+         */
+        LATE_RECEPTION(4);
         private int res;
 
         private Result(int res) {
             this.res = res;
         }
 
+        /**
+         * Gets res.
+         *
+         * @return the res
+         */
         public int getRes() {
             return res;
         }
 
+        /**
+         * Parse int result.
+         *
+         * @param res the res
+         * @return the result
+         */
         public static Result parseInt(int res) {
             switch (res) {
             case 0:
@@ -59,12 +89,21 @@ public class Abk extends ParametricSentence {
     private int sequence;
     private Result result;
 
+    /**
+     * Instantiates a new Abk.
+     */
     public Abk() {
         super();
         this.destination = 0;
         this.formatter = "ABK";
     }
 
+    /**
+     * Is abk boolean.
+     *
+     * @param line the line
+     * @return the boolean
+     */
     public static boolean isAbk(String line) {
         return line.indexOf("$AIABK") >= 0;
     }
@@ -128,49 +167,99 @@ public class Abk extends ParametricSentence {
 
     /**
      * Returns if result indicates success
-     * 
-     * @return success
+     *
+     * @return success boolean
      */
     public boolean isSuccess() {
         return getResult() == Result.ADDRESSED_SUCCESS || getResult() == Result.BROADCAST_SENT;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public int getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(int destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets channel.
+     *
+     * @return the channel
+     */
     public Character getChannel() {
         return channel;
     }
 
+    /**
+     * Sets channel.
+     *
+     * @param channel the channel
+     */
     public void setChannel(Character channel) {
         this.channel = channel;
     }
 
+    /**
+     * Gets msg id.
+     *
+     * @return the msg id
+     */
     public int getMsgId() {
         return msgId;
     }
 
+    /**
+     * Sets msg id.
+     *
+     * @param msgId the msg id
+     */
     public void setMsgId(int msgId) {
         this.msgId = msgId;
     }
 
+    /**
+     * Gets sequence.
+     *
+     * @return the sequence
+     */
     public int getSequence() {
         return sequence;
     }
 
+    /**
+     * Sets sequence.
+     *
+     * @param sequence the sequence
+     */
     public void setSequence(int sequence) {
         this.sequence = sequence;
     }
 
+    /**
+     * Gets result.
+     *
+     * @return the result
+     */
     public Result getResult() {
         return result;
     }
 
+    /**
+     * Sets result.
+     *
+     * @param result the result
+     */
     public void setResult(Result result) {
         this.result = result;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Abm.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Abm.java
@@ -27,12 +27,21 @@ public class Abm extends SendSentence {
 
     private int destination;
 
+    /**
+     * Instantiates a new Abm.
+     */
     public Abm() {
         super();
         formatter = "ABM";
         channel = '0';
     }
 
+    /**
+     * Is abm boolean.
+     *
+     * @param line the line
+     * @return the boolean
+     */
     public static boolean isAbm(String line) {
         return line.indexOf("!AIABM") >= 0 || line.indexOf("!BSABM") >= 0;
     }
@@ -47,13 +56,14 @@ public class Abm extends SendSentence {
         encodedFields.add(4, Integer.toString(destination));
         return finalEncode();
     }
-    
+
     /**
      * Helper method parsing line to SentenceLine and passing to parse
-     * @param line
-     * @return
-     * @throws SentenceException
-     * @throws SixbitException 
+     *
+     * @param line the line
+     * @return int
+     * @throws SentenceException the sentence exception
+     * @throws SixbitException   the sixbit exception
      */
     public int parse(String line) throws SentenceException, SixbitException {
         return parse(new SentenceLine(line));
@@ -62,8 +72,8 @@ public class Abm extends SendSentence {
     /**
      * Implemented parse method. See {@link EncapsulatedSentence}
      * 
-     * @throws SentenceException
-     * @throws SixbitException
+     * @throws SentenceException a Sentence Exception
+     * @throws SixbitException a Sixbit Exception
      */
     @Override
     public int parse(SentenceLine sl) throws SentenceException, SixbitException {
@@ -106,14 +116,34 @@ public class Abm extends SendSentence {
         return 1;
     }
 
+    /**
+     * Gets destination.
+     *
+     * @return the destination
+     */
     public int getDestination() {
         return destination;
     }
 
+    /**
+     * Sets destination.
+     *
+     * @param destination the destination
+     */
     public void setDestination(int destination) {
         this.destination = destination;
     }
 
+    /**
+     * Gets ais message.
+     *
+     * @param mmsi       the mmsi
+     * @param repeat     the repeat
+     * @param retransmit the retransmit
+     * @return the ais message
+     * @throws SentenceException the sentence exception
+     * @throws SixbitException   the sixbit exception
+     */
     public AisMessage getAisMessage(int mmsi, int repeat, int retransmit) throws SentenceException, SixbitException {
         AisMessage aisMessage;
         if (msgId == 12) {
@@ -141,13 +171,13 @@ public class Abm extends SendSentence {
 
     /**
      * Make a single VDM from this ABM
-     * 
-     * @param mmsi
-     * @param repeat
-     * @param retransmit
-     * @return
-     * @throws SixbitException
-     * @throws SentenceException
+     *
+     * @param mmsi       the mmsi
+     * @param repeat     the repeat
+     * @param retransmit the retransmit
+     * @return vdm
+     * @throws SixbitException   the sixbit exception
+     * @throws SentenceException the sentence exception
      */
     public Vdm makeVdm(int mmsi, int repeat, int retransmit) throws SixbitException, SentenceException {
         AisMessage aisMessage = getAisMessage(mmsi, repeat, retransmit);

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/AnySentence.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/AnySentence.java
@@ -24,6 +24,9 @@ import dk.dma.ais.binary.SixbitException;
  */
 public class AnySentence extends Sentence {
 
+    /**
+     * The Any fields.
+     */
     List<String> anyFields = new ArrayList<>();
 
     @Override
@@ -43,6 +46,11 @@ public class AnySentence extends Sentence {
         return super.finalEncode();
     }
 
+    /**
+     * Add field.
+     *
+     * @param field the field
+     */
     public void addField(String field) {
         anyFields.add(field);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Bbm.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Bbm.java
@@ -25,11 +25,20 @@ import dk.dma.ais.message.AisMessage8;
  */
 public class Bbm extends SendSentence {
 
+    /**
+     * Instantiates a new Bbm.
+     */
     public Bbm() {
         formatter = "BBM";
         channel = '0';
     }
 
+    /**
+     * Is bbm boolean.
+     *
+     * @param line the line
+     * @return the boolean
+     */
     public static boolean isBbm(String line) {
         return line.indexOf("!AIBBM") >= 0 || line.indexOf("!BSBBM") >= 0;
     }
@@ -42,14 +51,22 @@ public class Bbm extends SendSentence {
         super.encode();
         return finalEncode();
     }
-        
+
+    /**
+     * Parse int.
+     *
+     * @param line the line
+     * @return the int
+     * @throws SentenceException the sentence exception
+     * @throws SixbitException   the sixbit exception
+     */
     public int parse(String line) throws SentenceException, SixbitException {
         return parse(new SentenceLine(line));
     }
 
     /**
      * Implemented parse method. See {@link EncapsulatedSentence}
-     * @throws SixbitException 
+     * @throws SixbitException a SixbitException
      */
     @Override
     public int parse(SentenceLine sl) throws SentenceException, SixbitException {
@@ -84,6 +101,15 @@ public class Bbm extends SendSentence {
         return 1;
     }
 
+    /**
+     * Gets ais message.
+     *
+     * @param mmsi   the mmsi
+     * @param repeat the repeat
+     * @return the ais message
+     * @throws SentenceException the sentence exception
+     * @throws SixbitException   the sixbit exception
+     */
     public AisMessage getAisMessage(int mmsi, int repeat) throws SentenceException, SixbitException {
         AisMessage aisMessage;
         if (msgId == 14) {
@@ -108,12 +134,12 @@ public class Bbm extends SendSentence {
 
     /**
      * Make a single VDM from this BBM
-     * 
-     * @param mmsi
-     * @param repeat
-     * @return
-     * @throws SixbitException
-     * @throws SentenceException
+     *
+     * @param mmsi   the mmsi
+     * @param repeat the repeat
+     * @return vdm
+     * @throws SixbitException   the sixbit exception
+     * @throws SentenceException the sentence exception
      */
     public Vdm makeVdm(int mmsi, int repeat) throws SixbitException, SentenceException {
         AisMessage aisMessage = getAisMessage(mmsi, repeat);

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlock.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlock.java
@@ -38,8 +38,9 @@ public class CommentBlock {
 
     /**
      * Add line containing comment block
-     * 
-     * @param line
+     *
+     * @param line the line
+     * @throws CommentBlockException the comment block exception
      */
     public void addLine(String line) throws CommentBlockException {
         // Make line object and parse
@@ -80,17 +81,18 @@ public class CommentBlock {
 
     /**
      * Get number of entries in comment block
-     * @return
+     *
+     * @return size
      */
     public int getSize() {
         return parameterMap.size();
     }
-    
+
     /**
      * Get string value for parameter code
-     * 
-     * @param parameter
-     * @return
+     *
+     * @param parameter the parameter
+     * @return string
      */
     public String getString(String parameter) {
         return parameterMap.get(parameter);
@@ -98,9 +100,9 @@ public class CommentBlock {
 
     /**
      * Add key value pair with string value
-     * 
-     * @param parameter
-     * @param value
+     *
+     * @param parameter the parameter
+     * @param value     the value
      */
     public void addString(String parameter, String value) {
         parameterMap.put(parameter, value);
@@ -108,9 +110,9 @@ public class CommentBlock {
 
     /**
      * Add integer value
-     * 
-     * @param parameter
-     * @param value
+     *
+     * @param parameter the parameter
+     * @param value     the value
      */
     public void addInt(String parameter, int value) {
         parameterMap.put(parameter, Integer.toString(value));
@@ -118,8 +120,8 @@ public class CommentBlock {
 
     /**
      * Add timestamp
-     * 
-     * @param timestamp
+     *
+     * @param timestamp the timestamp
      */
     public void addTimestamp(Date timestamp) {
         parameterMap.put("c", Long.toString(timestamp.getTime() / 1000));
@@ -127,9 +129,9 @@ public class CommentBlock {
 
     /**
      * Get integer value of parameter code
-     * 
-     * @param parameter
-     * @return
+     *
+     * @param parameter the parameter
+     * @return int
      */
     public Integer getInt(String parameter) {
         String val = parameterMap.get(parameter);
@@ -142,9 +144,9 @@ public class CommentBlock {
 
     /**
      * Get long value of parameter code
-     * 
-     * @param parameter
-     * @return
+     *
+     * @param parameter the parameter
+     * @return long
      */
     public Long getLong(String parameter) {
         String val = parameterMap.get(parameter);
@@ -157,8 +159,8 @@ public class CommentBlock {
 
     /**
      * Get timestamp in tag
-     * 
-     * @return
+     *
+     * @return timestamp
      */
     public Long getTimestamp() {
         return getLong("c");
@@ -166,9 +168,9 @@ public class CommentBlock {
 
     /**
      * Determine if parameter exists in comment block
-     * 
-     * @param parameter
-     * @return
+     *
+     * @param parameter the parameter
+     * @return boolean
      */
     public boolean contains(String parameter) {
         return parameterMap.containsKey(parameter);
@@ -176,9 +178,9 @@ public class CommentBlock {
 
     /**
      * Determine if a line contains comment block
-     * 
-     * @param line
-     * @return
+     *
+     * @param line the line
+     * @return boolean
      */
     public static boolean hasCommentBlock(String line) {
         return line.length() > 0 && line.charAt(0) == '\\';
@@ -186,8 +188,8 @@ public class CommentBlock {
 
     /**
      * Determine if comment block is completed. That is no unfinished groups.
-     * 
-     * @return
+     *
+     * @return boolean
      */
     public boolean isFinished() {
         return lastGroupId == null;
@@ -195,8 +197,8 @@ public class CommentBlock {
 
     /**
      * Get id of last group
-     * 
-     * @return
+     *
+     * @return last group id
      */
     public String getLastGroupId() {
         return lastGroupId;
@@ -204,8 +206,8 @@ public class CommentBlock {
 
     /**
      * Get total number of lines in last group
-     * 
-     * @return
+     *
+     * @return total lines
      */
     public int getTotalLines() {
         return totalLines;
@@ -213,8 +215,8 @@ public class CommentBlock {
 
     /**
      * Determine if comment block contains any key value pairs
-     * 
-     * @return
+     *
+     * @return boolean
      */
     public boolean isEmpty() {
         return parameterMap.size() == 0;
@@ -222,8 +224,8 @@ public class CommentBlock {
 
     /**
      * Encode comment block in 80 character lines
-     * 
-     * @return
+     *
+     * @return string
      */
     public String encode() {
         return encode(80);
@@ -231,10 +233,9 @@ public class CommentBlock {
 
     /**
      * Encode comment block in a number of lines
-     * 
-     * @param maxLen
-     *            Maximum line length
-     * @return
+     *
+     * @param maxLen Maximum line length
+     * @return string
      */
     public String encode(int maxLen) {
         // Get all pairs

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockException.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockException.java
@@ -21,6 +21,11 @@ public class CommentBlockException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new Comment block exception.
+     *
+     * @param msg the msg
+     */
     public CommentBlockException(String msg) {
         super(msg);
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -32,6 +32,12 @@ public class CommentBlockLine {
     private String groupId;
     private int checksum;
 
+    /**
+     * Parse.
+     *
+     * @param line the line
+     * @throws CommentBlockException the comment block exception
+     */
     public void parse(String line) throws CommentBlockException {
         parameterMap = new HashMap<>();
         int start = -1;
@@ -125,18 +131,38 @@ public class CommentBlockLine {
         }
     }
 
+    /**
+     * Gets total lines.
+     *
+     * @return the total lines
+     */
     public Integer getTotalLines() {
         return totalLines;
     }
 
+    /**
+     * Gets line number.
+     *
+     * @return the line number
+     */
     public Integer getLineNumber() {
         return lineNumber;
     }
 
+    /**
+     * Gets group id.
+     *
+     * @return the group id
+     */
     public String getGroupId() {
         return groupId;
     }
 
+    /**
+     * Gets parameter map.
+     *
+     * @return the parameter map
+     */
     public Map<String, String> getParameterMap() {
         return parameterMap;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/EncapsulatedSentence.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/EncapsulatedSentence.java
@@ -24,15 +24,42 @@ import dk.dma.ais.message.AisMessage;
  */
 public abstract class EncapsulatedSentence extends Sentence {
 
+    /**
+     * The Msg id.
+     */
     protected int msgId;
+    /**
+     * The Total.
+     */
     protected int total;
+    /**
+     * The Sequence.
+     */
     protected Integer sequence;
     private int lastSeq = -1;
+    /**
+     * The Num.
+     */
     protected int num;
+    /**
+     * The Channel.
+     */
     protected Character channel;
+    /**
+     * The Bin array.
+     */
     protected BinArray binArray = new BinArray();
+    /**
+     * The Complete packet.
+     */
     protected boolean completePacket;
+    /**
+     * The Sixbit string.
+     */
     protected StringBuilder sixbitString = new StringBuilder();
+    /**
+     * The Pad bits.
+     */
     protected int padBits;
 
     /**
@@ -95,60 +122,100 @@ public abstract class EncapsulatedSentence extends Sentence {
         encodedFields.add(Integer.toString(padBits));
     }
 
+    /**
+     * Gets msg id.
+     *
+     * @return the msg id
+     */
     public int getMsgId() {
         return msgId;
     }
 
+    /**
+     * Sets msg id.
+     *
+     * @param msgId the msg id
+     */
     public void setMsgId(int msgId) {
         this.msgId = msgId;
     }
 
+    /**
+     * Gets sequence.
+     *
+     * @return the sequence
+     */
     public int getSequence() {
         return sequence;
     }
 
+    /**
+     * Sets sequence.
+     *
+     * @param sequence the sequence
+     */
     public void setSequence(int sequence) {
         this.sequence = sequence;
     }
 
     /**
      * Get total number of actual sentences
-     * 
+     *
      * @return number of sentences
      */
     public int getTotal() {
         return total;
     }
 
+    /**
+     * Sets total.
+     *
+     * @param total the total
+     */
     public void setTotal(int total) {
         this.total = total;
     }
 
     /**
      * Get sentence number
-     * 
-     * @return
+     *
+     * @return num
      */
     public int getNum() {
         return num;
     }
 
+    /**
+     * Sets num.
+     *
+     * @param num the num
+     */
     public void setNum(int num) {
         this.num = num;
     }
 
+    /**
+     * Gets channel.
+     *
+     * @return the channel
+     */
     public Character getChannel() {
         return channel;
     }
 
+    /**
+     * Sets channel.
+     *
+     * @param channel the channel
+     */
     public void setChannel(Character channel) {
         this.channel = channel;
     }
 
     /**
      * Get binary encapsulated data
-     * 
-     * @return
+     *
+     * @return bin array
      */
     public BinArray getBinArray() {
         return binArray;
@@ -156,8 +223,8 @@ public abstract class EncapsulatedSentence extends Sentence {
 
     /**
      * Set binary encapsulated data
-     * 
-     * @param binArray
+     *
+     * @param binArray the bin array
      */
     public void setBinArray(BinArray binArray) {
         this.binArray = binArray;
@@ -165,9 +232,9 @@ public abstract class EncapsulatedSentence extends Sentence {
 
     /**
      * Set binary part and pad bits from encoder
-     * 
-     * @param encoder
-     * @throws SixbitException
+     *
+     * @param encoder the encoder
+     * @throws SixbitException the sixbit exception
      */
     public void setEncodedMessage(SixbitEncoder encoder) throws SixbitException {
         sixbitString = new StringBuilder(encoder.encode());
@@ -176,9 +243,9 @@ public abstract class EncapsulatedSentence extends Sentence {
 
     /**
      * Set the binary encapsulated data from AIS message
-     * 
-     * @param aisMessage
-     * @throws SixbitException
+     *
+     * @param aisMessage the ais message
+     * @throws SixbitException the sixbit exception
      */
     public void setMessageData(AisMessage aisMessage) throws SixbitException {
         this.msgId = aisMessage.getMsgId();
@@ -187,11 +254,18 @@ public abstract class EncapsulatedSentence extends Sentence {
         padBits = encoder.getPadBits();
     }
 
+    /**
+     * Gets pad bits.
+     *
+     * @return the pad bits
+     */
     public int getPadBits() {
         return padBits;
     }
 
     /**
+     * Is complete packet boolean.
+     *
      * @return is complete packet has been received
      */
     public boolean isCompletePacket() {
@@ -200,17 +274,27 @@ public abstract class EncapsulatedSentence extends Sentence {
 
     /**
      * Set the six bit string of the sentence
-     * 
-     * @param sixbitString
+     *
+     * @param sixbitString the sixbit string
      */
     public void setSixbitString(String sixbitString) {
         this.sixbitString = new StringBuilder(sixbitString);
     }
 
+    /**
+     * Sets pad bits.
+     *
+     * @param padBits the pad bits
+     */
     public void setPadBits(int padBits) {
         this.padBits = padBits;
     }
 
+    /**
+     * Gets sixbit string.
+     *
+     * @return the sixbit string
+     */
     public String getSixbitString() {
         return sixbitString.toString();
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SendSentence.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SendSentence.java
@@ -38,9 +38,9 @@ public abstract class SendSentence extends EncapsulatedSentence {
 
     /**
      * Set binary content from binary application specific message
-     * 
-     * @param sentenceStr
-     * @throws SixbitException
+     *
+     * @param msg the msg
+     * @throws SixbitException the sixbit exception
      */
     public void setBinaryData(AisBinaryMessage msg) throws SixbitException {
         this.msgId = msg.getMsgId();
@@ -51,9 +51,9 @@ public abstract class SendSentence extends EncapsulatedSentence {
 
     /**
      * Set binary content from AIS message 12
-     * 
-     * @param sentenceStr
-     * @throws SixbitException
+     *
+     * @param msg the msg
+     * @throws SixbitException the sixbit exception
      */
     public void setTextData(AisMessage12 msg) throws SixbitException {
         this.msgId = msg.getMsgId();
@@ -62,9 +62,9 @@ public abstract class SendSentence extends EncapsulatedSentence {
 
     /**
      * Set binary content from AIS message 14
-     * 
-     * @param sentenceStr
-     * @throws SixbitException
+     *
+     * @param msg the msg
+     * @throws SixbitException the sixbit exception
      */
     public void setTextData(AisMessage14 msg) throws SixbitException {
         this.msgId = msg.getMsgId();
@@ -86,7 +86,7 @@ public abstract class SendSentence extends EncapsulatedSentence {
 
     /**
      * Split sentence to multiple sentences to agree with the 80 character max
-     * 
+     *
      * @return array of sentences
      */
     public SendSentence[] split() {

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Sentence.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Sentence.java
@@ -30,43 +30,81 @@ import java.util.List;
  */
 public abstract class Sentence {
 
+    /**
+     * The Delimiter.
+     */
     protected String delimiter = "!";
+    /**
+     * The Talker.
+     */
     protected String talker;
+    /**
+     * The Formatter.
+     */
     protected String formatter;
+    /**
+     * The Checksum.
+     */
     protected int checksum;
+    /**
+     * The Msg checksum.
+     */
     protected String msgChecksum;
+    /**
+     * The Sentence str.
+     */
     protected String sentenceStr;
+    /**
+     * The Org lines.
+     */
     protected List<String> orgLines = new ArrayList<>();
+    /**
+     * The Raw sentences.
+     */
     protected List<String> rawSentences = new ArrayList<>();
+    /**
+     * The Encoded fields.
+     */
     protected LinkedList<String> encodedFields;
+    /**
+     * The Comment block.
+     */
     protected CommentBlock commentBlock;
+    /**
+     * The Tags.
+     */
     protected LinkedList<IProprietaryTag> tags; // Possible proprietary source tags for the message
+    /**
+     * The Mssis timestamp.
+     */
     protected Date mssisTimestamp;
 
     /**
      * Abstract method that all sentence classes must implement
-     * 
+     * <p>
      * The method handles assembly and extraction of the 6-bit data from sentences. The sentence is expected to be in order.
-     * 
+     * <p>
      * It will return an error if received line is out of order or from a new sequence before the previous one is finished.
-     * 
-     * @param line
+     *
+     * @param sl the sl
      * @return 0 Complete packet - 1 Incomplete packet
+     * @throws SentenceException the sentence exception
+     * @throws SixbitException   the sixbit exception
      */
     public abstract int parse(SentenceLine sl) throws SentenceException, SixbitException;
 
     /**
      * Get an encoded sentence
-     * 
-     * @return
+     *
+     * @return encoded
      */
     public abstract String getEncoded();
 
     /**
      * Basic parse of line into sentence parts
-     * 
-     * @param line
-     * @throws SentenceException
+     *
+     * @param sl the sl
+     * @throws SentenceException the sentence exception
      */
     protected void baseParse(SentenceLine sl) throws SentenceException {
         this.orgLines.add(sl.getLine());
@@ -98,6 +136,12 @@ public abstract class Sentence {
         mssisTimestamp = findMssisTimestamp(sl);
     }
 
+    /**
+     * Add single comment block.
+     *
+     * @param line the line
+     * @throws SentenceException the sentence exception
+     */
     public void addSingleCommentBlock(String line) throws SentenceException {
         this.orgLines.add(line);
         addCommentBlock(line);
@@ -124,7 +168,7 @@ public abstract class Sentence {
 
     /**
      * Method to finalize the encoding and return sentence
-     * 
+     *
      * @return final sentence
      */
     protected String finalEncode() {
@@ -154,10 +198,10 @@ public abstract class Sentence {
 
     /**
      * Calculate checksum of sentence
-     * 
-     * @param sentence
-     * @return
-     * @throws SentenceException
+     *
+     * @param sentence the sentence
+     * @return checksum
+     * @throws SentenceException the sentence exception
      */
     public static int getChecksum(String sentence) throws SentenceException {
         int checksum = 0;
@@ -176,9 +220,9 @@ public abstract class Sentence {
 
     /**
      * Get checksum string representation
-     * 
-     * @param checksum
-     * @return
+     *
+     * @param checksum the checksum
+     * @return string checksum
      */
     public static String getStringChecksum(int checksum) {
         String strChecksum = Integer.toString(checksum, 16).toUpperCase();
@@ -190,8 +234,9 @@ public abstract class Sentence {
 
     /**
      * Try to get the proprietary MSSIS timestamp appended to the NMEA sentence
-     * 
-     * @return
+     *
+     * @param sentenceLine the sentence line
+     * @return date
      */
     public static Date findMssisTimestamp(SentenceLine sentenceLine) {
         if (sentenceLine == null) {
@@ -211,10 +256,11 @@ public abstract class Sentence {
         }
         return null;
     }
-    
+
     /**
      * Get found MSSIS timestamp
-     * @return
+     *
+     * @return mssis timestamp
      */
     public Date getMssisTimestamp() {
         return mssisTimestamp;
@@ -222,8 +268,8 @@ public abstract class Sentence {
 
     /**
      * Try to get timestamp in this order: Comment block timestamp, proprietary tag timestamp and MSSIS timestamp
-     * 
-     * @return
+     *
+     * @return timestamp
      */
     public Date getTimestamp() {
         // Try comment block first
@@ -249,6 +295,13 @@ public abstract class Sentence {
         return mssisTimestamp;
     }
 
+    /**
+     * Parse int int.
+     *
+     * @param str the str
+     * @return the int
+     * @throws SentenceException the sentence exception
+     */
     public static int parseInt(String str) throws SentenceException {
         if (str == null || str.length() == 0) {
             throw new SentenceException("Invalid integer field: " + str);
@@ -262,9 +315,9 @@ public abstract class Sentence {
 
     /**
      * Determine if a line seems to contain a sentence There should be a ! or $
-     * 
-     * @param line
-     * @return
+     *
+     * @param line the line
+     * @return boolean
      */
     public static boolean hasSentence(String line) {
         return line.indexOf('!') >= 0 || line.indexOf('$') >= 0;
@@ -272,8 +325,8 @@ public abstract class Sentence {
 
     /**
      * Get original lines for this sentence
-     * 
-     * @return
+     *
+     * @return org lines
      */
     public List<String> getOrgLines() {
         return orgLines;
@@ -281,8 +334,8 @@ public abstract class Sentence {
 
     /**
      * Get original lines joined by carriage return line feed
-     * 
-     * @return
+     *
+     * @return org lines joined
      */
     public String getOrgLinesJoined() {
         return StringUtils.join(orgLines.iterator(), "\r\n");
@@ -290,8 +343,8 @@ public abstract class Sentence {
 
     /**
      * Get original raw sentences without any prefix
-     * 
-     * @return
+     *
+     * @return raw sentences
      */
     public List<String> getRawSentences() {
         return rawSentences;
@@ -299,8 +352,8 @@ public abstract class Sentence {
 
     /**
      * Get original raw sentences without any prefix joined by carriage return line feed
-     * 
-     * @return
+     *
+     * @return raw sentences joined
      */
     public String getRawSentencesJoined() {
         return StringUtils.join(rawSentences.iterator(), "\r\n");
@@ -308,8 +361,8 @@ public abstract class Sentence {
 
     /**
      * Set talker
-     * 
-     * @param talker
+     *
+     * @param talker the talker
      */
     public void setTalker(String talker) {
         this.talker = talker;
@@ -317,8 +370,8 @@ public abstract class Sentence {
 
     /**
      * Set delimiter
-     * 
-     * @param delimiter
+     *
+     * @param delimiter the delimiter
      */
     public void setDelimiter(String delimiter) {
         this.delimiter = delimiter;
@@ -326,8 +379,8 @@ public abstract class Sentence {
 
     /**
      * Set formatter
-     * 
-     * @param formatter
+     *
+     * @param formatter the formatter
      */
     public void setFormatter(String formatter) {
         this.formatter = formatter;
@@ -335,8 +388,8 @@ public abstract class Sentence {
 
     /**
      * Get possible comment block
-     * 
-     * @return
+     *
+     * @return comment block
      */
     public CommentBlock getCommentBlock() {
         return commentBlock;
@@ -344,21 +397,26 @@ public abstract class Sentence {
 
     /**
      * Get all tags
-     * 
-     * @return
+     *
+     * @return tags
      */
     public LinkedList<IProprietaryTag> getTags() {
         return tags;
     }
 
+    /**
+     * Sets tags.
+     *
+     * @param tags the tags
+     */
     public void setTags(LinkedList<IProprietaryTag> tags) {
         this.tags = tags;
     }
 
     /**
      * Return the LAST source tag (closest to AIS sentence)
-     * 
-     * @return
+     *
+     * @return source tag
      */
     public IProprietarySourceTag getSourceTag() {
         if (tags == null) {
@@ -376,8 +434,8 @@ public abstract class Sentence {
 
     /**
      * Add tag (to front)
-     * 
-     * @param sourceTag
+     *
+     * @param tag the tag
      */
     public void setTag(IProprietaryTag tag) {
         if (this.tags == null) {
@@ -387,13 +445,14 @@ public abstract class Sentence {
     }
 
     /**
-     * Convert any sentence to new sentence with !<talker><formatter>,....,
-     * 
-     * @param sentence
-     * @param talker
-     * @param formatter
-     * @return
-     * @throws SentenceException
+     * Convert any sentence to new sentence with !
+     * <pre>{@code <talker><formatter>,...., }</pre>
+     *
+     * @param sentence  the sentence
+     * @param talker    the talker
+     * @param formatter the formatter
+     * @return string
+     * @throws SentenceException the sentence exception
      */
     public static String convert(String sentence, String talker, String formatter) throws SentenceException {
         String newSentence = sentence.trim();

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SentenceException.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SentenceException.java
@@ -29,24 +29,49 @@ public class SentenceException extends Exception {
 
     private final Deque<String> sentenceTrace;
 
+    /**
+     * Instantiates a new Sentence exception.
+     */
     public SentenceException() {
         sentenceTrace = null;
     }
 
+    /**
+     * Instantiates a new Sentence exception.
+     *
+     * @param msg the msg
+     */
     public SentenceException(String msg) {
         super(msg);
         sentenceTrace = null;
-    } 
+    }
 
+    /**
+     * Instantiates a new Sentence exception.
+     *
+     * @param msg           the msg
+     * @param sentenceTrace the sentence trace
+     */
     public SentenceException(String msg, Deque<String> sentenceTrace) {
         super(msg + "\nSentence trace:\n---\n" + StringUtils.join(sentenceTrace, "\n") + "\n---\n");
         this.sentenceTrace = sentenceTrace;
     }
 
+    /**
+     * Instantiates a new Sentence exception.
+     *
+     * @param e             the e
+     * @param sentenceTrace the sentence trace
+     */
     public SentenceException(SentenceException e, Deque<String> sentenceTrace) {
         this(e.getMessage(), sentenceTrace);
     }
 
+    /**
+     * Gets possible proprietary tag.
+     *
+     * @return the possible proprietary tag
+     */
     public String getPossibleProprietaryTag() {
         String possibleProprietaryTag = null;
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SentenceLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/SentenceLine.java
@@ -51,12 +51,23 @@ public class SentenceLine {
         }
     }
 
+    /**
+     * Instantiates a new Sentence line.
+     */
     public SentenceLine() {}
 
+    /**
+     * Instantiates a new Sentence line.
+     *
+     * @param line the line
+     */
     public SentenceLine(String line) {
         parse(line);
     }
 
+    /**
+     * Clear.
+     */
     public void clear() {
         line = null;
         talker = null;
@@ -69,6 +80,11 @@ public class SentenceLine {
         checksumField = -1;
     }
 
+    /**
+     * Parse.
+     *
+     * @param line the line
+     */
     public void parse(String line) {
         clear();
         this.line = line;
@@ -146,6 +162,12 @@ public class SentenceLine {
         }
     }
 
+    /**
+     * Is formatter boolean.
+     *
+     * @param formatters the formatters
+     * @return the boolean
+     */
     public boolean isFormatter(String... formatters) {
         if (formatter == null) {
             return false;
@@ -158,10 +180,20 @@ public class SentenceLine {
         return false;
     }
 
+    /**
+     * Has sentence boolean.
+     *
+     * @return the boolean
+     */
     public boolean hasSentence() {
         return sentence != null;
     }
 
+    /**
+     * Gets postfix start.
+     *
+     * @return the postfix start
+     */
     public int getPostfixStart() {
         if (checksumField < 0) {
             return -1;
@@ -169,6 +201,11 @@ public class SentenceLine {
         return checksumField + 1;
     }
 
+    /**
+     * Is checksum match boolean.
+     *
+     * @return the boolean
+     */
     public boolean isChecksumMatch() {
         String strChecksum = getChecksumField();
         if (strChecksum == null) {
@@ -184,18 +221,38 @@ public class SentenceLine {
         return true;
     }
 
+    /**
+     * Gets sentence head.
+     *
+     * @return the sentence head
+     */
     public String getSentenceHead() {
         return delimiter == null || fields.size() == 0 ? null : fields.get(0);
     }
 
+    /**
+     * Is proprietary boolean.
+     *
+     * @return the boolean
+     */
     public boolean isProprietary() {
         return ProprietaryFactory.isProprietaryTag(getSentenceHead());
     }
 
+    /**
+     * Gets checksum.
+     *
+     * @return the checksum
+     */
     public int getChecksum() {
         return checksum;
     }
 
+    /**
+     * Gets checksum string.
+     *
+     * @return the checksum string
+     */
     public String getChecksumString() {
         String strChecksum = Integer.toString(checksum, 16).toUpperCase();
         if (strChecksum.length() < 2) {
@@ -204,58 +261,128 @@ public class SentenceLine {
         return strChecksum;
     }
 
+    /**
+     * Gets checksum field.
+     *
+     * @return the checksum field
+     */
     public String getChecksumField() {
         return this.checksumField >= 0 ? fields.get(this.checksumField) : null;
     }
 
+    /**
+     * Gets line.
+     *
+     * @return the line
+     */
     public String getLine() {
         return line;
     }
 
+    /**
+     * Sets line.
+     *
+     * @param line the line
+     */
     public void setLine(String line) {
         this.line = line;
     }
 
+    /**
+     * Gets talker.
+     *
+     * @return the talker
+     */
     public String getTalker() {
         return talker;
     }
 
+    /**
+     * Sets talker.
+     *
+     * @param talker the talker
+     */
     public void setTalker(String talker) {
         this.talker = talker;
     }
 
+    /**
+     * Gets formatter.
+     *
+     * @return the formatter
+     */
     public String getFormatter() {
         return formatter;
     }
 
+    /**
+     * Sets formatter.
+     *
+     * @param formatter the formatter
+     */
     public void setFormatter(String formatter) {
         this.formatter = formatter;
     }
 
+    /**
+     * Gets delimiter.
+     *
+     * @return the delimiter
+     */
     public Character getDelimiter() {
         return delimiter;
     }
 
+    /**
+     * Sets delimiter.
+     *
+     * @param delimiter the delimiter
+     */
     public void setDelimiter(Character delimiter) {
         this.delimiter = delimiter;
     }
 
+    /**
+     * Gets prefix.
+     *
+     * @return the prefix
+     */
     public String getPrefix() {
         return prefix;
     }
 
+    /**
+     * Sets prefix.
+     *
+     * @param prefix the prefix
+     */
     public void setPrefix(String prefix) {
         this.prefix = prefix;
     }
 
+    /**
+     * Gets sentence.
+     *
+     * @return the sentence
+     */
     public String getSentence() {
         return sentence;
     }
 
+    /**
+     * Sets sentence.
+     *
+     * @param sentence the sentence
+     */
     public void setSentence(String sentence) {
         this.sentence = sentence;
     }
 
+    /**
+     * Gets fields.
+     *
+     * @return the fields
+     */
     public List<String> getFields() {
         return fields;
     }

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Vdm.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/Vdm.java
@@ -36,10 +36,10 @@ public class Vdm extends EncapsulatedSentence {
 
     /**
      * Helper method parsing line to SentenceLine and passing to parse
-     * 
-     * @param line
-     * @return
-     * @throws SentenceException
+     *
+     * @param line the line
+     * @return int
+     * @throws SentenceException the sentence exception
      */
     public int parse(String line) throws SentenceException {
         return parse(new SentenceLine(line));
@@ -100,9 +100,9 @@ public class Vdm extends EncapsulatedSentence {
 
     /**
      * Determine if line seems to contain VDM or VDO sentence
-     * 
-     * @param line
-     * @return
+     *
+     * @param line the line
+     * @return boolean
      */
     public static boolean isVdm(String line) {
         int sentenceStart = line.indexOf('!');
@@ -118,8 +118,8 @@ public class Vdm extends EncapsulatedSentence {
 
     /**
      * Determine if VDO instead of VDM
-     * 
-     * @return
+     *
+     * @return boolean
      */
     public boolean isOwnMessage() {
         return ownMessage;
@@ -137,14 +137,13 @@ public class Vdm extends EncapsulatedSentence {
 
     /**
      * Make max 80 chars length sentences from AIS message given sequence number
-     * 
+     * <p>
      * If all VDM fields are used, 61 chars are left for encoded AIS message
-     * 
-     * @param aisMessage
-     * @param sequence
+     *
+     * @param aisMessage the ais message
+     * @param sequence   the sequence
      * @return array of sentence parts
-     * @throws IllegalArgumentException
-     * @throws SixbitException
+     * @throws SixbitException the sixbit exception
      */
     public static String[] createSentences(AisMessage aisMessage, int sequence) throws SixbitException {
         // Encode the AIS message to get full string
@@ -186,8 +185,8 @@ public class Vdm extends EncapsulatedSentence {
 
     /**
      * Split single VDM into possible multiple VDM's to adherne to the 80 character max
-     * 
-     * @return
+     *
+     * @return vdm [ ]
      */
     public Vdm[] createSentences() {
         // Make sure there is a sequence number

--- a/ais-lib-utils/pom.xml
+++ b/ais-lib-utils/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>dk.dma.ais.lib</groupId>
 		<artifactId>ais-parent</artifactId>
-		<version>2.4-SNAPSHOT</version>
+		<version>2.4</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>dk.dma.ais.lib</groupId>
 	<artifactId>ais-parent</artifactId>
-	<version>2.4-SNAPSHOT</version>
+	<version>2.4</version>
 	<name>AIS Parent</name>
 	<packaging>pom</packaging>
 	<description>This parent pom for AIS</description>


### PR DESCRIPTION
Adding or updating JavaDoc to comply with the strict requirements maven-central. 
The JavaDoc was partly autogenerated.
The broken links in expressionFilterVisitor to the former public methods were changed to the nested inner classes.
This work is carried out to fix the build problems mentioned https://github.com/dma-ais/AisLib/issues/54