### PR TITLE
Replaced the deprecated getHostText with getHost

### DIFF
--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderMXBean.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisReaderMXBean.java
@@ -101,7 +101,7 @@ class AisReaderMXBeanImpl implements AisReaderMXBean {
     public String getHosts() {
         List<String> l = new ArrayList<>();
         for (HostAndPort hap : reader.hosts) {
-            l.add(hap.getHostText());
+            l.add(hap.getHost());
         }
         return Joiner.on(',').join(l);
     }

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
@@ -150,7 +150,7 @@ public class AisTcpReader extends AisReader {
         try {
             LOG.info("Connecting to source " + currentHost());
             clientSocket.set(new Socket());
-            InetSocketAddress address = new InetSocketAddress(currentHost().getHostText(), currentHost().getPort());
+            InetSocketAddress address = new InetSocketAddress(currentHost().getHost(), currentHost().getPort());
             clientSocket.get().connect(address);
             if (timeout > 0) {
                 clientSocket.get().setSoTimeout(timeout * 1000);
@@ -159,7 +159,7 @@ public class AisTcpReader extends AisReader {
             outputStream = clientSocket.get().getOutputStream();
             LOG.info("Connected to source " + currentHost());
         } catch (UnknownHostException e) {
-            LOG.error("Unknown host: " + currentHost().getHostText() + ": " + e.getMessage());
+            LOG.error("Unknown host: " + currentHost().getHost() + ": " + e.getMessage());
             throw e;
         } catch (IOException e) {
             if (!isShutdown()) {
@@ -248,7 +248,7 @@ public class AisTcpReader extends AisReader {
      * @return hostname hostname
      */
     public String getHostname() {
-        return currentHost().getHostText();
+        return currentHost().getHost();
     }
 
     /**

--- a/ais-lib-communication/src/test/java/dk/dma/ais/reader/AisReaderGroupTest.java
+++ b/ais-lib-communication/src/test/java/dk/dma/ais/reader/AisReaderGroupTest.java
@@ -47,8 +47,8 @@ public class AisReaderGroupTest {
     @Test
     public void parseTwoHosts() {
         AisTcpReader tr = AisReaders.parseSource("sdsd=ff:123, dd:1235");
-        assertEquals("ff", tr.hosts.get(0).getHostText());
-        assertEquals("dd", tr.hosts.get(1).getHostText());
+        assertEquals("ff", tr.hosts.get(0).getHost());
+        assertEquals("dd", tr.hosts.get(1).getHost());
         assertEquals(123, tr.hosts.get(0).getPort());
         assertEquals(1235, tr.hosts.get(1).getPort());
         assertEquals(2, tr.getHostCount());


### PR DESCRIPTION
In some of our projects we use a newer version of Guana.  `getHostText` has been deprecated for quite a while and was eventually removed in one of the later releases.
 
This PR replaces all the use of this deprecated function with the `getHost` equivalent.