### PR TITLE
Treat 25/26 like any other unsupported message type

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/message/AisMessage.java
@@ -312,14 +312,6 @@ public abstract class AisMessage implements Serializable {
         case 14:
             message = new AisMessage14(vdm);
             break;
-        case 15:
-            // TODO implement real message class
-            message = new AisUnsupportedMessageType(vdm);
-            break;
-        case 16:
-            // TODO implement real message class
-            message = new AisUnsupportedMessageType(vdm);
-            break;
         case 17:
             message = new AisMessage17(vdm);
             break;
@@ -329,26 +321,24 @@ public abstract class AisMessage implements Serializable {
         case 19:
             message = new AisMessage19(vdm);
             break;
-        case 20:
-            // TODO implement real message class
-            message = new AisUnsupportedMessageType(vdm);
-            break;
         case 21:
             message = new AisMessage21(vdm);
-            break;
-        case 22:
-            // TODO implement real message class
-            message = new AisUnsupportedMessageType(vdm);
-            break;
-        case 23:
-            // TODO implement real message class
-            message = new AisUnsupportedMessageType(vdm);
             break;
         case 24:
             message = new AisMessage24(vdm);
             break;
         case 27:
             message = new AisMessage27(vdm);
+            break;
+        // TODO: Implement the unsupported message types
+        case 15:
+        case 16:
+        case 20:
+        case 22:
+        case 23:
+        case 25:
+        case 26:
+            message = new AisUnsupportedMessageType(vdm);
             break;
         default:
             throw new AisMessageException("Unknown AIS message id " + vdm.getMsgId());


### PR DESCRIPTION
The library doesn't support all message types which then results for most types in the creation of an AisUnsupportedMessageType object when using the AisMessage.getInstance(Vdm) method. Just for type 25 and 26 an exception is thrown. 

I think it would be nicer if the unsupported types 25 and 26 would be treated in the same way as any other unsupported type and just create the AisUnsupportedMessageType object.