### PR TITLE
Change visibility of certain methods to protected

### DIFF
--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisDirectoryReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisDirectoryReader.java
@@ -80,7 +80,7 @@ public class AisDirectoryReader extends AisReader {
      * @param comparator the comparator
      * @throws IOException the io exception
      */
-    AisDirectoryReader(String dir, String pattern, boolean recursive, Comparator<Path> comparator) throws IOException {
+    protected AisDirectoryReader(String dir, String pattern, boolean recursive, Comparator<Path> comparator) throws IOException {
         requireNonNull(dir);
         requireNonNull(pattern);
         this.pattern = pattern;

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisStreamReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisStreamReader.java
@@ -42,7 +42,7 @@ public class AisStreamReader extends AisReader {
      *
      * @param stream the stream
      */
-    AisStreamReader(InputStream stream) {
+    protected AisStreamReader(InputStream stream) {
         this.stream = requireNonNull(stream);
     }
 

--- a/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
+++ b/ais-lib-communication/src/main/java/dk/dma/ais/reader/AisTcpReader.java
@@ -95,7 +95,7 @@ public class AisTcpReader extends AisReader {
      *
      * @param hostAndPort the host and port
      */
-    void addHostPort(HostAndPort hostAndPort) {
+    protected void addHostPort(HostAndPort hostAndPort) {
         requireNonNull(hostAndPort);
         hosts.add(hostAndPort);
         currentHostIndex++;
@@ -256,7 +256,7 @@ public class AisTcpReader extends AisReader {
      *
      * @return the host and port
      */
-    HostAndPort currentHost() {
+    protected HostAndPort currentHost() {
         return hosts.get(currentHostIndex);
     }
 


### PR DESCRIPTION
Previously, some methods of the AIS reader classes were package-private. By changing their visibility modifier to protected, subclasses in other packages can now override these methods for customization or extend their functionality.

One use case may be to create a TCPReader that can clean the raw input before parsing it to create AIS packets