### PR TITLE
Removed unneeded debug logging of the `CommentBlockLine`

### DIFF
--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -47,7 +47,6 @@ public class CommentBlockLine {
         if (line.startsWith("\\g:")) {
             parseCommentBlockWithLetterG(line);
         } else {
-            System.out.println(line);
             validateCommentBlock(line, start, end);
         }
     }


### PR DESCRIPTION
Retrieving an AIS message using the `AisTcpReader` will always result in the command block being put in the console.
When looking deeper into the code of `CommentBlockLine`, it seems that the content is always logged at the `parse` method. This didn't seem correct, so this line removal will fix this unneeded spamming of the console.