### PR TITLE
Improve tag block parsing

### DIFF
--- a/ais-lib-communication/src/test/java/dk/dma/ais/reader/AisReaderTest.java
+++ b/ais-lib-communication/src/test/java/dk/dma/ais/reader/AisReaderTest.java
@@ -48,7 +48,7 @@ public class AisReaderTest {
         });
         reader.start();
         reader.join();
-        assertEquals(4062L, reader.getNumberOfLinesRead());
+        assertEquals(4063L, reader.getNumberOfLinesRead());
     }
 
     @Test

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -80,19 +80,31 @@ public class CommentBlockLine {
         // Split each pair into parameter code and value
         for (String pair : pairs) {
             String[] parts = pair.split(":", 2);
+            String param_code = parts[0];
             if (parts.length != 2) {
                 throw new CommentBlockException("Malformed parameter-code and value pair: " + pair);
             }
 
             // Read group related values
-            if (parts[0].equals("g")) {
+            if (param_code.equals("g")) {
                 String[] group_tag = StringUtils.splitPreserveAllTokens(parts[1], "-");
                 lineNumber = Integer.parseInt(group_tag[0]);
                 totalLines = Integer.parseInt(group_tag[1]);
                 groupId = group_tag[2];
             }
 
-            parameterMap.put(parts[0], parts[1]);
+            int groupCharIndex;
+            if ((groupCharIndex = param_code.indexOf('G')) >= 0) {
+                try {
+                    lineNumber = Integer.parseInt(param_code.substring(0, groupCharIndex));
+                    totalLines = Integer.parseInt(param_code.substring(groupCharIndex + 1));
+                } catch (NumberFormatException e) {
+                    throw new CommentBlockException("Invalid group tag: " + param_code);
+                }
+                groupId = parts[1];
+            }
+
+            parameterMap.put(param_code, parts[1]);
         }
     }
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -40,17 +40,35 @@ public class CommentBlockLine {
      */
     public void parse(String line) throws CommentBlockException {
         parameterMap = new HashMap<>();
-        int start = -1;
-        int end = -1;
-        checksum = 0;
+        int start = line.indexOf("\\g:");
+        int end = line.indexOf("*");
 
-        if (line.startsWith("\\g:")) {
-            parseCommentBlockWithLetterG(line);
-        } else {
-            validateCommentBlock(line, start, end);
+        if (start < 0) {
+            throw new CommentBlockException("No comment block found");
+        }
+
+        if (end < 0) {
+            throw new CommentBlockException("Malformed comment block");
+        }
+
+        // Extract the parameter values from the line
+        String params = line.substring(start + 3, end);
+
+        // Split the parameters using regular expression
+        String[] pairs = params.split("(?<!\\\\),");
+
+        for (String pair : pairs) {
+            // Split each pair into parameter code and value
+            String[] parts = pair.split("(?<!\\\\):");
+            if (parts.length == 2) {
+                String parameterCode = parts[0].replaceAll("\\\\,", ",");
+                String value = parts[1].replaceAll("\\\\:", ":");
+                parameterMap.put(parameterCode, value);
+            }
         }
     }
 
+    @Deprecated
     public void validateCommentBlock(String line, int start, int end) throws CommentBlockException {
         // Find start, end, checksum and fields
         for (int i = 0; i < line.length(); i++) {
@@ -133,6 +151,7 @@ public class CommentBlockLine {
         }
     }
 
+    @Deprecated
     public void parseCommentBlockWithLetterG(String line) throws CommentBlockException {
         parameterMap = new HashMap<>();
         int start = line.indexOf("\\g:");

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -42,13 +42,30 @@ public class CommentBlockLine {
         parameterMap = new HashMap<>();
         int start = line.indexOf("\\");
         int end = line.indexOf("\\", start + 1);
+        checksum = 0;
 
         if (start < 0) {
             throw new CommentBlockException("No comment block found");
         }
-
         if (end < 0) {
             throw new CommentBlockException("Malformed comment block");
+        }
+
+        // Validate Checksum
+        for (int i = start + 1; i < end - 3; i++) {
+            char curr = line.charAt(i);
+            checksum ^= curr;
+        }
+
+        try {
+            String received = line.substring(end - 2, end);
+            if (checksum != Integer.parseInt(received, 16)) {
+                throw new CommentBlockException("Received checksum invalid: " + received + " != " + Integer.toString(checksum, 16).toUpperCase());
+            }
+        } catch (IndexOutOfBoundsException e) {
+            throw new CommentBlockException("Missing checksum in comment block");
+        } catch (NumberFormatException e) {
+            throw new CommentBlockException("Malformed checksum");
         }
 
         // Extract the parameter values from the line
@@ -60,8 +77,8 @@ public class CommentBlockLine {
         // Split the parameters using regular expression
         String[] pairs = params.split(",");
 
+        // Split each pair into parameter code and value
         for (String pair : pairs) {
-            // Split each pair into parameter code and value
             String[] parts = pair.split(":", 2);
             if (parts.length != 2) {
                 throw new CommentBlockException("Malformed parameter-code and value pair: " + pair);

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -40,8 +40,8 @@ public class CommentBlockLine {
      */
     public void parse(String line) throws CommentBlockException {
         parameterMap = new HashMap<>();
-        int start = line.indexOf("\\g:");
-        int end = line.indexOf("*");
+        int start = line.indexOf("\\");
+        int end = line.indexOf("\\", start + 1);
 
         if (start < 0) {
             throw new CommentBlockException("No comment block found");
@@ -52,19 +52,21 @@ public class CommentBlockLine {
         }
 
         // Extract the parameter values from the line
-        String params = line.substring(start + 3, end);
+        String params = line.substring(start + 1, end - 3);
+        if (params.isEmpty()) {
+            return;
+        }
 
         // Split the parameters using regular expression
-        String[] pairs = params.split("(?<!\\\\),");
+        String[] pairs = params.split(",");
 
         for (String pair : pairs) {
             // Split each pair into parameter code and value
-            String[] parts = pair.split("(?<!\\\\):");
-            if (parts.length == 2) {
-                String parameterCode = parts[0].replaceAll("\\\\,", ",");
-                String value = parts[1].replaceAll("\\\\:", ":");
-                parameterMap.put(parameterCode, value);
+            String[] parts = pair.split(":", 2);
+            if (parts.length != 2) {
+                throw new CommentBlockException("Malformed parameter-code and value pair: " + pair);
             }
+            parameterMap.put(parts[0], parts[1]);
         }
     }
 

--- a/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
+++ b/ais-lib-messages/src/main/java/dk/dma/ais/sentence/CommentBlockLine.java
@@ -66,6 +66,15 @@ public class CommentBlockLine {
             if (parts.length != 2) {
                 throw new CommentBlockException("Malformed parameter-code and value pair: " + pair);
             }
+
+            // Read group related values
+            if (parts[0].equals("g")) {
+                String[] group_tag = StringUtils.splitPreserveAllTokens(parts[1], "-");
+                lineNumber = Integer.parseInt(group_tag[0]);
+                totalLines = Integer.parseInt(group_tag[1]);
+                groupId = group_tag[2];
+            }
+
             parameterMap.put(parts[0], parts[1]);
         }
     }


### PR DESCRIPTION
Changes the parsing of tag blocks according to the discussion in [issue #103](https://github.com/dma-ais/AisLib/issues/103#issuecomment-4048109986).
Parsing should now be closer to the specification of NMEA sentences and can correctly handle sentences that start with the group tag `g`.
It still supports the custom group tag of the form `xGx:xxx`.